### PR TITLE
 Update tomcat and others by autoupdate

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -5,5 +5,5 @@ param(
 
 if(!$env:SCOOP_HOME) { $env:SCOOP_HOME = resolve-path (split-path (split-path (scoop which scoop))) }
 $autopr = "$env:SCOOP_HOME/bin/auto-pr.ps1"
-$dir = "$psscriptroot/./bucket" # checks the parent dir
+$dir = "$psscriptroot/../bucket" # checks the parent dir
 Invoke-Expression -command "$autopr -dir $dir -upstream $upstream $($args | ForEach-Object { "$_ " })"

--- a/bucket/mysql56.json
+++ b/bucket/mysql56.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://dev.mysql.com/downloads/mysql/",
-    "version": "5.6.42",
+    "version": "5.6.43",
     "license": "GPLv2",
     "architecture": {
         "64bit": {
-            "url": "https://dev.mysql.com/get/mysql-5.6.42-winx64.zip",
-            "hash": "d9319cb681ef1f311f18c5f9175f4b47e961e2929d1311112ed49b9a0084557d",
-            "extract_dir": "mysql-5.6.42-winx64"
+            "url": "https://dev.mysql.com/get/mysql-5.6.43-winx64.zip",
+            "hash": "88f10e1ff1d4c10b86c95d00258882117ea7bf722a1afc626ec3ef1beabe65e4",
+            "extract_dir": "mysql-5.6.43-winx64"
         },
         "32bit": {
-            "url": "https://dev.mysql.com/get/mysql-5.6.42-win32.zip",
-            "hash": "edb1c3dd71c1b3842b636d40c9777eae0244989a91bbd0f6d912988fc641df0d",
-            "extract_dir": "mysql-5.6.42-win32"
+            "url": "https://dev.mysql.com/get/mysql-5.6.43-win32.zip",
+            "hash": "21262992aa56c8d1e2d39c0f2b264dc1f76893d328bb6f1530d8cc5d04062f83",
+            "extract_dir": "mysql-5.6.43-win32"
         }
     },
     "bin": [

--- a/bucket/mysql57.json
+++ b/bucket/mysql57.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://dev.mysql.com/downloads/mysql/",
-    "version": "5.7.24",
+    "version": "5.7.25",
     "license": "GPLv2",
     "architecture": {
         "64bit": {
-            "url": "https://dev.mysql.com/get/mysql-5.7.24-winx64.zip",
-            "hash": "b851100272e5d6d741e650e59989dcccf518a75478e25b5947b1552fb47e4f11",
-            "extract_dir": "mysql-5.7.24-winx64"
+            "url": "https://dev.mysql.com/get/mysql-5.7.25-winx64.zip",
+            "hash": "a9dccddb00641160b7b9e7382093b4400639637deabb611deace6403ea5bf9ea",
+            "extract_dir": "mysql-5.7.25-winx64"
         },
         "32bit": {
-            "url": "https://dev.mysql.com/get/mysql-5.7.24-win32.zip",
-            "hash": "a066ea54ed04644c47ff42b01ca4957ae72dc7dcc56c483efb557bebcf6477e6",
-            "extract_dir": "mysql-5.7.24-win32"
+            "url": "https://dev.mysql.com/get/mysql-5.7.25-win32.zip",
+            "hash": "2570b9e649bd78e575d6f7ef0c315e60e8ad0c39483703980de0bdc9b4ba70fe",
+            "extract_dir": "mysql-5.7.25-win32"
         }
     },
     "bin": [

--- a/bucket/pwsh-beta.json
+++ b/bucket/pwsh-beta.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://github.com/PowerShell/PowerShell",
-    "version": "6.2.0-preview.3",
+    "version": "6.2.0-preview.4",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.3/PowerShell-6.2.0-preview.3-win-x64.zip",
-            "hash": "5871b5e83192fa2a0c560c3d24aaae645a99d7cdf5f364b0b8cd3072e673a458"
+            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.4/PowerShell-6.2.0-preview.4-win-x64.zip",
+            "hash": "c6978b584829777d32413d646551bf88e4c78b165fde89c1152cb9ecedd6e748"
         },
         "32bit": {
-            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.3/PowerShell-6.2.0-preview.3-win-x86.zip",
-            "hash": "0835d123be70009d6642fefca32cdbef4df76b066a0097321707157e4828b469"
+            "url": "https://github.com/PowerShell/PowerShell/releases/download/v6.2.0-preview.4/PowerShell-6.2.0-preview.4-win-x86.zip",
+            "hash": "5fbf9ae6c625d201ef54f5289579afd3e6a904eda7b4bee98c1a9cae1a618296"
         }
     },
     "bin": "pwsh.exe",

--- a/bucket/rclone-beta.json
+++ b/bucket/rclone-beta.json
@@ -1,33 +1,40 @@
 {
-  "version":"1.45-104-gba84eecd",
-  "bin":[["rclone.exe","rclone-beta"]],
-  "architecture":{
-    "64bit":{
-      "url":"https://beta.rclone.org/rclone-beta-latest-windows-amd64.zip",
-      "extract_dir":"rclone-v1.45-104-gba84eecd-beta-windows-amd64",
-      "hash":"md5:9588edf6170978a069245c4e9fd75143"
+    "version": "1.45-133-g291f2709",
+    "bin": [
+        [
+            "rclone.exe",
+            "rclone-beta"
+        ]
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://beta.rclone.org/rclone-beta-latest-windows-amd64.zip",
+            "extract_dir": "rclone-v1.45-133-g291f2709-beta-windows-amd64",
+            "hash": "015e53a38417047e4f60c08892f8c93e94e51d98f78aec71be451a118899644e"
+        },
+        "32bit": {
+            "url": "https://beta.rclone.org/rclone-beta-latest-windows-386.zip",
+            "extract_dir": "rclone-v1.45-133-g291f2709-beta-windows-386",
+            "hash": "1f053740d715b8a7292961f587e9fe9b4e81c6005ec4b7fcaccc89f391e2edf1"
+        }
     },
-    "32bit":{
-      "url":"https://beta.rclone.org/rclone-beta-latest-windows-386.zip",
-      "extract_dir":"rclone-v1.45-104-gba84eecd-beta-windows-386",
-      "hash":"md5:4c03d818bf8de90cb9f0341d0d7fbfa7"
+    "checkver": {
+        "url": "https://beta.rclone.org/version.txt",
+        "re": "rclone v([1-9]+\\.[0-9]+-[0-9]+-[a-z0-9]+)-beta"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://beta.rclone.org/rclone-beta-latest-windows-amd64.zip",
+                "extract_dir": "rclone-v$version-beta-windows-amd64"
+            },
+            "32bit": {
+                "url": "https://beta.rclone.org/rclone-beta-latest-windows-386.zip",
+                "extract_dir": "rclone-v$version-beta-windows-386"
+            }
+        },
+        "hash": {
+            "url": "$url.md5"
+        }
     }
-  },
-  "checkver":{
-    "url":"https://beta.rclone.org/version.txt",
-    "re":"rclone v([1-9]+\\.[0-9]+-[0-9]+-[a-z0-9]+)-beta"
-  },
-  "autoupdate":{
-    "architecture":{
-      "64bit":{
-        "url":"https://beta.rclone.org/rclone-beta-latest-windows-amd64.zip",
-        "extract_dir":"rclone-v$version-beta-windows-amd64"
-      },
-      "32bit":{
-        "url":"https://beta.rclone.org/rclone-beta-latest-windows-386.zip",
-        "extract_dir":"rclone-v$version-beta-windows-386"
-      }
-    },
-    "hash":{"url":"$url.md5"}
-  }
 }

