### PR TITLE
Python: Fix checkver error

### DIFF
--- a/bucket/python-beta.json
+++ b/bucket/python-beta.json
@@ -47,7 +47,7 @@
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "Python ([\\d.]+[abcr]{1,2}[\\d]+)"
+        "re": "python-(3[\\d.]+[abcr]{1,2}[\\d]+)-"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python27-beta.json
+++ b/bucket/python27-beta.json
@@ -1,0 +1,65 @@
+{
+    "homepage": "https://www.python.org/",
+    "license": "Python-2.0",
+    "version": "2.7.16rc1",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.python.org/ftp/python/2.7.16/python-2.7.16rc1.amd64.msi",
+            "hash": "md5:4c163b962ff061893da42ef9797dae02"
+        },
+        "32bit": {
+            "url": "https://www.python.org/ftp/python/2.7.16/python-2.7.16rc1.msi",
+            "hash": "md5:e48585321c4728fdcdb0dc450cc68b92"
+        }
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python2"
+        ],
+        "Lib\\idlelib\\idle.bat",
+        [
+            "Lib\\idlelib\\idle.bat",
+            "idle2"
+        ]
+    ],
+    "env_add_path": "scripts",
+    "post_install": [
+        "python2 -m ensurepip",
+        "",
+        "$create_reg = {",
+        "    param($path, $value)",
+        "",
+        "    $reg_base = \"Registry::HKEY_CURRENT_USER\\Software\"",
+        "",
+        "    new-item -path \"$reg_base\\$path\" -force | out-null",
+        "    new-itemproperty -path \"$reg_base\\$path\" `",
+        "        -name \"(Default)\" -value \"$value\" -force | out-null",
+        "}",
+        "",
+        "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\InstallPath\", `",
+        "    \"$dir\")",
+        "$create_reg.Invoke(\"Python\\PythonCore\\2.7\\PythonPath\", `",
+        "    \"$dir;$dir\\Lib\\;$dir\\DLLs\\\")"
+    ],
+    "checkver": {
+        "url": "https://www.python.org/downloads/windows/",
+        "re": "python-(2[\\d.]+[abcr]{1,2}[\\d]+)-"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.python.org/ftp/python/$matchHead/python-$version.amd64.msi"
+            },
+            "32bit": {
+                "url": "https://www.python.org/ftp/python/$matchHead/python-$version.msi"
+            }
+        },
+        "hash": {
+            "url": "https://www.python.org/downloads/release/python-$cleanVersion/",
+            "find": "$basename[\\S\\s]+?([A-Fa-f0-9]{32})"
+        }
+    }
+}

--- a/bucket/python35.json
+++ b/bucket/python35.json
@@ -55,7 +55,7 @@
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "Python (3\\.5\\.[\\d.]+)"
+        "re": "python-(3\\.5\\.[\\d.]+)-"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -55,7 +55,7 @@
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "Python (3\\.6\\.[\\d.]+)"
+        "re": "python-(3\\.6\\.[\\d.]+)-"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- Fix `checkver` in python manifests that may give wrong updated version that don't have binary files.
- Add `python27-beta`