### PR TITLE
Add ruby26 at 2.6.5-1

### DIFF
--- a/bucket/ruby26.json
+++ b/bucket/ruby26.json
@@ -1,0 +1,52 @@
+{
+    "homepage": "https://rubyinstaller.org",
+    "description": "A dynamic programming language with a focus on simplicity and productivity.",
+    "version": "2.6.5-1",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-2.6.5-1-x64.7z",
+            "hash": "9b1866e59fe1e7336c4e3231823ff24e121878ed1bac8194ad3fe5e9f2f9ef69",
+            "extract_dir": "rubyinstaller-2.6.5-1-x64"
+        },
+        "32bit": {
+            "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-2.6.5-1-x86.7z",
+            "hash": "28db577adbaf2e75d14c44569eccfd7cf73846e6286a67cbb262aba236151cfc",
+            "extract_dir": "rubyinstaller-2.6.5-1-x86"
+        }
+    },
+    "persist": "gems",
+    "env_add_path": [
+        "bin",
+        "gems\\bin"
+    ],
+    "env_set": {
+        "GEM_HOME": "$dir\\gems",
+        "GEM_PATH": "$dir\\gems"
+    },
+    "suggest": {
+        "MSYS2": "msys2"
+    },
+    "post_install": "gem install rake",
+    "notes": "Install MSYS2 via 'scoop install msys2' and then run 'ridk install' to install the toolchain!",
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/oneclick/rubyinstaller.org-website/master/_data/downloads.yaml",
+        "regex": "Ruby (2\\.6[\\d.]+(?:-[\\d])?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$version/rubyinstaller-$version-x64.7z",
+                "extract_dir": "rubyinstaller-$version-x64"
+            },
+            "32bit": {
+                "url": "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-$version/rubyinstaller-$version-x86.7z",
+                "extract_dir": "rubyinstaller-$version-x86"
+            }
+        },
+        "hash": {
+            "url": "https://raw.githubusercontent.com/oneclick/rubyinstaller.org-website/master/_data/downloads.yaml",
+            "regex": "(?sm)$basename[^.].*?$sha256"
+        }
+    }
+}


### PR DESCRIPTION
Source: https://github.com/ScoopInstaller/Main/blob/ad61ac28d0b811fbaf31986eabd2986a5b6ca631/bucket/ruby.json
Edited to specify 2.6.x in the `checkver`.