### PR TITLE
7zip-beta: Update to 21.03

### DIFF
--- a/bucket/7zip-beta.json
+++ b/bucket/7zip-beta.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://www.7-zip.org/",
     "description": "Multi-format compression/decompression tool (beta version)",
-    "license": "LGPL-2.1-or-later",
-    "version": "18.03",
+    "license": "https://www.7-zip.org/license.txt|LGPL-2.1-or-later|BSD-3-Clause",
+    "version": "21.03",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/18.03/7z1803-x64.msi",
-            "hash": "sha1:c2960c99f685f2f80475e5fce1e4c39ddd34fae3"
+            "url": "https://www.7-zip.org/a/7z2103-x64.exe",
+            "hash": "sha256:69b755f462d7d9018f4d8f004ffe7ca0fc64ef663246050dfbc864df039084b5"
         },
         "32bit": {
-            "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/18.03/7z1803.msi",
-            "hash": "sha1:21ce157040d1cd54f2ad005dc6be7eabc2fdd88d"
-        }
+            "url": "https://www.7-zip.org/a/7z2103.exe",
+            "hash": "sha256:447916156f9f8a4d0bf9371745250ec4a59c6172993e428141bd2f28d68a0fb9"
+        },
     },
     "extract_dir": "Files/7-Zip",
     "bin": [

--- a/bucket/7zip-beta.json
+++ b/bucket/7zip-beta.json
@@ -1,17 +1,17 @@
 {
     "homepage": "https://www.7-zip.org/",
     "description": "Multi-format compression/decompression tool (beta version)",
-    "license": "https://www.7-zip.org/license.txt|LGPL-2.1-or-later|BSD-3-Clause",
+    "license": "LGPL-2.1-or-later,BSD-3-Clause",
     "version": "21.03",
     "architecture": {
         "64bit": {
-            "url": "https://www.7-zip.org/a/7z2103-x64.exe",
-            "hash": "sha256:69b755f462d7d9018f4d8f004ffe7ca0fc64ef663246050dfbc864df039084b5"
+            "url": "https://www.7-zip.org/a/7z2103-x64.msi",
+            "hash": "371edca2936196fe7e80c009b2ab45920abbaee3f7e1fe1c8a3d2470b337e424"
         },
         "32bit": {
-            "url": "https://www.7-zip.org/a/7z2103.exe",
-            "hash": "sha256:447916156f9f8a4d0bf9371745250ec4a59c6172993e428141bd2f28d68a0fb9"
-        },
+            "url": "https://www.7-zip.org/a/7z2103.msi",
+            "hash": "e7ebcc3adf86e79327383ed0d7d5eea850bc0a97c6eaaa2d5fab2407b9da7247"
+        }
     },
     "extract_dir": "Files/7-Zip",
     "bin": [
@@ -25,10 +25,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/$version/7z$cleanVersion-x64.msi"
+                "url": "https://www.7-zip.org/a/7z$cleanVersion-x64.msi"
             },
             "32bit": {
-                "url": "https://downloads.sourceforge.net/project/sevenzip/7-Zip/$version/7z$cleanVersion.msi"
+                "url": "https://www.7-zip.org/a/7z$cleanVersion.msi"
             }
         }
     },


### PR DESCRIPTION
#### Changes
- Changed URLs from MSI to EXE for a slightly smaller file size. 
  The unzipped contents appear to be identical.
- License(s) updated. Previously lacked the BSD 3-Clause (due to code derived from Apple's "LZFSE compression library") and UnRAR licenses.

#### Questions
- Are MSIs preferred when the assembly is unsigned?
- I find it a little strange the auto-updater didn't catch the latest beta release. That may need to be investigated.

#### Notes
- URLs pulled from https://7-Zip.org/Download.html and https://sourceforge.net/p/sevenzip/discussion/45797/thread/9f5b067368/
- I was also going to add the URL and SHA256 for the ARM64 release, but Scoop's ARM64 specs haven't been finalized just yet.