### PR TITLE
gcc: Add some alternative versions

### DIFF
--- a/bucket/gcc-llvm-ucrt.json
+++ b/bucket/gcc-llvm-ucrt.json
@@ -1,6 +1,6 @@
 {
     "version": "11.2.0-13.0.0-9.0.0-r2",
-    "description": "GNU Compiler Collection w/ LLVM/Clang/LLD/LLDB (UCRT, WinLibs build)",
+    "description": "GNU Compiler Collection with LLVM/Clang/LLD/LLDB (UCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {

--- a/bucket/gcc-llvm-ucrt.json
+++ b/bucket/gcc-llvm-ucrt.json
@@ -1,0 +1,37 @@
+{
+    "version": "11.2.0-13.0.0-9.0.0-r2",
+    "description": "GNU Compiler Collection w/ LLVM/Clang/LLD/LLDB (UCRT, WinLibs build)",
+    "homepage": "https://winlibs.com",
+    "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-11.2.0-llvm-13.0.0-mingw-w64ucrt-9.0.0-r2.7z",
+            "hash": "sha512:868b3380bc6821f797ed082ea4d4259b89d0e841f9f5e001f43ed02efd5954375e36b6b00293282c34d6e9b84e4ac877e55bfbd5e5b89ce69eeaa4f05252dff3",
+            "extract_dir": "mingw64"
+        },
+        "32bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-11.2.0-llvm-13.0.0-mingw-w64ucrt-9.0.0-r2.7z",
+            "hash": "sha512:b4e4df25205e393ff8d07624a3f8f7b4c56b53adb39702071fc3b8799c9a840c9b186959c63066dbc201ce5500e07e696c2c197032973d74aad1cc3ef76c20cb",
+            "extract_dir": "mingw32"
+        }
+    },
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "regex": "GCC ([\\d.]+).*?LLVM.*?([\\d.]+).*?MinGW\\-w64 ([\\d.]+).*?UCRT.*?release ([\\d.]+).*?LATEST",
+        "replace": "${1}-${2}-${3}-r${4}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-ucrt-r$match4/winlibs-x86_64-posix-seh-gcc-$match1-llvm-$match2-mingw-w64ucrt-$match3-r$match4.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-ucrt-r$match4/winlibs-i686-posix-dwarf-gcc-$match1-llvm-$match2-mingw-w64ucrt-$match3-r$match4.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512"
+        }
+    }
+}

--- a/bucket/gcc-llvm.json
+++ b/bucket/gcc-llvm.json
@@ -1,0 +1,37 @@
+{
+    "version": "11.2.0-13.0.0-9.0.0-r3",
+    "description": "GNU Compiler Collection w/ LLVM/Clang/LLD/LLDB (WinLibs build)",
+    "homepage": "https://winlibs.com",
+    "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-msvcrt-r3/winlibs-x86_64-posix-seh-gcc-11.2.0-llvm-13.0.0-mingw-w64-9.0.0-r3.7z",
+            "hash": "sha512:2e55f8a76b034b28235150851749f2e5b0a5e6752b4d769a7f6271f8e3595a9db7b48b3bf99b2ccf3a2ab1e38e2102920f5ba714dd12c5316d5b116aa9e6ca8a",
+            "extract_dir": "mingw64"
+        },
+        "32bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-msvcrt-r3/winlibs-i686-posix-dwarf-gcc-11.2.0-llvm-13.0.0-mingw-w64-9.0.0-r3.7z",
+            "hash": "sha512:d78b2b4cf9568c344f522c6e20a464e9de903fda69f697e3329be41d1abf7c4869a0bbb71a6e42f2eaf17360545d101065acd432c09efccf33750be6177c4432",
+            "extract_dir": "mingw32"
+        }
+    },
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "regex": "GCC ([\\d.]+).*?LLVM.*?([\\d.]+).*?MinGW\\-w64 ([\\d.]+).*?MSVCRT.*?release ([\\d.]+).*?LATEST",
+        "replace": "${1}-${2}-${3}-r${4}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-x86_64-posix-seh-gcc-$match1-llvm-$match2-mingw-w64-$match3-r$match4.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-msvcrt-r$match4/winlibs-i686-posix-dwarf-gcc-$match1-llvm-$match2-mingw-w64-$match3-r$match4.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512"
+        }
+    }
+}

