### PR TITLE
Add MariaDB 10.3

### DIFF
--- a/bucket/mariadb103.json
+++ b/bucket/mariadb103.json
@@ -1,0 +1,73 @@
+{
+    "homepage": "https://mariadb.org",
+    "version": "10.3.18",
+    "license": "GPL-2.0-only",
+    "description": "Community developed fork of MySQL server.",
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.mariadb.com/MariaDB/mariadb-10.3.18/winx64-packages/mariadb-10.3.18-winx64.zip",
+            "hash": "7fc64098a4d5f4853277ce6279b3d1ba5adc503a0013a0ed23b16709abd75935",
+            "extract_dir": "mariadb-10.3.18-winx64"
+        },
+        "32bit": {
+            "url": "https://downloads.mariadb.com/MariaDB/mariadb-10.3.18/winx32-packages/mariadb-10.3.18-winx32.zip",
+            "hash": "656e9b35041fb4a0c1bcb9d4f6a0be3528f1db50f0f9c00f81dd0a5b9ac96a20",
+            "extract_dir": "mariadb-10.3.18-win32"
+        }
+    },
+    "bin": [
+        "bin\\aria_chk.exe",
+        "bin\\aria_dump_log.exe",
+        "bin\\aria_ftdump.exe",
+        "bin\\aria_pack.exe",
+        "bin\\aria_read_log.exe",
+        "bin\\innochecksum.exe",
+        "bin\\myisamchk.exe",
+        "bin\\myisamlog.exe",
+        "bin\\myisampack.exe",
+        "bin\\myisam_ftdump.exe",
+        "bin\\mysql.exe",
+        "bin\\mysqladmin.exe",
+        "bin\\mysqlbinlog.exe",
+        "bin\\mysqlcheck.exe",
+        "bin\\mysqld.exe",
+        "bin\\mysqldump.exe",
+        "bin\\mysqlimport.exe",
+        "bin\\mysqlshow.exe",
+        "bin\\mysqlslap.exe",
+        "bin\\mysql_install_db.exe",
+        "bin\\mysql_plugin.exe",
+        "bin\\mysql_tzinfo_to_sql.exe",
+        "bin\\mysql_upgrade.exe",
+        "bin\\mysql_upgrade_service.exe",
+        "bin\\my_print_defaults.exe"
+    ],
+    "persist": "data",
+    "post_install": [
+        "# Initialize data directory (without generating root password)",
+        "if (!(Test-Path \"$dir\\data\\auto.cnf\")) { mysqld --initialize-insecure }"
+    ],
+    "notes": [
+        "Run following command as administrator to run MariaDB as a service.",
+        "mysqld --install \"[Service Name(default:MySQL)]\""
+    ],
+    "checkver": {
+        "url": "https://downloads.mariadb.org/",
+        "re": "Download ([\\d.]+) Stable"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.mariadb.com/MariaDB/mariadb-$version/winx64-packages/mariadb-$version-winx64.zip",
+                "extract_dir": "mariadb-$version-winx64"
+            },
+            "32bit": {
+                "url": "https://downloads.mariadb.com/MariaDB/mariadb-$version/win32-packages/mariadb-$version-win32.zip",
+                "extract_dir": "mariadb-$version-win32"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/sha256sums.txt"
+        }
+    }
+}

--- a/bucket/mariadb103.json
+++ b/bucket/mariadb103.json
@@ -53,7 +53,7 @@
     ],
     "checkver": {
         "url": "https://downloads.mariadb.org/",
-        "re": "Download ([\\d.]+) Stable"
+        "re": "Download (10\\.3\\.[\\d]+) Stable"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Adds [latest stable version](https://downloads.mariadb.org/mariadb/+releases/) of MariaDB 10.3 (10.3.18)

> _MariaDB 10.3 is the previous major stable version. The first stable release was in May 2018, and it will be supported until May 2023._
> https://mariadb.com/kb/en/library/changes-improvements-in-mariadb-103/