### PR TITLE
Fix php 5.6 installation

### DIFF
--- a/php56.json
+++ b/php56.json
@@ -9,7 +9,7 @@
                 "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe"
             ],
             "hash": [
-                "sha1:83a325a5dc09884ce227de00c4b1c90a63d2e2f5",
+                "sha1:ae0b41a4e2e3eda219ff44c16b9e7baa6d7fc9bc",
                 "681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064"
             ]
         },
@@ -19,7 +19,7 @@
 				"https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe"
 			],
             "hash": [
-				"sha1:cb58af8546b063dcb90eb73ae8fce882c6c31a75",
+				"sha1:e0d22bb387e932326af39842bd0117d408cce0a3",
 				"b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386"
 			]
         }

--- a/php56.json
+++ b/php56.json
@@ -1,11 +1,11 @@
 {
     "homepage": "http://windows.php.net",
-    "version": "5.6.29",
+    "version": "5.6.30",
     "license": "http://www.php.net/license/",
     "architecture": {
         "64bit": {
             "url": [
-                "http://windows.php.net/downloads/releases/php-5.6.29-Win32-VC11-x64.zip",
+                "http://windows.php.net/downloads/releases/php-5.6.30-Win32-VC11-x64.zip",
                 "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe"
             ],
             "hash": [
@@ -15,7 +15,7 @@
         },
         "32bit": {
             "url": [
-				"http://windows.php.net/downloads/releases/php-5.6.29-Win32-VC11-x86.zip",
+				"http://windows.php.net/downloads/releases/php-5.6.30-Win32-VC11-x86.zip",
 				"https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe"
 			],
             "hash": [


### PR DESCRIPTION
Files for versions 5.6.29 do not exist anymore. I updated to the latest 5.6.X files available.