### PR TITLE
Create composer1

### DIFF
--- a/bucket/composer1.json
+++ b/bucket/composer1.json
@@ -36,7 +36,7 @@
     },
     "checkver": {
         "url": "https://github.com/composer/composer/releases",
-        "regex": "tag/(1.[\\d.]+)[^-]"
+        "regex": "tag/(1\\.[\\d.]+)[^-]"
     },
     "autoupdate": {
         "url": "https://getcomposer.org/download/$version/composer.phar",

--- a/bucket/composer1.json
+++ b/bucket/composer1.json
@@ -1,0 +1,47 @@
+{
+    "version": "1.10.19",
+    "description": "Dependency Manager for PHP (version 1)",
+    "homepage": "https://getcomposer.org/",
+    "license": "MIT",
+    "notes": "'composer selfupdate --1' is aliased to 'scoop update composer'",
+    "url": "https://getcomposer.org/download/1.10.19/composer.phar",
+    "hash": "688bf8f868643b420dded326614fcdf969572ac8ad7fbbb92c28a631157d39e8",
+    "pre_install": [
+        "@(",
+        "    'if ($args.length -eq 1 -and ($args -eq \"selfupdate\" -or $args -eq \"self-update\")) { & scoop update composer1 }'",
+        "    'else { & php (Join-Path $psscriptroot \"composer.phar\") @args --1}'",
+        ") | Add-Content -Path \"$dir\\composer.ps1\"",
+        "if (!(Test-Path \"$persist_dir\\home\") -and (Test-Path \"$env:Appdata\\Composer\")) {",
+        "    Write-Host -F yellow \"Moving old 'COMPOSER_HOME' to '$persist_dir\\home'\"",
+        "    Move-Item \"$env:Appdata\\Composer\" \"$persist_dir\\home\" -Force",
+        "}"
+    ],
+    "bin": [
+        "composer.ps1",
+        [
+            "composer.ps1",
+            "composer1"
+        ]
+    ],
+    "env_set": {
+        "COMPOSER_HOME": "$persist_dir\\home"
+    },
+    "env_add_path": "home\\vendor\\bin",
+    "persist": "home",
+    "suggest": {
+        "PHP": [
+            "php",
+            "php-nts"
+        ]
+    },
+    "checkver": {
+        "url": "https://github.com/composer/composer/releases",
+        "regex": "tag/(1.[\\d.]+)[^-]"
+    },
+    "autoupdate": {
+        "url": "https://getcomposer.org/download/$version/composer.phar",
+        "hash": {
+            "url": "$url.sha256sum"
+        }
+    }
+}


### PR DESCRIPTION
following the discussion here https://github.com/ScoopInstaller/Main/commit/71d7c4398527d1aad1aa240c2974ee1275036f8e and related to https://github.com/ScoopInstaller/Main/pull/1690 I created a manifest for the "legacy" version of composer.

I tested it and it works along side the version found in the Main bucket so that you can have both version installed at the same time and switch between one or the other