### PR TITLE
Update PHP versions and dependencies

### DIFF
--- a/php53.json
+++ b/php53.json
@@ -1,9 +1,0 @@
-{
-    "homepage": "http://windows.php.net",
-    "version": "5.3.29",
-    "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/archives/php-5.3.29-Win32-VC9-x86.zip",
-    "hash": "sha1:61615fe9db85c3ab630fe35673a1b6f45782e5d4",
-    "bin": "php.exe",
-    "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\""
-}

--- a/php54.json
+++ b/php54.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.4.44",
+    "version": "5.5.45",
     "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/php-5.4.44-Win32-VC9-x86.zip",
-    "hash": "sha1:2fcc47dff254ccae812ce2ccfd4ddf4f21ce9e8d",
+    "url": "http://windows.php.net/downloads/releases/php-5.4.45-Win32-VC9-x86.zip",
+    "hash": "sha1:133d5b02843b6791fe67199e4a730a3d6aa2d402",
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {

--- a/php54.json
+++ b/php54.json
@@ -5,7 +5,13 @@
     "url": "http://windows.php.net/downloads/releases/php-5.4.45-Win32-VC9-x86.zip",
     "hash": "sha1:133d5b02843b6791fe67199e4a730a3d6aa2d402",
     "bin": "php.exe",
-    "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
+    "post_install": "
+#Copy PHP configuration file to expected location
+cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"
+
+#Enable extensions to be found in installation-relative folder (the default is to search C:/php)
+(gc \"$dir\\php.ini\") | % { $_ -replace '; extension_dir = \"ext\"', 'extension_dir = \"ext\"' } | sc \"$dir\\php.ini\"
+",
     "checkver": {
         "url": "http://windows.php.net/download/",
         "re": "<h3 id=\"php-5.4\".*?>.*?\\(([0-9\\.]+)\\)</h3>"

--- a/php55.json
+++ b/php55.json
@@ -2,8 +2,16 @@
     "homepage": "http://windows.php.net",
     "version": "5.5.33",
     "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",
-    "hash": "sha1:b4eb6204a00e2555222cef288159aa391213d8ec",
+    "architecture": {
+        "64bit": {
+            "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
+            "hash": "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d"
+        },
+        "32bit": {
+            "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",
+            "hash": "sha1:b4eb6204a00e2555222cef288159aa391213d8ec"
+        }
+    },
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {

--- a/php55.json
+++ b/php55.json
@@ -19,7 +19,13 @@
         }
     },
     "bin": "php.exe",
-    "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
+    "post_install": "
+#Copy PHP configuration file to expected location
+cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"
+
+#Enable extensions to be found in installation-relative folder (the default is to search C:/php)
+(gc \"$dir\\php.ini\") | % { $_ -replace '; extension_dir = \"ext\"', 'extension_dir = \"ext\"' } | sc \"$dir\\php.ini\"
+",
     "checkver": {
         "url": "http://windows.php.net/download/",
         "re": "<h3 id=\"php-5.5\".*?>.*?\\(([0-9\\.]+)\\)</h3>"

--- a/php55.json
+++ b/php55.json
@@ -4,8 +4,14 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
-            "hash": "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d"
+            "url": [
+                "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/11/64-bit/msvcr110.dll"
+            ],
+            "hash": [
+                "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d",
+                "sha256:ae996edb9b050677c4f82d56092efdc75f0addc97a14e2c46753e2db3f6bd732"
+            ]
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",

--- a/php55.json
+++ b/php55.json
@@ -1,9 +1,9 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.5.32",
+    "version": "5.5.33",
     "license": "http://www.php.net/license/",
-    "url": "http://windows.php.net/downloads/releases/php-5.5.32-Win32-VC11-x86.zip",
-    "hash": "sha1:93552def273ba8bab1d4e206e59a491128c9f294",
+    "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",
+    "hash": "sha1:b4eb6204a00e2555222cef288159aa391213d8ec",
     "bin": "php.exe",
     "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
     "checkver": {

--- a/php56.json
+++ b/php56.json
@@ -4,8 +4,14 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x64.zip",
-            "hash": "sha1:8e24f10fc28ce4a9a32ddb112896cd96631b4b59"
+            "url": [
+                "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x64.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/11/64-bit/msvcr110.dll"
+            ],
+            "hash": [
+                "sha1:8e24f10fc28ce4a9a32ddb112896cd96631b4b59",
+                "sha256:ae996edb9b050677c4f82d56092efdc75f0addc97a14e2c46753e2db3f6bd732"
+            ]
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x86.zip",

--- a/php56.json
+++ b/php56.json
@@ -13,7 +13,13 @@
         }
     },
     "bin": "php.exe",
-    "post_install": "cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"",
+    "post_install": "
+#Copy PHP configuration file to expected location
+cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"
+
+#Enable extensions to be found in installation-relative folder (the default is to search C:/php)
+(gc \"$dir\\php.ini\") | % { $_ -replace '; extension_dir = \"ext\"', 'extension_dir = \"ext\"' } | sc \"$dir\\php.ini\"
+",
     "checkver": {
         "url": "http://windows.php.net/download/",
         "re": "<h3 id=\"php-5.6\".*?>.*?\\(([0-9\\.]+)\\)</h3>"


### PR DESCRIPTION
Following up on lukesampson/scoop#756, add the Visual C++ runtimes as a dependency when needed to older PHP versions. Specifically, only 64-bit version of PHP appear to need the DLL, with 32-bit versions working even if no Visual C++ runtime is installed.

Following up on lukesampson/scoop#757, add a command to the `post-install` scripts changing the `php.ini` configuration to look for extensions in an installation-relative folder, rather than looking in the default location, `C:\php\ext`, which makes the apps not work out-of-the-box and makes them less self-contained.

Update PHP 5.4 to 5.4.45, and 5.5 to 5.5.33. The current manifests return errors, since the referenced files no longer exist on the PHP download site. Also add a 64-bit architecture section to PHP 5.5, since there are 64-bit builds available.

Remove PHP 5.3 altogether, as support for it has been dropped by PHP, and it has some significant security holes and bugs.