### PR TITLE
openssl-light: fix license

### DIFF
--- a/bucket/openssl-light.json
+++ b/bucket/openssl-light.json
@@ -1,10 +1,7 @@
 {
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
     "version": "3.0.0",
-    "license": {
-        "identifier": "OpenSSL|SSLeay",
-        "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
-    },
+    "license": "Apache-2.0",
     "description": "TLS/SSL toolkit (Light)",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
As of v3.0.0 OpenSSL is published under Apache License 2.0