### PR TITLE
stunnel: Add stunnel-beta and rename stunnel 5.49

### DIFF
--- a/bucket/stunnel-beta.json
+++ b/bucket/stunnel-beta.json
@@ -1,0 +1,36 @@
+{
+    "homepage": "https://www.stunnel.org",
+    "version": "5.51b1",
+    "license": "GPL-2.0-or-later",
+    "description": "A multiplatform GNU/GPL-licensed proxy encrypting arbitrary TCP connections with SSL/TLS",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.stunnel.org/downloads/beta/stunnel-5.51b1-win64-installer.exe#/dl.7z",
+            "hash": "0e9c47f6601b183c3daa9289c11d4caf2d8c828e1f7827d609fdee978690f2f6"
+        }
+    },
+    "bin": "bin\\stunnel.exe",
+    "persist": "config",
+    "uninstaller": {
+        "script": [
+            "stunnel -stop -quiet",
+            "stunnel -uninstall -quiet",
+            "stunnel -exit -quiet"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.stunnel.org/downloads.html",
+        "re": "beta/stunnel-(.+?)-win64"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.stunnel.org/downloads/beta/stunnel-$version-win64-installer.exe#/dl.7z"
+            }
+        }
+    },
+    "notes": [
+        "For Windows 32bit, use \"stunnel549\" instead",
+        "Run \"stunnel -install\" in the directory where a configured stunnel.conf is located (eg C:\\ProgramData\\scoop\\persist\\stunnel\\config) to create a native Windows service. Please note that as of version 5.50 Stunnel is a 64 bit application."
+    ]
+}

--- a/bucket/stunnel549.json
+++ b/bucket/stunnel549.json
@@ -1,21 +1,18 @@
 {
     "homepage": "https://www.stunnel.org",
     "version": "5.49",
-    "license": "GPL-2.0-only",
+    "license": "GPL-2.0-or-later",
     "description": "A multiplatform GNU/GPL-licensed proxy encrypting arbitrary TCP connections with SSL/TLS",
     "url": "https://www.stunnel.org/downloads/archive/5.x/stunnel-5.49-win32-installer.exe#/dl.7z",
     "hash": "459bbb212baf0b9821c80e0664c830246ef6e97c7329fb08160e87ff11ae9692",
     "bin": "bin\\stunnel.exe",
     "persist": "config",
-    "checkver": {
-        "url": "https://www.stunnel.org/downloads.html",
-        "re": "stunnel-([\\d.]+[\\d]+)-win32-installer.exe"
-    },
-    "autoupdate": {
-        "url": "https://www.stunnel.org/downloads/archive/$majorVersion.x/stunnel-$version-win32-installer.exe#/dl.7z",
-        "hash": {
-            "url": "https://www.stunnel.org/downloads/archive/$majorVersion.x/stunnel-$version-win32-installer.exe.sha256"
-        }
+    "uninstaller": {
+        "script": [
+            "stunnel -stop -quiet",
+            "stunnel -uninstall -quiet",
+            "stunnel -exit -quiet"
+        ]
     },
     "notes": "Run \"stunnel -install\" in the directory where a configured stunnel.conf is located (eg C:\\ProgramData\\scoop\\persist\\stunnel\\config) to create a native Windows service"
 }


### PR DESCRIPTION
- Add stunnel-beta
- Rename stunel5.49 to stunel549, add `uninstaller.script`, remove `checkver` and `autoupdate`, since it is the latest version that support win32.