### PR TITLE
putty-cac: Add version 0.76u1

### DIFF
--- a/bucket/putty-cac.json
+++ b/bucket/putty-cac.json
@@ -1,0 +1,69 @@
+{
+    "version": "0.76u1",
+    "description": "PuTTY CAC is a fork of the PuTTY, a popular Secure Shell (SSH) terminal. PuTTY CAC adds the ability to use the Windows Certificate API (CAPI) or a Public Key Cryptography Standards (PKCS) library to perform SSH public key authentication using a private key associated with a certificate that is stored on a hardware token.",
+    "homepage": "https://github.com/NoMoreFood/putty-cac",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.76u1/binaries/puttycac-64bit-0.76u1.zip",
+            "hash": "4d4d514e776fe7f413b673b4aadead4a038182b745b1b6a1a86d9eab3de445c2"
+        },
+        "32bit": {
+            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.76u1/binaries/puttycac-0.76u1.zip",
+            "hash": "1ddece989f5d552d4594a0c0733b42f5b42a5f149aae6708d8d8d574ede1dce4"
+        }
+    },
+    "bin": [
+        "putty.exe",
+        "puttygen.exe",
+        "pscp.exe",
+        "pageant.exe",
+        "psftp.exe",
+        "plink.exe",
+        "puttytel.exe"
+    ],
+    "shortcuts": [
+        [
+            "putty.exe",
+            "PuTTY"
+        ],
+        [
+            "pageant.exe",
+            "Pageant"
+        ],
+        [
+            "psftp.exe",
+            "PSFTP"
+        ],
+        [
+            "puttygen.exe",
+            "PuTTYgen"
+        ],
+        [
+            "puttytel.exe",
+            "PuTTYtel"
+        ]
+    ],
+    "checkver": {
+        "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/master/binaries/puttycac-hash.txt",
+        "regex": "(?:puttycac-)([u\\d.]+)(?:\\.zip)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-64bit-$version.zip",
+                "hash": {
+                    "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-hash.txt",
+                    "regex": "(?:SHA256\\s+)$sha256(?:\\s+$basename)"
+                }
+            },
+            "32bit": {
+                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-$version.zip",
+                "hash": {
+                    "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-hash.txt",
+                    "regex": "(?:SHA256\\s+)$sha256(?:\\s+$basename)"
+                }
+            }
+        }
+    }
+}

--- a/bucket/putty-cac.json
+++ b/bucket/putty-cac.json
@@ -45,25 +45,21 @@
         ]
     ],
     "checkver": {
-        "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/master/binaries/puttycac-hash.txt",
-        "regex": "(?:puttycac-)([u\\d.]+)(?:\\.zip)"
+        "github": "https://github.com/NoMoreFood/putty-cac",
+        "regex": "tree/([\\w.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-64bit-$version.zip",
-                "hash": {
-                    "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-hash.txt",
-                    "regex": "(?:SHA256\\s+)$sha256(?:\\s+$basename)"
-                }
+                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-64bit-$version.zip"
             },
             "32bit": {
-                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-$version.zip",
-                "hash": {
-                    "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-hash.txt",
-                    "regex": "(?:SHA256\\s+)$sha256(?:\\s+$basename)"
-                }
+                "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/$version/binaries/puttycac-$version.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/puttycac-hash.txt",
+            "regex": "$sha256.*?$basename"
         }
     }
 }


### PR DESCRIPTION
Add PuTTY CAC (with CAPI and PKCS support).