### PR TITLE
Allow for scoop reset python27

### DIFF
--- a/bucket/python27.json
+++ b/bucket/python27.json
@@ -25,7 +25,10 @@
             "idle2"
         ]
     ],
-    "env_add_path": "scripts",
+    "env_add_path": [
+        ".",
+        "scripts"
+    ],
     "post_install": [
         "python2 -m ensurepip",
         "",


### PR DESCRIPTION
Sadly all newer version of python are adding to the path ".", rather than relying on the shims. The effect is:

scoop install python27
scoop install python
python --version # say 3.9
scoop reset python27
python --version # still 3.9 because python/current is part of the path and takes precedence over ~/scoop/shims 

----
The change above would result in python27/current taking higher priority in the path
python --version # 2.7.18

----
Ideally none of the python versions would depend on path, but not sure if this was a requirement on new versions.