### PR TITLE
Add current versions of PHP/MySQL

### DIFF
--- a/apache24.json
+++ b/apache24.json
@@ -4,26 +4,15 @@
     "license": "Apache 2.0",
     "architecture": {
         "64bit": {
-            "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa",
-                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
-            ]
+            "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
+            "hash": "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa"
         },
         "32bit": {
-            "url": [
-                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38",
-                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
-            ]
+            "url": "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
+            "hash": "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38"
         }
     },
+    "depends": "vc-redist14",
     "extract_dir": "Apache24",
     "bin": [
         "bin\\ab.exe",

--- a/apache24.json
+++ b/apache24.json
@@ -1,0 +1,53 @@
+{
+    "homepage": "http://www.apachelounge.com",
+    "version": "2.4.18",
+    "license": "Apache 2.0",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win64-VC14.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
+            ],
+            "hash": [
+                "sha256:543aff046b0ea2bf58be76d7d20fcd1fa16eec9ae836ca4639feb1c2a7e09cfa",
+                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://www.apachelounge.com/download/VC14/binaries/httpd-2.4.18-win32-VC14.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
+            ],
+            "hash": [
+                "sha256:2259bea85cbcb4e9e525bfff0863b4ae3eae5f91fddb153191fd310575a04f38",
+                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
+            ]
+        }
+    },
+    "extract_dir": "Apache24",
+    "bin": [
+        "bin\\ab.exe",
+        "bin\\abs.exe",
+        "bin\\htcacheclean.exe",
+        "bin\\htdbm.exe",
+        "bin\\htdigest.exe",
+        "bin\\htpasswd.exe",
+        "bin\\httpd.exe",
+        "bin\\httxt2dbm.exe",
+        "bin\\logresolve.exe",
+        "bin\\rotatelogs.exe"
+    ],
+    "post_install": "
+#Copy needed DLL to bin subdirectory
+mv \"$dir\\vcruntime140.dll\" \"$dir\\bin\\vcruntime140.dll\"
+
+# set directory in httpd.conf
+$conf = \"$dir/conf/httpd.conf\"
+$root=(scoop which httpd | split-path -res -par | split-path -par) -replace '\\\\', '/';
+(gc $conf) | % { $_ -replace 'c:/Apache24', \"$root\" } | sc $conf
+",
+    "checkver": {
+        "url": "http://www.apachelounge.com/download/",
+        "re": "Apache ([0-9\\.]+) Win32"
+    }
+}

--- a/mysql57.json
+++ b/mysql57.json
@@ -1,0 +1,41 @@
+{
+    "homepage": "https://dev.mysql.com/downloads/mysql/",
+    "version": "5.7.11",
+    "license": "GPLv2",
+    "architecture": {
+        "64bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-winx64.zip",
+            "hash": "md5:9805750100ab3e2411f4887eb5f4cb77",
+            "extract_dir": "mysql-5.7.11-winx64"
+        },
+        "32bit": {
+            "url": "https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-5.7.11-win32.zip",
+            "hash": "md5:710b588c8df3134c87818f765118329a",
+            "extract_dir": "mysql-5.7.11-win32"
+        }
+    },
+    "bin": [
+        "bin\\mysqld.exe",
+        "bin\\mysql.exe",
+        "bin\\mysqldump.exe",
+        "bin\\mysqladmin.exe",
+        "bin\\mysqlbinlog.exe",
+        "bin\\mysqlcheck.exe",
+        "bin\\mysqlimport.exe",
+        "bin\\mysqlshow.exe",
+        "bin\\mysqlslap.exe",
+        "bin\\my_print_defaults.exe"
+        ],
+    "post_install": "
+#Initialize data directory (without generating root password)
+mysqld --initialize-insecure
+
+#Copy provided sample file to live file location
+cp $dir/my-default.ini $dir/my.ini
+
+#Output client configuration to my.ini file so no username is required when connecting
+echo \"\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"[client]\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+echo \"user=root\" | out-file \"$dir/my.ini\" -Encoding UTF8 -Append
+"
+}

--- a/php70.json
+++ b/php70.json
@@ -4,26 +4,15 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
-            ],
-            "hash": [
-                "sha1:52b0ce7ee7600672383694c65071966ff3a20b92",
-                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
+            "hash": "sha1:52b0ce7ee7600672383694c65071966ff3a20b92"
         },
         "32bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
-            ],
-            "hash": [
-               "sha1:60569b17d7883c710675d217f3521821f97b4a0d",
-                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
+            "hash": "sha1:60569b17d7883c710675d217f3521821f97b4a0d"
         }
     },
+    "depends": "vc-redist14",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location

--- a/php70.json
+++ b/php70.json
@@ -1,0 +1,39 @@
+{
+    "homepage": "http://windows.php.net",
+    "version": "7.0.4",
+    "license": "http://www.php.net/license/",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
+            ],
+            "hash": [
+                "sha1:52b0ce7ee7600672383694c65071966ff3a20b92",
+                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
+            ],
+            "hash": [
+               "sha1:60569b17d7883c710675d217f3521821f97b4a0d",
+                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
+            ]
+        }
+    },
+    "bin": "php.exe",
+    "post_install": "
+#Copy PHP configuration file to expected location
+cp \"$dir\\php.ini-production\" \"$dir\\php.ini\"
+
+#Enable extensions to be found in installation-relative folder (the default is to search C:/php)
+(gc \"$dir\\php.ini\") | % { $_ -replace '; extension_dir = \"ext\"', 'extension_dir = \"ext\"' } | sc \"$dir\\php.ini\"
+",
+    "checkver": {
+        "url": "http://windows.php.net/download/",
+        "re": "<h3 id=\"php-7.0\".*?>.*?\\(([0-9\\.]+)\\)</h3>"
+    }
+}


### PR DESCRIPTION
Provides long-term support for PHP 7.0 and MySQL 5.7, so that even when the apps in the main bucket update a new major or minor version, the older versions will still be able to update to patch releases without breaking compatibility.

This proposed change is really just to open a discussion on the subject of including current versions of apps in this bucket. Especially with apps like PHP and MySQL that often include compatibility-breaking changes in minor releases, I believe it's prudent to include these manifests so that users don't have to uninstall the current version and install a previous one when the change finally does happen. This way, users who need to be guaranteed long-term support for something (like me, needing to sync development machines and production servers, which tend to stay on a specific release for a long time) can be assured that compatibility won't be broken when updating.