### PR TITLE
Move lynx from main bucket to versions/lynx283

### DIFF
--- a/lynx283.json
+++ b/lynx283.json
@@ -1,5 +1,5 @@
 {
-	"_comment": "moved from https://raw.githubusercontent.com/lukesampson/scoop/dc859edce45c7cf723fbcda9f6c462028ca7e2f6/bucket/lynx.json",
+    "_comment": "moved from https://raw.githubusercontent.com/lukesampson/scoop/dc859edce45c7cf723fbcda9f6c462028ca7e2f6/bucket/lynx.json",
     "version": "2.8.3",
     "extract_dir": "lynx_w32",
     "url": "http://www.vordweb.co.uk/standards/lynx_v283.zip",

--- a/lynx283.json
+++ b/lynx283.json
@@ -1,0 +1,17 @@
+{
+	"_comment": "moved from https://raw.githubusercontent.com/lukesampson/scoop/dc859edce45c7cf723fbcda9f6c462028ca7e2f6/bucket/lynx.json",
+    "version": "2.8.3",
+    "extract_dir": "lynx_w32",
+    "url": "http://www.vordweb.co.uk/standards/lynx_v283.zip",
+    "homepage": "http://www.vordweb.co.uk/standards/download_lynx.htm",
+    "hash": "552bc68afd2ff9a5de88f26d76f55dd8697cf6082c6afb01b3d1a9942f4d3ee0",
+    "bin": "lynx.cmd",
+    "persist": [
+        "$dir/lynx.cfg"
+    ],
+    "pre_install": [
+        "$q = [char]34",
+        "set-content \"$dir/lynx.cfg\" -value $null",
+        "set-content \"$dir/lynx.cmd\" -value \"@$q$dir\\lynx.exe$q --cfg=$q$dir\\lynx.cfg$q %*\""
+    ]
+}


### PR DESCRIPTION
Version 2.8.3 doesn't support SSL. The newly added [scoop/lynx 2.8.9dev.16](https://github.com/lukesampson/scoop/pull/2004) does.