### PR TITLE
Rename and mod openssl10

### DIFF
--- a/bucket/openssl10.json
+++ b/bucket/openssl10.json
@@ -2,15 +2,18 @@
     "description": "TLS/SSL toolkit (1.0.x branch)",
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
     "version": "1.0.2q",
-    "license": "https://www.openssl.org/source/license.html",
+    "license": {
+        "identifier": "OpenSSL|SSLeay",
+        "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
+    },
     "architecture": {
         "32bit": {
-            "hash": "sha512:eec46028dd3082975ee16721700d2e9faf5540302175d917634848f0dcd30f3277d94afd67ea823ada230830970472a3f07e1029b59dc7531118e505bdd7fbd9",
-            "url": "https://slproweb.com/download/Win32OpenSSL_Light-1_0_2q.exe"
+            "url": "https://slproweb.com/download/Win32OpenSSL_Light-1_0_2q.exe",
+            "hash": "0605a16d41cba761beee3930c4a2e5c6a20b20b28d4abd0608028d8aee0fe438"
         },
         "64bit": {
-            "hash": "sha512:c35956fe6daf641c148d476c51be42b844ccad60a818ff84d4f58aee0942ebbb03b57e80314eb5908e4e55a2367a9aab0bebfbe660aaf98e9276c7d470bc5a59",
-            "url": "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2q.exe"
+            "url": "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2q.exe",
+            "hash": "3c8de534115fe7c3d53919d4727bcb1413920299c61f2413503a06815b4aa957"
         }
     },
     "innosetup": true,
@@ -19,7 +22,7 @@
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\openssl.cfg"
     },
-    "checkver": ">Win32 OpenSSL v(1.0.[\\w]+)\\s+Light<",
+    "checkver": ">Win32 OpenSSL v(1\\.0\\.[\\w]+)\\s+Light<",
     "autoupdate": {
         "architecture": {
             "64bit": {
@@ -31,7 +34,7 @@
         },
         "hash": {
             "mode": "json",
-            "jp": "$.files.$basename.sha512",
+            "jp": "$['files']['$basename']['sha256']",
             "url": "https://slproweb.com/download/win32_openssl_hashes.json"
         }
     }


### PR DESCRIPTION
- Rename from `openssl10x` to `openssl10` as to be consistent with other one's name
- Change license
- Change `hash` and `checkver` to default sha256