### PR TITLE
helm2: add new shim 'helm2'

### DIFF
--- a/bucket/helm2.json
+++ b/bucket/helm2.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://helm.sh",
-    "description": "The package manager for Kubernetes",
+    "description": "The package manager for Kubernetes. Use as helm2.",
     "license": "Apache-2.0",
     "version": "2.16.6",
     "architecture": {
@@ -10,7 +10,7 @@
         }
     },
     "extract_dir": "windows-amd64",
-    "bin": "helm.exe",
+    "bin": [[ "helm.exe", "helm2" ]],
     "checkver": {
         "github": "https://github.com/kubernetes/helm",
         "regex": "tag/v(2\\.[\\d.]+)"

--- a/bucket/helm2.json
+++ b/bucket/helm2.json
@@ -1,6 +1,6 @@
 {
     "homepage": "https://helm.sh",
-    "description": "The package manager for Kubernetes. Use as helm2.",
+    "description": "The package manager for Kubernetes",
     "license": "Apache-2.0",
     "version": "2.16.6",
     "architecture": {
@@ -10,7 +10,13 @@
         }
     },
     "extract_dir": "windows-amd64",
-    "bin": [[ "helm.exe", "helm2" ]],
+    "bin": [
+        "helm.exe",
+        [
+            "helm.exe",
+            "helm2"
+        ]
+    ],
     "checkver": {
         "github": "https://github.com/kubernetes/helm",
         "regex": "tag/v(2\\.[\\d.]+)"


### PR DESCRIPTION
The main bucket now has the latest helm release: helm3.
Majority helm2 users would now (or soon) be in the process of migrating their helm2 managed workloads to helm3, and having them both side-by-side makes the process very convenient.