### PR TITLE
tomcat7: Change tomcat7 download url (#290)

### DIFF
--- a/bucket/tomcat7.json
+++ b/bucket/tomcat7.json
@@ -3,11 +3,11 @@
     "version": "7.0.109",
     "architecture": {
         "64bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-7/v7.0.109/bin/apache-tomcat-7.0.109-windows-x64.zip",
+            "url": "https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.109/bin/apache-tomcat-7.0.109-windows-x64.zip",
             "hash": "sha512:444b384fd6eff3210842e74b1470e31674dd43723903ebf65a037c9bcd2d6d0bc94d5fad97e840dea892b991ff37b12a35342593bbddc92f0aa36c9b1bbd2025"
         },
         "32bit": {
-            "url": "https://www.apache.org/dist/tomcat/tomcat-7/v7.0.109/bin/apache-tomcat-7.0.109-windows-x86.zip",
+            "url": "https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.109/bin/apache-tomcat-7.0.109-windows-x86.zip",
             "hash": "sha512:e3ad4fb5c736092f4783a1285b8589eb610c21077883445a0e769b110a1f4e6da653ba671c3d55f25e4033beff683b4858dfa9f1e319819ebe6f0cb6aef2395a"
         }
     },
@@ -21,16 +21,16 @@
         "JRE": "java/openjdk"
     },
     "checkver": {
-        "url": "https://www.apache.org/dist/tomcat/tomcat-7/?C=M;O=D",
+        "url": "https://archive.apache.org/dist/tomcat/tomcat-7/?C=M;O=D",
         "re": "v(?<version>[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x64.zip"
+                "url": "https://archive.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x64.zip"
             },
             "32bit": {
-                "url": "https://www.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x86.zip"
+                "url": "https://archive.apache.org/dist/tomcat/tomcat-7/v$version/bin/apache-tomcat-$version-windows-x86.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
Tomcat 7 is removed from www.apache.org to change the URL. 

Resolved #290 