### PR TITLE
postman-canary: Add version 7.36.0-canary02

### DIFF
--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,0 +1,49 @@
+{
+    "version": "7.35.0-canary03",
+    "description": "Complete API development environment.",
+    "homepage": "https://www.getpostman.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://www.getpostman.com/licenses/postman_eula"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dl.pstmn.io/download/7.35.0-canary03/PostmanCanary-win64-7.35.0-canary03-full.nupkg#/dl.7z",
+            "hash": "sha1:ea64fbd8c90a5a29c0ad8c42dcf2f5475a114a0a"
+        },
+        "32bit": {
+            "url": "https://dl.pstmn.io/download/7.35.0-canary03/PostmanCanary-win32-7.35.0-canary03-full.nupkg#/dl.7z",
+            "hash": "sha1:45bf2be96074b1f0927eb0f93f0672f49dc671ea"
+        }
+    },
+    "extract_dir": "lib\\net45",
+    "bin": "PostmanCanary.exe",
+    "shortcuts": [
+        [
+            "PostmanCanary.exe",
+            "PostmanCanary"
+        ]
+    ],
+    "checkver": {
+        "url": "https://dl.pstmn.io/changelog?channel=canary&platform=win64",
+        "jsonpath": "$.changelog[0].name"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dl.pstmn.io/download/$version/PostmanCanary-win64-$version-full.nupkg#/dl.7z",
+                "hash": {
+                    "url": "https://dl.pstmn.io/RELEASES?platform=win64&channel=canary",
+                    "jsonpath": "$.releases[*].files[?(@.name=='$basename')].hash"
+                }
+            },
+            "32bit": {
+                "url": "https://dl.pstmn.io/download/$version/PostmanCanary-win32-$version-full.nupkg#/dl.7z",
+                "hash": {
+                    "url": "https://dl.pstmn.io/RELEASES?platform=win32&channel=canary",
+                    "jsonpath": "$.releases[*].files[?(@.name=='$basename')].hash"
+                }
+            }
+        }
+    }
+}

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.35.0-canary03",
+    "version": "7.36.0-canary02",
     "description": "Complete API development environment.",
     "homepage": "https://www.getpostman.com/",
     "license": {
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/7.35.0-canary03/PostmanCanary-win64-7.35.0-canary03-full.nupkg#/dl.7z",
-            "hash": "sha1:ea64fbd8c90a5a29c0ad8c42dcf2f5475a114a0a"
+            "url": "https://dl.pstmn.io/download/7.36.0-canary02/PostmanCanary-win64-7.36.0-canary02-full.nupkg#/dl.7z",
+            "hash": "sha1:f2bcfddb351979f664b2cb631dea22d050deebde"
         },
         "32bit": {
-            "url": "https://dl.pstmn.io/download/7.35.0-canary03/PostmanCanary-win32-7.35.0-canary03-full.nupkg#/dl.7z",
-            "hash": "sha1:45bf2be96074b1f0927eb0f93f0672f49dc671ea"
+            "url": "https://dl.pstmn.io/download/7.36.0-canary02/PostmanCanary-win32-7.36.0-canary02-full.nupkg#/dl.7z",
+            "hash": "sha1:5c4ad8f98f3a2d98d2700f8050e93e11039af5e8"
         }
     },
     "extract_dir": "lib\\net45",


### PR DESCRIPTION
I noticed Postman's canary channel wasn't available in scoop and I wanted to use it. That's pretty much all there is to it.