### PR TITLE
aws1: Add version 1.18.144

### DIFF
--- a/bucket/aws1.json
+++ b/bucket/aws1.json
@@ -4,7 +4,7 @@
     "homepage": "https://aws.amazon.com/cli/",
     "description": "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.",
     "url": "https://s3.amazonaws.com/aws-cli/AWSCLI64PY3-1.18.144.msi",
-    "hash": "8b5441903fddb493b491ece924304d602e571726f9ba4a824fc0fae1cf59b72a",
+    "hash": "ba5767cd03bb465fe3e561e510713f4026aa7a9c4fe3d6fddda85667db58f588",
     "extract_dir": "Amazon/AWSCLI",
     "bin": [
         [

--- a/bucket/aws1.json
+++ b/bucket/aws1.json
@@ -1,9 +1,9 @@
 {
-    "version": "1.18.44",
+    "version": "1.18.144",
     "license": "Apache-2.0",
     "homepage": "https://aws.amazon.com/cli/",
     "description": "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.",
-    "url": "https://s3.amazonaws.com/aws-cli/AWSCLI64PY3-1.18.44.msi",
+    "url": "https://s3.amazonaws.com/aws-cli/AWSCLI64PY3-1.18.144.msi",
     "hash": "8b5441903fddb493b491ece924304d602e571726f9ba4a824fc0fae1cf59b72a",
     "extract_dir": "Amazon/AWSCLI",
     "bin": [

--- a/bucket/aws1.json
+++ b/bucket/aws1.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.18.44",
+    "license": "Apache-2.0",
+    "homepage": "https://aws.amazon.com/cli/",
+    "description": "The AWS Command Line Interface (CLI) is a unified tool to manage your AWS services. With just one tool to download and configure, you can control multiple AWS services from the command line and automate them through scripts.",
+    "url": "https://s3.amazonaws.com/aws-cli/AWSCLI64PY3-1.18.44.msi",
+    "hash": "8b5441903fddb493b491ece924304d602e571726f9ba4a824fc0fae1cf59b72a",
+    "extract_dir": "Amazon/AWSCLI",
+    "bin": [
+        [
+            "runtime/python.exe",
+            "aws",
+            "-m awscli"
+        ]
+    ],
+    "autoupdate": {
+        "url": "https://s3.amazonaws.com/aws-cli/AWSCLI64PY3-$version.msi"
+    }
+}


### PR DESCRIPTION
See https://github.com/ScoopInstaller/Main/pull/1395

Updated `aws` in main bucket to `2.x` and **migrated** `1.x` to `aws1` [versions](https://github.com/ScoopInstaller/Versions) bucket