### PR TITLE
pwsh-beta: Change shortcut name

### DIFF
--- a/bucket/pwsh-beta.json
+++ b/bucket/pwsh-beta.json
@@ -16,7 +16,7 @@
     "shortcuts": [
         [
             "pwsh.exe",
-            "PowerShell Core"
+            "PowerShell"
         ]
     ],
     "pre_install": "if(!(Test-Path \"$dir\\profile.ps1\")) { New-Item \"$dir\\profile.ps1\" -ItemType File }",


### PR DESCRIPTION
@r15ch13
With Powershell 7 the naming convention is changing from 6.2.3 "Powershell Core" to just "Powershell", therefore the shortcut name should reflect that.

Also, while not edited, should future betas (7.1+) have this make the shims "pwsh-preview.exe" to allow for side-by-side?