### PR TITLE
Update PHP 7.0 to 7.0.5, 5.5 to 5.5.34

### DIFF
--- a/php55.json
+++ b/php55.json
@@ -1,21 +1,21 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.5.33",
+    "version": "5.5.34",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x64.zip",
+                "http://windows.php.net/downloads/releases/php-5.5.34-Win32-VC11-x64.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/11/64-bit/msvcr110.dll"
             ],
             "hash": [
-                "sha1:43c321a240f2c743c53ab6a4e25aefe23518724d",
+                "sha1:6496a91e214c2d496253037e1f75bd93e43b12cf",
                 "sha256:ae996edb9b050677c4f82d56092efdc75f0addc97a14e2c46753e2db3f6bd732"
             ]
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-5.5.33-Win32-VC11-x86.zip",
-            "hash": "sha1:b4eb6204a00e2555222cef288159aa391213d8ec"
+            "url": "http://windows.php.net/downloads/releases/php-5.5.34-Win32-VC11-x86.zip",
+            "hash": "sha1:6f41be14dac37f44a52cd9d3028265d5174c82be"
         }
     },
     "bin": "php.exe",

--- a/php70.json
+++ b/php70.json
@@ -1,18 +1,29 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.4",
+    "version": "7.0.5",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
-            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x64.zip",
-            "hash": "sha1:52b0ce7ee7600672383694c65071966ff3a20b92"
+            "url": [
+                "http://windows.php.net/downloads/releases/php-7.0.5-Win32-VC14-x64.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
+            ],
+            "hash": [
+                "sha1:ef09d80e264a010d538cf88004acb68c52812a26",
+                "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
+            ]
         },
         "32bit": {
-            "url": "http://windows.php.net/downloads/releases/php-7.0.4-Win32-VC14-x86.zip",
-            "hash": "sha1:60569b17d7883c710675d217f3521821f97b4a0d"
+            "url": [
+                "http://windows.php.net/downloads/releases/php-7.0.5-Win32-VC14-x86.zip",
+                "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
+            ],
+            "hash": [
+               "sha1:335c24c5b056246c384591c39b462d7ef3005b5c",
+                "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
+            ]
         }
     },
-    "depends": "vc-redist14",
     "bin": "php.exe",
     "post_install": "
 #Copy PHP configuration file to expected location


### PR DESCRIPTION
Following up on lukesampson/scoop#769. Also, remove the `vc-redist14` dependency, which apparently didn't get cleaned up in the last pull request.