### PR TITLE
oh-my-posh2: Add version 2.0.496

### DIFF
--- a/bucket/oh-my-posh2.json
+++ b/bucket/oh-my-posh2.json
@@ -1,0 +1,17 @@
+{
+    "version": "2.0.496",
+    "description": "A prompt theming engine for Powershell running in ConEmu",
+    "homepage": "https://github.com/JanDeDobbeleer/oh-my-posh2",
+    "license": "MIT",
+    "notes": [
+        "Deprecated. Use 'main/oh-my-posh3'",
+        "Oh-My-Posh must be manually enabled (add to $Profile to make it permanent):",
+        "Import-Module oh-my-posh"
+    ],
+    "depends": "extras/posh-git",
+    "url": "https://github.com/JanDeDobbeleer/oh-my-posh2/releases/download/2.0.496/oh-my-posh.zip",
+    "hash": "48d20c92cd97f4ac513f632a67b5a24c8362e1f0d0d990d336ac22159abdc7d7",
+    "psmodule": {
+        "name": "oh-my-posh"
+    }
+}


### PR DESCRIPTION
oh-my-posh v2 is archived to https://github.com/JanDeDobbeleer/oh-my-posh2 and scoop extras bucket remove it.
So it should be add to this.