### PR TITLE
Create atom-beta-portable.json

### DIFF
--- a/bucket/atom-beta-portable.json
+++ b/bucket/atom-beta-portable.json
@@ -1,0 +1,54 @@
+{
+    "homepage": "https://atom.io/",
+    "version": "1.35.0-beta0",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/atom/atom/releases/download/v1.35.0-beta0/atom-x64-1.35.0-beta0-full.nupkg",
+            "hash": "sha1:df955171999b580e6fc72d5678e52609e16ad9d7"
+        },
+        "32bit": {
+            "url": "https://github.com/atom/atom/releases/download/v1.35.0-beta0/atom-1.35.0-beta0-full.nupkg",
+            "hash": "sha1:e8f66d2d2eff287854d6c194e9119f2c8735ed7e"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "extract_to": "AtomPortable",
+    "bin": [
+        "\\AtomPortable\\resources\\cli\\atom.cmd",
+        "\\AtomPortable\\resources\\app\\apm\\bin\\apm.cmd"
+    ],
+    "shortcuts": [
+        [
+            "AtomPortable\\atom.exe",
+            "Atom Beta"
+        ]
+    ],
+    "persist": ".atom",
+    "post_install": [
+        "if(-not(Test-Path \"$dir\\.atom\\electronUserData\")) {",
+        "   New-Item -Type Directory \"$dir\\.atom\\electronUserData\" | Out-Null",
+        "}"
+    ],
+    "checkver": {
+        "url": "https://github.com/atom/atom/releases",
+        "regex": "/releases/tag/(?:v)?([\\d.]+-beta\\d)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-x64-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES-x64",
+                    "regex": "([a-fA-F0-9]+)\\s+?(?:atom-$version-full.nupkg)"
+                }
+            },
+            "32bit": {
+                "url": "https://github.com/atom/atom/releases/download/v$version/atom-$version-full.nupkg",
+                "hash": {
+                    "url": "$baseurl/RELEASES"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow the [Flight Manual](https://flight-manual.atom.io/getting-started/sections/installing-atom/#portable-mode) to make Atom accessing `.atom` in the same installed dir, instead of accessing `$HOME\.atom` and `$APPDATA\atom`.