--- a/bucket/tomcat7.json
+++ b/bucket/tomcat7.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://tomcat.apache.org/",
-    "version": "7.0.90",
+    "version": "7.0.92",
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-7/v7.0.90/bin/apache-tomcat-7.0.90-windows-x64.zip",
-            "hash": "sha1:910776d00adb2348d32410214629b4771f435244"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-7/v7.0.92/bin/apache-tomcat-7.0.92-windows-x64.zip",
+            "hash": "eedbdaec2afd9285c8c1c6d9d925d12716c4c72d445dad70a2ccade31eaf79a0"
         },
         "32bit": {
-            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-7/v7.0.90/bin/apache-tomcat-7.0.90-windows-x86.zip",
-            "hash": "sha1:5925a8781926439fc76310e611de852d09abd2e9"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-7/v7.0.92/bin/apache-tomcat-7.0.92-windows-x86.zip",
+            "hash": "7d3d08f5eec5c50e7ecf79fa02db5aa2ad7eb8ed12d75a5652765d5254313a8f"
         }
     },
-    "extract_dir": "apache-tomcat-7.0.90",
+    "extract_dir": "apache-tomcat-7.0.92",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",

--- a/bucket/tomcat85.json
+++ b/bucket/tomcat85.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://tomcat.apache.org/",
-    "version": "8.5.33",
+    "version": "8.5.35",
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.33/bin/apache-tomcat-8.5.33-windows-x64.zip",
-            "hash": "sha1:e535093b04da7795d1e1bcde255dd91b8d2d463f"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.35/bin/apache-tomcat-8.5.35-windows-x64.zip",
+            "hash": "3f4b973deb3fdc0b1a309459d16d4a7d2b77ae4c34dbe01bc7b080543f80f295"
         },
         "32bit": {
-            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.33/bin/apache-tomcat-8.5.33-windows-x86.zip",
-            "hash": "sha1:ad6a28c0c97ce95006c0850d5e57602a12c12386"
+            "url": "https://www.apache.org/dyn/closer.cgi?action=download&filename=tomcat/tomcat-8/v8.5.35/bin/apache-tomcat-8.5.35-windows-x86.zip",
+            "hash": "74b1d2b162a7ff1d72cdafcdf4093828f58205ea7cec4293c7182f9cb98f27cd"
         }
     },
-    "extract_dir": "apache-tomcat-8.5.33",
+    "extract_dir": "apache-tomcat-8.5.35",
     "bin": "bin\\catalina.bat",
     "env_set": {
         "CATALINA_HOME": "$dir",


### PR DESCRIPTION
Hi,

The outdated tomcat85 files are no more available, I run the autoupdate script to update it and now it seems to work.

Also `auto-pr` seems to work a little strange. Is there an instruction on how to use it?
Also, there was a mistake in a path to `bucket` folder in it.

Thanks