### PR TITLE
dotnet-sdk-preview: Fixing path

### DIFF
--- a/bucket/dotnet-sdk-preview.json
+++ b/bucket/dotnet-sdk-preview.json
@@ -14,8 +14,10 @@
         }
     },
     "bin": "dotnet.exe",
+    "env_add_path": ".",
     "env_set": {
-        "DOTNET_ROOT": "$dir"
+        "DOTNET_ROOT": "$dir",
+        "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",


### PR DESCRIPTION
Before this fix the the dotnet path was not working correctly with the IDE Rider as it could not find the path to the sdk.