--- a/bucket/gcc-llvm.json
+++ b/bucket/gcc-llvm.json
@@ -1,6 +1,6 @@
 {
     "version": "11.2.0-13.0.0-9.0.0-r3",
-    "description": "GNU Compiler Collection w/ LLVM/Clang/LLD/LLDB (WinLibs build)",
+    "description": "GNU Compiler Collection with LLVM/Clang/LLD/LLDB (WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {

--- a/bucket/gcc-msys.json
+++ b/bucket/gcc-msys.json
@@ -1,0 +1,82 @@
+{
+    "version": "11.2.0-2",
+    "description": "GNU Compiler Collection (Mingw-w64 port from MSYS2 project)",
+    "homepage": "http://mingw-w64.org/doku.php",
+    "license": "GPL-3.0-or-later,ZPL-2.1,...",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-binutils-2.37-4-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-crt-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-11.2.0-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-11.2.0-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-gmp-6.2.1-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-headers-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-isl-0.24-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libiconv-1.16-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-libwinpthread-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpc-1.2.1-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-mpfr-4.1.0.p13-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-windows-default-manifest-6.4-3-any.pkg.tar.xz",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-winpthreads-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zlib-1.2.11-9-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-zstd-1.5.0-1-any.pkg.tar.zst"
+            ],
+            "hash": [
+                "a518d2630c11fe363abd394763d0bb82fdde72386ffb58d87ecc8f46cbe878d6",
+                "2a4c2cf3f052e63e215104a7b6010b5942c0bd4fc0f39a01040259e2662a3c21",
+                "b6b0cbd658900b8a6ee63f4b6ed9af96104b36eea9226b573e279aeb18f9a41d",
+                "ede3e245b89753989fc33b5fc2d7e9707ca60ba11febc171c6806a5295007d30",
+                "9e6b49368fe45a811c4c83876e9d5fd48104c265b816c59515f40e1db3824e01",
+                "32451601d0e251fbe48ace7931679cfb5585e69b6503d1c9c060855f03f01e19",
+                "cda411304a921ece14a6a17fd69196ee28dc104234a7c7774d71701faeb9cf36",
+                "44d1f338012a8f503eb31ad8941129df09d3d6307f688f30d612eef3b17a285b",
+                "b93ff2dca398150d0b86f9b56c087befd2d655570608293c335e14d23462178a",
+                "8c69669df65257ec8abbb38fb4110371da8f73c60f065ecd162811f59489c11c",
+                "26e320bb309eb0b107eccdc026716e00404cdf07224d95353cadb57a8263749e",
+                "6c0ea4adcef503dc8174e9d4d70a10aee8295d620db4494f78fa512df0589dcf",
+                "18a356dbffcc57b2302748cbfa0d1932d626ce891885107f697108d37c7095e5",
+                "9da9ebafaef832dba2f442ad44d9ae8759784b86478dcbe326500195f8ea6339",
+                "7fa44523a0e4a168a11941680e2207df2cbc01ccf72bde0f562579a434f6ba3f"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-binutils-2.37-4-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-crt-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-11.2.0-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gcc-libs-11.2.0-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-gmp-6.2.1-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-headers-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-isl-0.24-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libiconv-1.16-2-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-libwinpthread-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-mpc-1.2.1-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-mpfr-4.1.0.p13-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-windows-default-manifest-6.4-3-any.pkg.tar.xz",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-winpthreads-git-9.0.0.6346.6cc97775a-1-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zlib-1.2.11-9-any.pkg.tar.zst",
+                "https://mirror.msys2.org/mingw/mingw32/mingw-w64-i686-zstd-1.5.0-1-any.pkg.tar.zst"
+            ],
+            "hash": [
+                "20b2e5beefb831c665ac5b1be4feb447e0f4e543e15c0fd5855dc0c258a29a02",
+                "d724a2769c95f5e4c6454c4332471424796aae608f4dfbcc3519c42e6901196a",
+                "92b8228a6c1ac4e5644036ef0b468043ead8ea0e6cc0d43a0248f94eefc1eb75",
+                "abf025044a83cc50cf1db2ded5d659a2e46b726f2a91124f88f316fc156e7097",
+                "13b10f89279786a1af9b010dfbe02ac495ef8739dce1a3ab382733054e10fbfe",
+                "7cb3335063a3da792e1a902099e1f980c1bacd1a81298b187406e7ae821a7608",
+                "74f7d90caf43bb72d173e9f62b8bf4ac46221016fe6f724c3ad602feca05d0ae",
+                "c41d820099d5b4e34f1099cae5092113d0ca44a17bd78d03da873100a25c8aad",
+                "f78a04c32afd0d0745bad7f1277fdbc1113b0be7b0ad6bba34191808d48c1711",
+                "fb6252f23762b93cb302b7db029ba61f36d1798a886a8d96819f996842dfa331",
+                "6359058b1d0adefe866b9ecbfdaeee4b5e8cde5bf4653c5108a4517495320834",
+                "56323bc39c7de0ff727915c09c4aaa25b8396efc0d7eda0006d5951bb6a6b983",
+                "ebce71b31c42b447eb0f98ed80c6bffc2bdf3d4a59e40f0d9b7e6c393c0c9032",
+                "8d594fc14497d41a66415bfdd200d7d1d56a6ecd3fe81b9190bec0c4841a5eff",
+                "416e78a8e66b71d1e8aa76f90d1702b44c7fe49d4026eac789660ece4ca58504"
+            ]
+        }
+    },
+    "pre_install": "movedir \"$dir\\$(if ($arch = '64bit') {'mingw64'} else {'mingw32'})\" \"$dir\" | Out-Null",
+    "env_add_path": "bin"
+}

