### PR TITLE
Modify python27, python35, python36 and python-beta manifests

### DIFF
--- a/bucket/python-beta.json
+++ b/bucket/python-beta.json
@@ -1,18 +1,17 @@
 {
     "homepage": "https://www.python.org/",
-    "license": "https://docs.python.org/3/license.html",
-    "version": "3.7.0",
+    "license": "Python-2.0",
+    "version": "3.7.2rc1",
     "architecture": {
         "64bit": {
-            "url": "https://www.python.org/ftp/python/3.7.0/python-3.7.0-amd64.exe#/py3.exe",
-            "hash": "9d6afa39538aade3a2bacb099ef1c9f78e8d4afaefff99057b902118845c5dda"
+            "url": "https://www.python.org/ftp/python/3.7.2/python-3.7.2rc1-amd64.exe#/py3.exe",
+            "hash": "md5:b9f5c413c183b2d937730290200d12b5"
         },
         "32bit": {
-            "url": "https://www.python.org/ftp/python/3.7.0/python-3.7.0.exe#/py3.exe",
-            "hash": "559e56d293e05ff6159c3676da2b5a93081efad7a8acc74c12bb757e2b93daba"
+            "url": "https://www.python.org/ftp/python/3.7.2/python-3.7.2rc1.exe#/py3.exe",
+            "hash": "md5:53e054fbbec5bfea8f4c244a316e8ebe"
         }
     },
-    "pre_install": "copy-item $dir\\py3.exe $dir\\uninstall.exe",
     "installer": {
         "args": [
             "/quiet",
@@ -21,10 +20,11 @@
             "AssociateFiles=0",
             "Shortcuts=0",
             "InstallLauncherAllUsers=$(@{$true=1;$false=0}[$global])"
-        ]
+        ],
+        "keep": true
     },
     "uninstaller": {
-        "file": "uninstall.exe",
+        "file": "py3.exe",
         "args": [
             "/uninstall",
             "/quiet",
@@ -37,21 +37,30 @@
         [
             "python.exe",
             "python3"
+        ],
+        "Lib\\idlelib\\idle.bat",
+        [
+            "Lib\\idlelib\\idle.bat",
+            "idle3"
         ]
     ],
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "python-(3.7.[\\d\\w.]+)-amd64.exe"
+        "re": "Python ([\\d.]+[abcr]{1,2}[\\d]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.python.org/ftp/python/3.7.0/python-$version-amd64.exe#/py3.exe"
+                "url": "https://www.python.org/ftp/python/$matchHead/python-$version-amd64.exe#/py3.exe"
             },
             "32bit": {
-                "url": "https://www.python.org/ftp/python/3.7.0/python-$version.exe#/py3.exe"
+                "url": "https://www.python.org/ftp/python/$matchHead/python-$version.exe#/py3.exe"
             }
+        },
+        "hash": {
+            "url": "https://www.python.org/downloads/release/python-$cleanVersion/",
+            "find": "$basename[\\S\\s]+?([A-Fa-f0-9]{32})"
         }
     }
 }

--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.python.org/",
-    "license": "https://docs.python.org/2/license.html",
+    "license": "Python-2.0",
     "version": "2.7.15",
     "architecture": {
         "64bit": {
             "url": "https://www.python.org/ftp/python/2.7.15/python-2.7.15.amd64.msi",
-            "hash": "5e85f3c4c209de98480acbf2ba2e71a907fd5567a838ad4b6748c76deb286ad7"
+            "hash": "md5:0ffa44a86522f9a37b916b361eebc552"
         },
         "32bit": {
             "url": "https://www.python.org/ftp/python/2.7.15/python-2.7.15.msi",
-            "hash": "1afa1b10cf491c788baa340066a813d5ec6232561472cfc3af1664dbc6f29f77"
+            "hash": "md5:023e49c9fba54914ebc05c4662a93ffe"
         }
     },
     "bin": [
@@ -46,7 +46,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "python-(2.[\\d.]+).amd64.msi"
+        "re": "Python (2\\.7\\.[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -56,6 +56,10 @@
             "32bit": {
                 "url": "https://www.python.org/ftp/python/$version/python-$version.msi"
             }
+        },
+        "hash": {
+            "url": "https://www.python.org/downloads/release/python-$cleanVersion/",
+            "find": "$basename[\\S\\s]+?([A-Fa-f0-9]{32})"
         }
     }
 }

