### PR TITLE
spotbugs-beta: Add version 4.0.2

### DIFF
--- a/bucket/spotbugs-beta.json
+++ b/bucket/spotbugs-beta.json
@@ -1,8 +1,8 @@
 {
     "version": "4.0.2",
-    "description": "Static analysis tool for Java.",
+    "description": "Static analysis tool for Java",
     "homepage": "https://spotbugs.github.io/",
-    "license": "LGPL-2.1",
+    "license": "LGPL-2.1-only",
     "suggest": {
         "JDK": [
             "java/oraclejdk",
@@ -16,9 +16,12 @@
     "shortcuts": [
         [
             "bin\\spotbugs.bat",
-            "SpotBugs"
+            "SpotBugs",
+            "",
+            "bin\\spotbugs.ico"
         ]
     ],
+    "persist": "plugin",
     "checkver": {
         "url": "https://api.github.com/repos/spotbugs/spotbugs/releases",
         "jp": "$[0].tag_name"

--- a/bucket/spotbugs-beta.json
+++ b/bucket/spotbugs-beta.json
@@ -1,0 +1,30 @@
+{
+    "version": "4.0.2",
+    "description": "Static analysis tool for Java.",
+    "homepage": "https://spotbugs.github.io/",
+    "license": "LGPL-2.1",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    },
+    "url": "https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/4.0.2/spotbugs-4.0.2.zip",
+    "hash": "84a1e40abc9d3f7721723b1384a37c75029c2e3a7d710ef94cf950d3250c15e6",
+    "extract_dir": "spotbugs-4.0.2",
+    "bin": "bin\\spotbugs.bat",
+    "shortcuts": [
+        [
+            "bin\\spotbugs.bat",
+            "SpotBugs"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/spotbugs/spotbugs/releases",
+        "jp": "$[0].tag_name"
+    },
+    "autoupdate": {
+        "url": "https://repo.maven.apache.org/maven2/com/github/spotbugs/spotbugs/$version/spotbugs-$version.zip",
+        "extract_dir": "spotbugs-$version"
+    }
+}


### PR DESCRIPTION
[SpotBugs](https://spotbugs.github.io/) is a static analysis tool for Java code. It comes with a command-line interface and a GUI.
Although 4.0.2 *is* currently the latest release of SpotBugs, when there are newer betas or release candidates available, this manifest will automatically update to them (see https://github.com/spotbugs/spotbugs/releases).