### PR TITLE
wox: Add Wox-beta, i.e. pre-release v1.4.1196

### DIFF
--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "suggest": {
         "Python3": "python",
-        "Everything": "everything"
+        "Everything": "extras/everything"
     },
     "url": "https://github.com/Wox-launcher/Wox/releases/download/v1.4.1196/Wox-1.4.1196-full.nupkg",
     "hash": "sha1:69fcc97e4b7b2702885463793ad617ed2d0c94b6",

--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.4.1196",
+    "description": "A full-featured launcher, access programs and web contents as you type.",
+    "homepage": "http://www.wox.one",
+    "license": "MIT",
+    "suggest": {
+        "Python3": "python",
+        "Everything": "everything"
+    },
+    "url": "https://github.com/Wox-launcher/Wox/releases/download/v1.4.1196/Wox-1.4.1196-full.nupkg",
+    "hash": "sha1:69fcc97e4b7b2702885463793ad617ed2d0c94b6",
+    "extract_dir": "lib\\net462",
+    "bin": "Wox.exe",
+    "shortcuts": [
+        [
+            "Wox.exe",
+            "Wox"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Wox-launcher/Wox"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/Wox-$version-full.nupkg",
+        "hash": {
+            "url": "$baseurl/RELEASES"
+        }
+    }
+}


### PR DESCRIPTION
The `extras` bucket already has the latest release Wox v1.3.524, however it was [released](https://github.com/Wox-launcher/Wox/releases/tag/v1.3.524) more than 3 years ago. The latest [pre-release v1.4.1196](https://github.com/Wox-launcher/Wox/releases/tag/v1.4.1196) is about a year old, it includes nice improvement in search speeds, many customizations in UI since the latest release, but also for me it fixed a critical bug on Windows 10 that made app unusable after computer is being put into Sleep mode.

I suggest to add this version as a beta, since `autoupdate` ignores pre-releases, but the Wox's maintainers neither update the latest release nor add more pre-releases

I used the original [`wox.json`](https://github.com/lukesampson/scoop-extras/blob/b3c4b46dda148ef40a29e83723925659b19a57a6/bucket/wox.json), only changed `version`, `url` of archive, `hash`, and `extract_dir` from `"lib\\net45"` to `"lib\\net462"`.