--- a/bucket/python35.json
+++ b/bucket/python35.json
@@ -1,18 +1,17 @@
 {
     "homepage": "https://www.python.org/",
-    "license": "https://docs.python.org/3/license.html",
+    "license": "Python-2.0",
     "version": "3.5.4",
     "architecture": {
         "64bit": {
             "url": "https://www.python.org/ftp/python/3.5.4/python-3.5.4-amd64.exe#/py3.exe",
-            "hash": "9b7741cc32357573a77d2ee64987717e527628c38fd7eaf3e2aaca853d45a1ee"
+            "hash": "md5:4276742a4a75a8d07260f13fe956eec4"
         },
         "32bit": {
             "url": "https://www.python.org/ftp/python/3.5.4/python-3.5.4.exe#/py3.exe",
-            "hash": "f27c2d67fd9688e4970f3bff799bb9d722a0d6c2c13b04848e1f7d620b524b0e"
+            "hash": "md5:9693575358f41f452d03fd33714f223f"
         }
     },
-    "pre_install": "copy-item $dir\\py3.exe $dir\\uninstall.exe",
     "installer": {
         "args": [
             "/quiet",
@@ -21,10 +20,11 @@
             "AssociateFiles=0",
             "Shortcuts=0",
             "InstallLauncherAllUsers=$(@{$true=1;$false=0}[$global])"
-        ]
+        ],
+        "keep": true
     },
     "uninstaller": {
-        "file": "uninstall.exe",
+        "file": "py3.exe",
         "args": [
             "/uninstall",
             "/quiet",
@@ -45,16 +45,17 @@
         "Lib\\idlelib\\idle.bat",
         [
             "Lib\\idlelib\\idle.bat",
+            "idle3"
+        ],
+        [
+            "Lib\\idlelib\\idle.bat",
             "idle35"
         ]
     ],
-    "env_add_path": [
-        ".",
-        "scripts"
-    ],
+    "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "python-(3.5.[\\d.]+)-amd64.exe"
+        "re": "Python (3\\.5\\.[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -64,6 +65,10 @@
             "32bit": {
                 "url": "https://www.python.org/ftp/python/$version/python-$version.exe#/py3.exe"
             }
+        },
+        "hash": {
+            "url": "https://www.python.org/downloads/release/python-$cleanVersion/",
+            "find": "$basename[\\S\\s]+?([A-Fa-f\\d]{32})"
         }
     }
 }

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -1,18 +1,17 @@
 {
     "homepage": "https://www.python.org/",
-    "license": "https://docs.python.org/3/license.html",
+    "license": "Python-2.0",
     "version": "3.6.8",
     "architecture": {
         "64bit": {
             "url": "https://www.python.org/ftp/python/3.6.8/python-3.6.8-amd64.exe#/py3.exe",
-            "hash": "96088a58b7c43bc83b84e6b67f15e8706c614023dd64f9a5a14e81ff824adadc"
+            "hash": "md5:72f37686b7ab240ef70fdb931bdf3cb5"
         },
         "32bit": {
             "url": "https://www.python.org/ftp/python/3.6.8/python-3.6.8.exe#/py3.exe",
-            "hash": "89871d432bc06e4630d7b64cb1a8451e53c80e68de29029976b12aad7dbfa5a0"
+            "hash": "md5:9c7b1ebdd3a8df0eebfda2f107f1742c"
         }
     },
-    "pre_install": "copy-item $dir\\py3.exe $dir\\uninstall.exe",
     "installer": {
         "args": [
             "/quiet",
@@ -21,10 +20,11 @@
             "AssociateFiles=0",
             "Shortcuts=0",
             "InstallLauncherAllUsers=$(@{$true=1;$false=0}[$global])"
-        ]
+        ],
+        "keep": true
     },
     "uninstaller": {
-        "file": "uninstall.exe",
+        "file": "py3.exe",
         "args": [
             "/uninstall",
             "/quiet",
@@ -45,16 +45,17 @@
         "Lib\\idlelib\\idle.bat",
         [
             "Lib\\idlelib\\idle.bat",
+            "idle3"
+        ],
+        [
+            "Lib\\idlelib\\idle.bat",
             "idle36"
         ]
     ],
-    "env_add_path": [
-        ".",
-        "scripts"
-    ],
+    "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "python-(3.6.[\\d.]+)-amd64.exe"
+        "re": "Python (3\\.6\\.[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
@@ -64,6 +65,10 @@
             "32bit": {
                 "url": "https://www.python.org/ftp/python/$version/python-$version.exe#/py3.exe"
             }
+        },
+        "hash": {
+            "url": "https://www.python.org/downloads/release/python-$cleanVersion/",
+            "find": "$basename[\\S\\s]+?([A-Fa-f\\d]{32})"
         }
     }
 }


### PR DESCRIPTION
- Change `python-beta` to only check "beta" versions
- Update `python27`, `python35`, `python36` manifests (`checkver`, `autoupdate.hash`)
- Fix `python35`, `python36`, `python-beta` `installer` and `uninstaller`, according to `python`'s
- When user has installed `python`, he wouldn't be able to install `python-beta` that has version prior to current stable, e.g., python=3.7.2 while python-beta=3.7.2rc1