### PR TITLE
sbt013: Rename and fix

### DIFF
--- a/bucket/sbt013.json
+++ b/bucket/sbt013.json
@@ -8,7 +8,7 @@
     "bin": "bin\\sbt.bat",
     "checkver": {
         "url": "http://www.scala-sbt.org/0.13/docs/index.html",
-        "re": "This\\sdocumentation\\sapplies\\sto\\ssbt\\s([\\d.]+)."
+        "re": "applies to sbt ([\\d.]+)\\."
     },
     "autoupdate": {
         "url": "https://cocl.us/sbt$cleanVersionzip#/dl.zip",


### PR DESCRIPTION
- Rename `sbt0.13` to `sbt013` as to be consistent with other manifests
- Fix `checkver`

Is it neccesary to keep this one's `checkver` and `autoupdate`?