### PR TITLE
beef-nightly: Add version 0.43.1.11182021

### DIFF
--- a/bucket/beef-nightly.json
+++ b/bucket/beef-nightly.json
@@ -1,0 +1,34 @@
+{
+    "homepage": "https://www.beeflang.org/",
+    "description": "Beef programming language compiler. (nightly version)",
+    "version": "0.43.1.11182021",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "http://nightly.beeflang.org/BeefSetup_0_43_1__11_18_2021.exe#/dl.7z",
+            "hash": "1e9743891fd8f1a6813067cd73d7e4364d74f58219d9ecfd33da3b082d6d3929"
+        }
+    },
+    "bin": [
+        [
+            "bin\\BeefIDE.exe",
+            "beefn"
+        ],
+        [
+            "bin\\BeefBuild.exe",
+            "BeefBuildN"
+        ]
+    ],
+    "checkver": {
+        "url": "http://nightly.beeflang.org/index.html",
+        "re": "(?s)BeefSetup_(\\d+)_(\\d+)_(\\d+)__(\\d{2})_(\\d{2})_(\\d{4})",
+        "replace": "${1}.${2}.${3}.${4}${5}${6}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://nightly.beeflang.org/BeefSetup_$match1_$match2_$match3__$match4_$match5_$match6.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supersedes #227.

This adds the nightly version of *beef* compiler.