### PR TITLE
dotnet-sdk-preview: Add the possibility to get RC versions as well

### DIFF
--- a/bucket/dotnet-sdk-preview.json
+++ b/bucket/dotnet-sdk-preview.json
@@ -1,39 +1,36 @@
 {
-    "version": "6.0.100-rc.2.21505.57",
-    "homepage": "https://www.microsoft.com/net/",
-    "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
-    "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x64.zip",
-            "hash": "eb0f1cc60c6a44060acd06a66fc6605046e817483b1322cf85b081db71ffbff8"
-        },
-        "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x86.zip",
-            "hash": "927cf0b561ab001fd60c06afc089e559c87fe327453db2b65a939f66632d2a1c"
-        }
+  "version": "6.0.100-rc.2.21505.57",
+  "homepage": "https://www.microsoft.com/net/",
+  "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x64.zip",
+      "hash": "eb0f1cc60c6a44060acd06a66fc6605046e817483b1322cf85b081db71ffbff8"
     },
-    "bin": "dotnet.exe",
-    "env_add_path": ".",
-    "env_set": {
-        "DOTNET_ROOT": "$dir",
-        "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
-    },
-    "checkver": {
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
-        "jsonpath": "$..releases-index[?(@.support-phase == 'preview' || @.support-phase == 'rc')].latest-sdk"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x64.zip"
-            },
-            "32bit": {
-                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x86.zip"
-            }
-        },
-        "hash": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$version-sdk-sha.txt"
-        }
+    "32bit": {
+      "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x86.zip",
+      "hash": "927cf0b561ab001fd60c06afc089e559c87fe327453db2b65a939f66632d2a1c"
     }
+  },
+  "bin": "dotnet.exe",
+  "env_add_path": ".",
+  "env_set": {
+    "DOTNET_ROOT": "$dir",
+    "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
+  },
+  "checkver": {
+    "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
+    "jsonpath": "$..releases-index[?(@.support-phase == 'preview' || @.support-phase == 'rc')].latest-sdk"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x64.zip"
+      },
+      "32bit": {
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x86.zip"
+      }
+    }
+  }
 }

--- a/bucket/dotnet-sdk-preview.json
+++ b/bucket/dotnet-sdk-preview.json
@@ -1,16 +1,16 @@
 {
-    "version": "6.0.100-preview.7.21379.14",
+    "version": "6.0.100-rc.2.21505.57",
     "homepage": "https://www.microsoft.com/net/",
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-preview.7.21379.14/dotnet-sdk-6.0.100-preview.7.21379.14-win-x64.zip",
-            "hash": "574f5df9444234d68db1641dcb30447fbacae060d9f4237b06b24f0a378d9b9d"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x64.zip",
+            "hash": "eb0f1cc60c6a44060acd06a66fc6605046e817483b1322cf85b081db71ffbff8"
         },
         "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-preview.7.21379.14/dotnet-sdk-6.0.100-preview.7.21379.14-win-x86.zip",
-            "hash": "c4cc3acf153252517b9bbcdf7c4407dca494188dc43b86b1103c20f652745b35"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.100-rc.2.21505.57/dotnet-sdk-6.0.100-rc.2.21505.57-win-x86.zip",
+            "hash": "927cf0b561ab001fd60c06afc089e559c87fe327453db2b65a939f66632d2a1c"
         }
     },
     "bin": "dotnet.exe",
@@ -21,7 +21,7 @@
     },
     "checkver": {
         "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
-        "jsonpath": "$..releases-index[?(@.support-phase == 'preview')].latest-sdk"
+        "jsonpath": "$..releases-index[?(@.support-phase == 'preview' || @.support-phase == 'rc')].latest-sdk"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Release candidate is a kind of preview as well, and it was not on the checkver jsonpath