### PR TITLE
Remove errant quotes around $dir var

### DIFF
--- a/7zip-zstd.json
+++ b/7zip-zstd.json
@@ -32,7 +32,7 @@
     "installer": {
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "shortcuts": [

--- a/nodejs4.json
+++ b/nodejs4.json
@@ -24,7 +24,7 @@
     ],
     "post_install": "
         # Set npm prefix to install modules inside bin and npm cache so they persist
-        Set-Content -Value \"prefix=\\\"$persist_dir\\bin\\\"`ncache=\\\"$persist_dir\\cache\\\"\" -Path \"$dir\\node_modules\\npm\\npmrc\"
+        Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\"
     ",
     "checkver": {
         "url": "https://nodejs.org/dist/latest-v4.x/",

--- a/nodejs6.json
+++ b/nodejs6.json
@@ -24,7 +24,7 @@
     ],
     "post_install": "
         # Set npm prefix to install modules inside bin and npm cache so they persist
-        Set-Content -Value \"prefix=\\\"$persist_dir\\bin\\\"`ncache=\\\"$persist_dir\\cache\\\"\" -Path \"$dir\\node_modules\\npm\\npmrc\"
+        Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\"
     ",
     "checkver": {
         "url": "https://nodejs.org/dist/latest-v6.x/",

--- a/nodejs7.json
+++ b/nodejs7.json
@@ -24,7 +24,7 @@
     ],
     "post_install": "
         # Set npm prefix to install modules inside bin and npm cache so they persist
-        Set-Content -Value \"prefix=\\\"$persist_dir\\bin\\\"`ncache=\\\"$persist_dir\\cache\\\"\" -Path \"$dir\\node_modules\\npm\\npmrc\"
+        Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\"
     ",
     "checkver": {
         "url": "https://nodejs.org/dist/latest-v7.x/",

--- a/nodejs8.json
+++ b/nodejs8.json
@@ -24,7 +24,7 @@
     ],
     "post_install": "
         # Set npm prefix to install modules inside bin and npm cache so they persist
-        Set-Content -Value \"prefix=\\\"$persist_dir\\bin\\\"`ncache=\\\"$persist_dir\\cache\\\"\" -Path \"$dir\\node_modules\\npm\\npmrc\"
+        Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\"
     ",
     "checkver": {
         "url": "https://nodejs.org/dist/latest-v8.x/",

--- a/nodejs9.json
+++ b/nodejs9.json
@@ -24,7 +24,7 @@
     ],
     "post_install": "
         # Set npm prefix to install modules inside bin and npm cache so they persist
-        Set-Content -Value \"prefix=\\\"$persist_dir\\bin\\\"`ncache=\\\"$persist_dir\\cache\\\"\" -Path \"$dir\\node_modules\\npm\\npmrc\"
+        Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\"
     ",
     "checkver": {
         "url": "https://nodejs.org/dist/latest-v9.x/",

--- a/php55-xdebug.json
+++ b/php55-xdebug.json
@@ -16,7 +16,7 @@
     $phpconfd = \"$persist_dir\\..\\php55\\cli\\conf.d\"
     if((test-path $phpconfd)) {
         echo \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"
-        echo \"zend_extension=\\\"$dir\\php_xdebug.dll\\\"\" | sc \"$phpconfd\\xdebug.ini\"
+        echo \"zend_extension=$dir\\php_xdebug.dll\" | sc \"$phpconfd\\xdebug.ini\"
     } else { write-host -f yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually!\" }",
     "notes": "Xdebug is already enabled if PHP was installed through scoop!
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",

--- a/php56-xdebug.json
+++ b/php56-xdebug.json
@@ -16,7 +16,7 @@
     $phpconfd = \"$persist_dir\\..\\php56\\cli\\conf.d\"
     if((test-path $phpconfd)) {
         echo \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"
-        echo \"zend_extension=\\\"$dir\\php_xdebug.dll\\\"\" | sc \"$phpconfd\\xdebug.ini\"
+        echo \"zend_extension=$dir\\php_xdebug.dll\" | sc \"$phpconfd\\xdebug.ini\"
     } else { write-host -f yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually!\" }",
     "notes": "Xdebug is already enabled if PHP was installed through scoop!
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",

--- a/php70-xdebug.json
+++ b/php70-xdebug.json
@@ -16,7 +16,7 @@
     $phpconfd = \"$persist_dir\\..\\php70\\cli\\conf.d\"
     if((test-path $phpconfd)) {
         echo \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"
-        echo \"zend_extension=\\\"$dir\\php_xdebug.dll\\\"\" | sc \"$phpconfd\\xdebug.ini\"
+        echo \"zend_extension=$dir\\php_xdebug.dll\" | sc \"$phpconfd\\xdebug.ini\"
     } else { write-host -f yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually!\" }",
     "notes": "Xdebug is already enabled if PHP was installed through scoop!
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",

--- a/php71-xdebug.json
+++ b/php71-xdebug.json
@@ -16,7 +16,7 @@
     $phpconfd = \"$persist_dir\\..\\php\\cli\\conf.d\"
     if((test-path $phpconfd)) {
         echo \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"
-        echo \"zend_extension=\\\"$dir\\php_xdebug.dll\\\"\" | sc \"$phpconfd\\xdebug.ini\"
+        echo \"zend_extension=$dir\\php_xdebug.dll\" | sc \"$phpconfd\\xdebug.ini\"
     } else { write-host -f yellow \"PHP was not installed through scoop, you have to activate php_xdebug.dll manually!\" }",
     "notes": "Xdebug is already enabled if PHP was installed through scoop!
 Otherwise add '$dir\\php_xdebug.dll' to your php.ini",

--- a/tesseract4.json
+++ b/tesseract4.json
@@ -10,7 +10,7 @@
         "_comment": "/D option is ignored",
         "args": [
             "/S",
-            "/D=\"$dir\""
+            "/D=$dir"
         ]
     },
     "license": "Apache-2.0",


### PR DESCRIPTION
See http://nsis.sourceforge.net/Docs/Chapter3.html#installerusagecommon :
/D sets the default installation directory ($INSTDIR), overriding InstallDir and InstallDirRegKey. It must be the last parameter used in the command line and must not contain any quotes, even if the path contains spaces. Only absolute paths are supported.