### PR TITLE
Add MySQL 5.6 app manifest

### DIFF
--- a/mysql56.json
+++ b/mysql56.json
@@ -1,0 +1,41 @@
+{
+    "homepage": "https://dev.mysql.com/downloads/mysql/",
+    "version": "5.6.29",
+    "license": "GPLv2",
+    "architecture": {
+        "64bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.29-winx64.zip",
+            "hash": "md5:b750549342927b902f8b16c647f51b8c",
+            "extract_dir": "mysql-5.6.29-winx64"
+        },
+        "32bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-5.6.29-win32.zip",
+            "hash": "md5:a8711ef773068fdb9422208b1315c57d ",
+            "extract_dir": "mysql-5.6.29-win32"
+        }
+    },
+    "bin": [
+        "bin\\mysqld.exe",
+        "bin\\mysql.exe",
+        "bin\\mysqldump.exe",
+        "bin\\mysqladmin.exe",
+        "bin\\mysqlbinlog.exe",
+        "bin\\mysqlcheck.exe",
+        "bin\\mysqlimport.exe",
+        "bin\\mysqlshow.exe",
+        "bin\\mysqlslap.exe",
+        "bin\\my_print_defaults.exe"
+        ],
+    "post_install": "
+#Initialize data directory (without generating root password)
+mysqld --initialize-insecure
+
+#Copy provided sample file to live file location
+cp $dir/my-default.ini $dir/my.ini
+
+#Output client configuration to my.ini file so no username is required when connecting
+echo \"\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+"
+}


### PR DESCRIPTION
Following up on lukesampson/scoop#749, this manifest adds a MySQL 5.6 (currently 5.6.29) manifest to allow installation of the previous version of MySQL if needed.