### PR TITLE
upgraded 7.0.5 -> 7.0.6

### DIFF
--- a/php70.json
+++ b/php70.json
@@ -1,25 +1,25 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "7.0.5",
+    "version": "7.0.6",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.5-Win32-VC14-x64.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.6-Win32-VC14-x64.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/64-bit/vcruntime140.dll"
             ],
             "hash": [
-                "sha1:ef09d80e264a010d538cf88004acb68c52812a26",
+                "sha1:607e510e60903ea58e2194fb2a87a07d3744cdca",
                 "sha256:acf65e565021f2017815fc5ec8a3145cf6c15e75c132cf23a378cc943e68327c"
             ]
         },
         "32bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-7.0.5-Win32-VC14-x86.zip",
+                "http://windows.php.net/downloads/releases/php-7.0.6-Win32-VC14-x86.zip",
                 "https://raw.githubusercontent.com/MPLew-is/scoop-wamp/master/visual-c-redistributables/14/32-bit/vcruntime140.dll"
             ],
             "hash": [
-               "sha1:335c24c5b056246c384591c39b462d7ef3005b5c",
+               "sha1:e0c41a01c16b3633cfffceac9528cf5a44019778",
                 "sha256:b7c13f8519340257ba6ae3129afce961f137e394dde3e4e41971b9f912355f5e"
             ]
         }


### PR DESCRIPTION
Upgraded php version 7.0.5 to 7.0.6.
Windows.php.net removed version 7.0.5 which causes "scoop install php" to fail.
@lukesampson 