### PR TITLE
Update PHP to 5.6.19

### DIFF
--- a/php56.json
+++ b/php56.json
@@ -1,15 +1,15 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.6.18",
+    "version": "5.6.19",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.18-Win32-VC11-x64.zip",
-            "hash": "sha1:b9763b0d20e45c0cb61bbbfe428316554ff3f2ba"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x64.zip",
+            "hash": "sha1:8e24f10fc28ce4a9a32ddb112896cd96631b4b59"
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.18-Win32-VC11-x86.zip",
-            "hash": "sha1:f99ca7f6ca4cc64e11289924548fd3ae366768ec"
+            "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x86.zip",
+            "hash": "sha1:b21b30636e3988e1a7e116f8ab440b4ccecb9e24"
         }
     },
     "bin": "php.exe",


### PR DESCRIPTION
PHP 5.6.18 has been removed from the PHP download site in favor of the updated 5.6.19, leading to a PowerShell exception when attempting to install `php56`. This change simply updates the `php56` manifest to use the new 5.6.19 details.