### PR TITLE
Add postgresql12

### DIFF
--- a/bucket/postgresql12.json
+++ b/bucket/postgresql12.json
@@ -1,0 +1,45 @@
+{
+    "version": "12.6",
+    "description": "Object-relational database management system based on POSTGRES.",
+    "homepage": "https://www.postgresql.org",
+    "license": "PostgreSQL",
+    "notes": [
+        "Run run 'pg_ctl start' or 'pg_ctl stop' to start and stop the database or",
+        "register it as a service by running 'pg_ctl register -N PostgreSQL' from an elevated shell.",
+        "Default superuser login: postgres, password: <blank>"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://get.enterprisedb.com/postgresql/postgresql-12.6-1-windows-x64-binaries.zip",
+            "hash": "540cd213dfacc74c553bdf8c5e21882ff58c6572f793e58defb839591c761c0d"
+        }
+    },
+    "extract_dir": "pgsql",
+    "post_install": [
+        "if (!(Test-Path \"$dir\\data\\pg_hba.conf\")) {",
+        "   Invoke-ExternalCommand -FilePath \"$dir\\bin\\initdb.exe\" -ArgumentList \"--username=postgres --encoding=UTF8 --locale=en --lc-collate=C\" | Out-Null",
+        "}"
+    ],
+    "shortcuts": [
+        [
+            "pgAdmin 4\\bin\\pgAdmin4.exe",
+            "pgAdmin 4"
+        ]
+    ],
+    "env_add_path": "bin",
+    "env_set": {
+        "PGDATA": "$dir\\data"
+    },
+    "persist": "data",
+    "checkver": {
+        "url": "https://www.postgresql.org/ftp/source/",
+        "re": "v(12\\.[\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://get.enterprisedb.com/postgresql/postgresql-$version-1-windows-x64-binaries.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm new to scoop and need version 12 for work.

I took the last 12.4 manifest from Main, updated it to 12.6 manually, and adjusted `checkver` to work like `postgresql10`, although I'm not sure how to test that works.