### PR TITLE
Add scantailor and scantailor-universal

### DIFF
--- a/bucket/scantailor-universal.json
+++ b/bucket/scantailor-universal.json
@@ -1,0 +1,34 @@
+{
+    "description": "A fork based on Enhanced+Featured+Master versions of ScanTailor.",
+    "homepage": "https://github.com/trufanov-nok/scantailor",
+    "license": "GPL-3.0-only",
+    "version": "0.2.6",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/trufanov-nok/scantailor/releases/download/0.2.6/scantailor-0.2.6-64bit-install.exe#!/dl.7z",
+            "hash": "714c8559d2863594922541c4918bbef123351dff8ff330ba72cea22c8a67bcd6"
+        },
+        "32bit": {
+            "url": "https://github.com/trufanov-nok/scantailor/releases/download/0.2.6/scantailor-0.2.6-32bit-install.exe#!/dl.7z",
+            "hash": "0e07fa4b430eeba8fdf2e851a825cd34bd7d761561fc72846ea2d6ed7007332c"
+        }
+    },
+    "bin": "scantailor-cli.exe",
+    "shortcuts": [
+        [
+            "scantailor.exe",
+            "ScanTailor Universal"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/trufanov-nok/scantailor/releases/download/$version/scantailor-$version-64bit-install.exe#!/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/trufanov-nok/scantailor/releases/download/$version/scantailor-$version-32bit-install.exe#!/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/scantailor.json
+++ b/bucket/scantailor.json
@@ -1,0 +1,37 @@
+{
+    "description": "An interactive post-processing tool for scanned pages.",
+    "homepage": "http://scantailor.org/",
+    "license": "GPL-3.0-only",
+    "version": "0.9.11.1",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/scantailor/scantailor/releases/download/RELEASE_0_9_11_1/scantailor-0.9.11.1-64bit-install.exe#!/dl.7z",
+            "hash": "6ae6302e55ef0bb6c53349f8330c6e0accc6c985826c4c33a1089704e88f8bb2"
+        },
+        "32bit": {
+            "url": "https://github.com/scantailor/scantailor/releases/download/RELEASE_0_9_11_1/scantailor-0.9.11.1-32bit-install.exe#!/dl.7z",
+            "hash": "8cc324730890e0a4eb669dc43c7658d3512b983884fa792ec4bfaa4f8fd7d753"
+        }
+    },
+    "bin": "scantailor-cli.exe",
+    "shortcuts": [
+        [
+            "scantailor.exe",
+            "ScanTailor"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/scantailor/scantailor/releases",
+        "re": "scantailor-([\\d.]+)-64bit-install.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/scantailor/scantailor/releases/download/RELEASE_$underscoreVersion/scantailor-$version-64bit-install.exe#!/dl.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/scantailor/scantailor/releases/download/RELEASE_$underscoreVersion/scantailor-$version-32bit-install.exe#!/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
As suggestion by@Ash258, scantailor and one of its forks is moved to versions bucket.

https://github.com/lukesampson/scoop-extras/pull/2378