### PR TITLE
Add Android Studio Beta & Canary

### DIFF
--- a/bucket/android-studio-beta.json
+++ b/bucket/android-studio-beta.json
@@ -1,0 +1,38 @@
+{
+    "version": "2021.1.1.17",
+    "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
+    "homepage": "https://developer.android.com/studio/preview",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://developer.android.com/studio/terms.html"
+    },
+    "suggest": {
+        "SDK": [
+            "android-clt",
+            "android-sdk"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.1.1.17/android-studio-2021.1.1.17-windows.zip",
+            "hash": "6e872d5f7510f53c10343d40f29db9795de23f8868a2b5adf1966dd10ec23a74",
+            "shortcuts": [
+                [
+                    "bin\\studio64.exe",
+                    "Android Studio Beta"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "android-studio",
+    "checkver": {
+        "regex": "Android Studio [\\d.]+ Beta \\d+\\s+for\\s+Windows\\s+<\\/a>\\s+<p><em>android-studio-([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip"
+            }
+        }
+    }
+}

--- a/bucket/android-studio-canary.json
+++ b/bucket/android-studio-canary.json
@@ -19,7 +19,7 @@
             "shortcuts": [
                 [
                     "bin\\studio64.exe",
-                    "Android Studio"
+                    "Android Studio Canary"
                 ]
             ]
         }

--- a/bucket/android-studio-canary.json
+++ b/bucket/android-studio-canary.json
@@ -1,0 +1,39 @@
+{
+    "version": "2021.2.1.5",
+    "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
+    "homepage": "https://developer.android.com/studio/preview",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://developer.android.com/studio/terms.html"
+    },
+    "suggest": {
+        "SDK": [
+            "android-clt",
+            "android-sdk"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2021.2.1.5/android-studio-2021.2.1.5-windows.zip",
+            "hash": "ba70215d46fc6fa5711b94e707ccf1e9c75d5442bf740c9d13dfb8f973b3db90",
+            "shortcuts": [
+                [
+                    "bin\\studio64.exe",
+                    "Android Studio"
+                ]
+            ]
+        }
+    },
+    "extract_dir": "android-studio",
+    "checkver": {
+        "regex": "Android Studio ([\\d.]+) Canary (\\d+)",
+        "replace": "${1}.${2}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #274

Largely based on Android Studio stable in Extras https://github.com/ScoopInstaller/Extras/blob/master/bucket/android-studio.json

Adding both Beta and Canary in one go because their manifests are so similar.