### PR TITLE
python: Seperate python-alpha and python-beta

### DIFF
--- a/bucket/python-alpha.json
+++ b/bucket/python-alpha.json
@@ -1,15 +1,15 @@
 {
     "homepage": "https://www.python.org/",
     "license": "Python-2.0",
-    "version": "3.7.3rc1",
+    "version": "3.8.0a2",
     "architecture": {
         "64bit": {
-            "url": "https://www.python.org/ftp/python/3.7.3/python-3.7.3rc1-amd64.exe#/py3.exe",
-            "hash": "md5:f52a9dad92a6ef66b4fe9c46e612216e"
+            "url": "https://www.python.org/ftp/python/3.8.0/python-3.8.0a2-amd64.exe#/py3.exe",
+            "hash": "md5:821835b9afd5a0b6da430a715e7fdc8e"
         },
         "32bit": {
-            "url": "https://www.python.org/ftp/python/3.7.3/python-3.7.3rc1.exe#/py3.exe",
-            "hash": "md5:85542faf758734f25af323d5528feee1"
+            "url": "https://www.python.org/ftp/python/3.8.0/python-3.8.0a2.exe#/py3.exe",
+            "hash": "md5:c29cbabd12f6ab4ed1f57029c302d7c0"
         }
     },
     "installer": {
@@ -47,7 +47,7 @@
     "env_add_path": "scripts",
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "re": "python-(3[\\d.]+rc{1,2}[\\d]+)-"
+        "re": "python-(3[\\d.]+[ab]{1,2}[\\d]+)-"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
- python-alpha check alpha and beta versions (3.8.0a2)
- python-beta check rc versions (3.7.3rc1)