### PR TITLE
Update previous PHP versions with Visual C++ installer dependencies

### DIFF
--- a/php54.json
+++ b/php54.json
@@ -4,6 +4,7 @@
     "license": "http://www.php.net/license/",
     "url": "http://windows.php.net/downloads/releases/php-5.4.45-Win32-VC9-x86.zip",
     "hash": "sha1:133d5b02843b6791fe67199e4a730a3d6aa2d402",
+    "depends": "vc-redist9",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location

--- a/php55.json
+++ b/php55.json
@@ -4,20 +4,15 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/11/64-bit/msvcr110.dll"
-            ],
-            "hash": [
-                "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d",
-                "sha256:ae996edb9b050677c4f82d56092efdc75f0addc97a14e2c46753e2db3f6bd732"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
+            "hash": "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d"
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",
             "hash": "sha1:b4eb6204a00e2555222cef288159aa391213d8ec"
         }
     },
+    "depends": "vc-redist11",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location

--- a/php56.json
+++ b/php56.json
@@ -4,20 +4,15 @@
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": [
-                "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x64.zip",
-                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/11/64-bit/msvcr110.dll"
-            ],
-            "hash": [
-                "sha1:8e24f10fc28ce4a9a32ddb112896cd96631b4b59",
-                "sha256:ae996edb9b050677c4f82d56092efdc75f0addc97a14e2c46753e2db3f6bd732"
-            ]
+            "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x64.zip",
+            "hash": "sha1:8e24f10fc28ce4a9a32ddb112896cd96631b4b59"
         },
         "32bit": {
             "url": "http://windows.php.net/downloads/releases/php-5.6.19-Win32-VC11-x86.zip",
             "hash": "sha1:b21b30636e3988e1a7e116f8ab440b4ccecb9e24"
         }
     },
+    "depends": "vc-redist11",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location

--- a/vc-redist11.json
+++ b/vc-redist11.json
@@ -1,0 +1,48 @@
+{
+    "homepage": "https://www.visualstudio.com",
+    "version": "2012",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe",
+            "hash": "sha256:681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064",
+            "installer": {
+                "file": "vcredist_x64.exe",
+                "args": [
+                    "/install",
+                    "/q",
+                    "/norestart"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "vcredist_x64.exe",
+                "args": [
+                    "/uninstall",
+                    "/q",
+                    "/norestart"
+                ]
+            }
+        },
+        "32bit": {
+            "url": "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe",
+            "hash": "sha256:b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386",
+            "installer": {
+                "file": "vcredist_x86.exe",
+                "args": [
+                    "/install",
+                    "/q",
+                    "/norestart"
+                ],
+                "keep": "true"
+            },
+            "uninstaller": {
+                "file": "vcredist_x86.exe",
+                "args": [
+                    "/uninstall",
+                    "/q",
+                    "/norestart"
+                ]
+            }
+        }
+    }
+}

--- a/vc-redist9.json
+++ b/vc-redist9.json
@@ -1,0 +1,23 @@
+{
+    "homepage": "https://www.visualstudio.com",
+    "version": "2010",
+    "url": "https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe",
+    "hash": "sha256:8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8",
+    "installer": {
+        "file": "vcredist_x86.exe",
+        "args": [
+            "/install",
+            "/q",
+            "/norestart"
+        ],
+        "keep": "true"
+    },
+    "uninstaller": {
+        "file": "vcredist_x86.exe",
+        "args": [
+            "/uninstall",
+            "/q",
+            "/norestart"
+        ]
+    }
+}


### PR DESCRIPTION
Following up on lukesampson/scoop#763 and lukesampson/scoop#766, this updates the previous PHP versions to use installers for their Visual C++ dependency, rather than direct downloading of DLLs.

(Sorry for the barrage of pull requests, just trying to get all this cleaned up)