--- a/bucket/gcc-ucrt.json
+++ b/bucket/gcc-ucrt.json
@@ -1,0 +1,37 @@
+{
+    "version": "11.2.0-9.0.0-r2",
+    "description": "GNU Compiler Collection (UCRT, WinLibs build)",
+    "homepage": "https://winlibs.com",
+    "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-11.2.0-mingw-w64ucrt-9.0.0-r2.7z",
+            "hash": "sha512:c0b8039aa6221a22bdd6fe8fa3afd1de08c190c1a7e5af4ab9346d23c50e500930cb46696739e71cb0fe23d2fb39e7853fb9ff9fdb57d5efec4f22279c49c505",
+            "extract_dir": "mingw64"
+        },
+        "32bit": {
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/11.2.0-13.0.0-9.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-11.2.0-mingw-w64ucrt-9.0.0-r2.7z",
+            "hash": "sha512:d7a2c1f19010ec5186a8454cb946099b763763d88c07d088fc1883552cb606c60fdda15bb5df474e510251257e6215a5777d826bb364ae9c176e4a014924bf2f",
+            "extract_dir": "mingw32"
+        }
+    },
+    "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
+    "env_add_path": "bin",
+    "checkver": {
+        "regex": "GCC ([\\d.]+).*?LLVM.*?([\\d.]+).*?MinGW\\-w64 ([\\d.]+).*?UCRT.*?release ([\\d.]+).*?LATEST",
+        "replace": "${1}-${3}-r${4}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-ucrt-r$match4/winlibs-x86_64-posix-seh-gcc-$match1-mingw-w64ucrt-$match3-r$match4.7z"
+            },
+            "32bit": {
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$match1-$match2-$match3-ucrt-r$match4/winlibs-i686-posix-dwarf-gcc-$match1-mingw-w64ucrt-$match3-r$match4.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha512"
+        }
+    }
+}


### PR DESCRIPTION
- gcc-msys: Original gcc from `Main`
- gcc-llvm: WinLibs build w/ LLVM/Clang/LLD/LLDB
- gcc-ucrt: WInLibs build w/ UCRT runtime
- gcc-llvm-ucrt: WinLibs build w/ LLVM/Clang/LLD/LLDB & UCRT runtime