### PR TITLE
Update Python 2.7 installer hash

### DIFF
--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -5,11 +5,11 @@
     "architecture": {
         "64bit": {
             "url": "https://www.python.org/ftp/python/2.7.16/python-2.7.16.amd64.msi",
-            "hash": "md5:2841e92ba89a6f036305a8a07fbe9d18"
+            "hash": "md5:2fe86194bb4027be75b29852027f1a79"
         },
         "32bit": {
             "url": "https://www.python.org/ftp/python/2.7.16/python-2.7.16.msi",
-            "hash": "md5:01a8c4bca5f69e6f05e80495d5a5bccb"
+            "hash": "md5:912428345b7e0428544ec4edcdf70286"
         }
     },
     "bin": [


### PR DESCRIPTION
Retrieved from https://www.python.org/downloads/release/python-2716/