### PR TITLE
Fix 7zip-beta and 7zip-zstd

### DIFF
--- a/bucket/7zip-beta.json
+++ b/bucket/7zip-beta.json
@@ -1,16 +1,16 @@
 {
     "homepage": "http://www.7-zip.org/",
     "description": "Multi-format compression/decompression tool (beta version)",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.1-or-later",
     "version": "18.03",
     "architecture": {
         "64bit": {
-            "url": "http://7-zip.org/a/7z1803-x64.msi",
-            "hash": "b4bd12759fe990a3c5f53296ba1fe920b1502d5db696ccfbc345db149c24b2a2"
+            "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/18.03/7z1803-x64.msi",
+            "hash": "sha1:c2960c99f685f2f80475e5fce1e4c39ddd34fae3"
         },
         "32bit": {
-            "url": "http://7-zip.org/a/7z1803.msi",
-            "hash": "8a6155e1ad83e0555c0388248e8945ed5dfa14305ba295f0288b11b3cb33fe75"
+            "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/18.03/7z1803.msi",
+            "hash": "sha1:21ce157040d1cd54f2ad005dc6be7eabc2fdd88d"
         }
     },
     "extract_dir": "Files/7-Zip",
@@ -19,23 +19,23 @@
         "7zG.exe"
     ],
     "checkver": {
-        "re": "Download 7-Zip ([\\d.]+) beta",
-        "url": "http://www.7-zip.org/download.html"
+        "url": "https://www.7-zip.org/history.txt",
+        "regex": "\\n([\\d.]+) beta"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "http://7-zip.org/a/7z$cleanVersion-x64.msi"
+                "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/$version/7z$cleanVersion-x64.msi"
             },
             "32bit": {
-                "url": "http://7-zip.org/a/7z$cleanVersion.msi"
+                "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/$version/7z$cleanVersion.msi"
             }
         }
     },
     "shortcuts": [
         [
             "7zFM.exe",
-            "7zip"
+            "7-Zip"
         ]
     ]
 }

--- a/bucket/7zip-zstd.json
+++ b/bucket/7zip-zstd.json
@@ -1,23 +1,26 @@
 {
     "homepage": "https://github.com/mcmilk/7-Zip-zstd/",
     "description": "Multi-format compression/decompression tool with brotli and other codecs (beta version)",
-    "license": "LGPL-2.1",
-    "version": "18.05-v1.3.7-R4",
+    "license": "LGPL-2.1-or-later",
+    "version": "18.06-v1.3.8-R1",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/18.05-v1.3.7-R4/7z18.05-zstd-x64.exe#/dl.7z",
-            "hash": "0bcb5770a7ffc64671d33726577dc1ff18395199753f9962bc8453dffe5934b8"
+            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/18.06-v1.3.8-R1/7z18.06-zstd-x64.exe#/dl.7z",
+            "hash": "8cdd8951e07c871e80c287f6fc15e174dc486377c0dadcedec3812bbff48887e"
         },
         "32bit": {
-            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/18.05-v1.3.7-R4/7z18.05-zstd-x32.exe#/dl.7z",
-            "hash": "8d8297a5176c5df328671325b854d39a55fbc99a1c247a91cb5ab10645552e76"
+            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/18.06-v1.3.8-R1/7z18.06-zstd-x32.exe#/dl.7z",
+            "hash": "cae19be61fb418c6f8b38d3f53e5cc8b28e47b9eca6251dd85a42319c90c6336"
         }
     },
     "bin": [
         "7z.exe",
-        "7zg.exe"
+        "7zG.exe"
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/mcmilk/7-Zip-zstd/",
+        "regex": "/tag/(\\S+)\""
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -31,7 +34,7 @@
     "shortcuts": [
         [
             "7zFM.exe",
-            "7-Zip-Zstandard"
+            "7-Zip"
         ]
     ]
 }


### PR DESCRIPTION
- 7zip-beta: Beta version of 7zip (maybe older than latest stable version, just latest "beta" version)
- 7zip-zstd: 7zip with Zstandard support

User could switch 7zip, 7zip-beta and 7zip-zstd by `scoop reset`.