### PR TITLE
Update pwsh-prev and rename

### DIFF
--- a/bucket/pwsh-beta.json
+++ b/bucket/pwsh-beta.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://github.com/PowerShell/PowerShell",
-    "version": "6.1.1",
+    "version": "6.2.0-preview.3",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.1.1/PowerShell-6.1.1-win-x64.zip",
-            "hash": "f1198f0421a9d0d8cfe10d012ae8edb625787b341777bf0a2187ff0069ee8661"
+            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.3/PowerShell-6.2.0-preview.3-win-x64.zip",
+            "hash": "5871b5e83192fa2a0c560c3d24aaae645a99d7cdf5f364b0b8cd3072e673a458"
         },
         "32bit": {
-            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.1.1/PowerShell-6.1.1-win-x86.zip",
-            "hash": "1c7146e3879eae99476ff75fc560245b6097a39ab0bda76fab62ca2525b06b69"
+            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.3/PowerShell-6.2.0-preview.3-win-x86.zip",
+            "hash": "0835d123be70009d6642fefca32cdbef4df76b066a0097321707157e4828b469"
         }
     },
     "bin": "pwsh.exe",
@@ -19,7 +19,10 @@
             "PowerShell Core"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/PowerShell/PowerShell/releases.atom",
+        "re": "\\/releases\\/tag\\/(?:v)?([\\d.]+-[a-z]+[\\d.]+)"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -31,7 +34,7 @@
         },
         "hash": {
             "url": "https://github.com/PowerShell/PowerShell/releases/tag/v$version/",
-            "find": "$basename\\s*<ul>\\s*<li>([A-Fa-f\\d]{64})"
+            "find": "$basename\\s*<ul>\\s*<li>([A-Fa-f0-9]{64})"
         }
     }
 }


### PR DESCRIPTION
- Rename pwsh-prev to pwsh-beta so as to be consistent with other "beta version"s
- Fix manifest to only check `xxx-preview.x`("6.2.0-preview.3") or `xxx-rc.x`("6.1.0-rc.1")
- Change between stable and preview by `scoop reset`