### PR TITLE
anaconda2/miniconda2: Fix checkver

### DIFF
--- a/bucket/anaconda2.json
+++ b/bucket/anaconda2.json
@@ -1,9 +1,9 @@
 {
-    "version": "2.4.0",
+    "version": "2019.10",
     "license": "BSD-3-Clause",
     "homepage": "https://www.anaconda.com/",
     "checkver": {
-        "url": "https://repo.continuum.io/archive",
+        "url": "https://docs.anaconda.com/anaconda/install/hashes/win-2-64/",
         "re": "Anaconda2-([\\d.]+)-Windows"
     },
     "bin": [
@@ -31,21 +31,21 @@
     "env_add_path": "Scripts",
     "architecture": {
         "64bit": {
-            "url": "https://repo.continuum.io/archive/Anaconda2-2.4.0-Windows-x86_64.exe",
-            "hash": "7a40484e58e91f62d91961c8607de586d3ef14645319c0395683e5f7182551bd"
+            "url": "https://repo.anaconda.com/archive/Anaconda2-2019.10-Windows-x86_64.exe",
+            "hash": "3e09c8e95e10f077be1e1d26f26df8d6a13356449e06d7d47ddc066fbaf435f5"
         },
         "32bit": {
-            "url": "https://repo.continuum.io/archive/Anaconda2-2.4.0-Windows-x86.exe",
-            "hash": "2a05db81a0fe4155bc2dd83a689294d3ac7fa1d1a68a5ec6bdafaac9140d451a"
+            "url": "https://repo.anaconda.com/archive/Anaconda2-2019.10-Windows-x86.exe",
+            "hash": "b4731acd02f96923922d995bb16984d71b4a934b7af6737984dd9eb5d8cc6389"
         }
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.continuum.io/archive/Anaconda2-$version-Windows-x86_64.exe"
+                "url": "https://repo.anaconda.com/archive/Anaconda2-$version-Windows-x86_64.exe"
             },
             "32bit": {
-                "url": "https://repo.continuum.io/archive/Anaconda2-$version-Windows-x86.exe"
+                "url": "https://repo.anaconda.com/archive/Anaconda2-$version-Windows-x86.exe"
             }
         },
         "hash": {

--- a/bucket/miniconda2.json
+++ b/bucket/miniconda2.json
@@ -1,33 +1,33 @@
 {
-    "version": "3.18.3",
+    "version": "4.8.3",
     "homepage": "https://conda.io/miniconda.html",
     "license": "BSD-3-Clause",
     "checkver": {
-        "url": "https://repo.continuum.io/miniconda",
-        "re": "Miniconda2-([\\d.]+)-Windows"
+        "url": "https://docs.conda.io/en/latest/miniconda_hashes.html",
+        "re": "Miniconda2-py27_([\\d.]+)-Windows"
     },
     "architecture": {
         "64bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda2-3.18.3-Windows-x86_64.exe",
-            "hash": "md5:78accfad67613b62ea8d6eb06c1559a7"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Windows-x86_64.exe",
+            "hash": "6973025404832944e074bf02bda8c4594980eeed4707bb51baa8fbdba4bf326c"
         },
         "32bit": {
-            "url": "https://repo.continuum.io/miniconda/Miniconda2-3.18.3-Windows-x86.exe",
-            "hash": "md5:77e599048e9ed6f94c2aae1b9557250c"
+            "url": "https://repo.anaconda.com/miniconda/Miniconda2-py27_4.8.3-Windows-x86.exe",
+            "hash": "c8049d26f8b6b954b57bcd4e99ad72d1ffa13f4a6b218e64e641504437b2617b"
         }
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://repo.continuum.io/miniconda/Miniconda2-$version-Windows-x86_64.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda2-py27_$version-Windows-x86_64.exe"
             },
             "32bit": {
-                "url": "https://repo.continuum.io/miniconda/Miniconda2-$version-Windows-x86.exe"
+                "url": "https://repo.anaconda.com/miniconda/Miniconda2-py27_$version-Windows-x86.exe"
             }
         },
         "hash": {
-            "url": "$baseurl",
-            "find": "$basename[\\S\\s]+?<td>([a-fA-F0-9]{32})</td>"
+            "url": "https://docs.conda.io/en/latest/miniconda_hashes.html",
+            "find": "(?sm)$basename.*?$sha256"
         }
     },
     "installer": {


### PR DESCRIPTION
Address an issue with `checkver` as of lukesampson/scoop-extras#5197 and lukesampson/scoop-extras#4598.

Maybe should consider adding `miniconda37` as well:
![image](https://user-images.githubusercontent.com/24728204/100477908-a7478d00-3124-11eb-996f-2d90cb8e671d.png)
