### PR TITLE
autohotkey1(-installer): Add version 1.1.33.10

### DIFF
--- a/bucket/autohotkey1-installer.json
+++ b/bucket/autohotkey1-installer.json
@@ -1,0 +1,56 @@
+{
+    "version": "1.1.33.10",
+    "description": "The ultimate automation scripting language for Windows. (version 1)",
+    "homepage": "https://www.autohotkey.com/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.33.10/AutoHotkey_1.1.33.10_setup.exe#/autohotkey-installer.exe",
+    "hash": "3f3b4324e8fe78131951abcda7f31173d4954179a4fc1a7559476ac04b45d759",
+    "architecture": {
+        "64bit": {
+            "hash": "3f3b4324e8fe78131951abcda7f31173d4954179a4fc1a7559476ac04b45d759",
+            "installer": {
+                "args": [
+                    "/S",
+                    "/x64",
+                    "/uiAccess=0",
+                    "/IsHostApp=1",
+                    "/D=\"$dir\""
+                ],
+                "keep": true
+            },
+            "bin": [
+                "autohotkeyu64.exe",
+                [
+                    "autohotkeyu64.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ]
+        },
+        "32bit": {
+            "installer": {
+                "args": [
+                    "/S",
+                    "/U32",
+                    "/uiAccess=0",
+                    "/IsHostApp=1",
+                    "/D=\"$dir\""
+                ],
+                "keep": true
+            },
+            "bin": [
+                "autohotkeyu32.exe",
+                [
+                    "autohotkeyu32.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ]
+        }
+    },
+    "pre_install": " Write-Host 'Installing AutoHotKey with their installer and its own options ( create registry keys removed by uninstaller )' -ForegroundColor Magenta ",
+    "uninstaller": {
+        "file": "autohotkey-installer.exe",
+        "args": "/Uninstall"
+    }
+}

--- a/bucket/autohotkey1.json
+++ b/bucket/autohotkey1.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.1.33.10",
+    "description": "The ultimate automation scripting language for Windows. (version 1)",
+    "homepage": "https://www.autohotkey.com/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://github.com/Lexikos/AutoHotkey_L/releases/download/v1.1.33.10/AutoHotkey_1.1.33.10_setup.exe#/dl.7z",
+    "hash": "3f3b4324e8fe78131951abcda7f31173d4954179a4fc1a7559476ac04b45d759",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                "autohotkeyu64.exe",
+                [
+                    "autohotkeyu64.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ]
+        },
+        "32bit": {
+            "bin": [
+                "autohotkeyu32.exe",
+                [
+                    "autohotkeyu32.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Related: https://github.com/ScoopInstaller/Extras/pull/7448

[autohotkey.com](https://www.autohotkey.com/) says version 1.0 is deprecated. Therefore we are add **v2** to the *extras* bucket, and move **v1** here.