### PR TITLE
Cleanup LÖVE manifests

### DIFF
--- a/bucket/love10.json
+++ b/bucket/love10.json
@@ -1,15 +1,16 @@
 {
     "homepage": "https://love2d.org/",
+    "description": "LÖVE is an open-source 2D game framework for Lua.",
     "version": "0.10.2",
     "license": "Zlib",
     "architecture": {
         "64bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.10.2-win64.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.10.2/love-0.10.2-win64.zip",
             "hash": "a9603b1e1fb353bc0d5608629ea4c0d2e94df3598f3cc4c2e9e84723e6a5a2b9",
             "extract_dir": "love-0.10.2-win64"
         },
         "32bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.10.2-win32.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.10.2/love-0.10.2-win32.zip",
             "hash": "31132c176cd03e3eb2952c4b837e1049e907b8542deaa297d8efcd31cfa6a46a",
             "extract_dir": "love-0.10.2-win32"
         }
@@ -24,23 +25,7 @@
     "shortcuts": [
         [
             "love.exe",
-            "LOVE 0.10"
+            "LÖVE 0.10"
         ]
-    ],
-    "checkver": {
-        "url": "https://bitbucket.org/rude/love/downloads/",
-        "regex": "love-(0.10[0-9.]+)-w"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win64.zip",
-                "extract_dir": "love-$version-win64"
-            },
-            "32bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win32.zip",
-                "extract_dir": "love-$version-win32"
-            }
-        }
-    }
+    ]
 }

--- a/bucket/love6.json
+++ b/bucket/love6.json
@@ -1,8 +1,9 @@
 {
     "homepage": "https://love2d.org/",
+    "description": "LÖVE is an open-source 2D game framework for Lua.",
     "version": "0.6.2",
     "license": "Zlib",
-    "url": "https://bitbucket.org/rude/love/downloads/love-0.6.2-win-x86.zip",
+    "url": "https://github.com/love2d/love/releases/download/0.6.2/love-0.6.2-win-x86.zip",
     "hash": "f8725981e5d3437255fb4e4eb0fa308b3097d7689bd4abb699ce3dfba59bed4a",
     "extract_dir": "love",
     "bin": [
@@ -15,14 +16,7 @@
     "shortcuts": [
         [
             "love.exe",
-            "LOVE 0.6"
+            "LÖVE 0.6"
         ]
-    ],
-    "checkver": {
-        "url": "https://bitbucket.org/rude/love/downloads/",
-        "regex": "love-(0.6[0-9.]+)-w"
-    },
-    "autoupdate": {
-        "url": "https://bitbucket.org/rude/love/downloads/love-$version-win-x86.zip"
-    }
+    ]
 }

--- a/bucket/love7.json
+++ b/bucket/love7.json
@@ -1,8 +1,9 @@
 {
     "homepage": "https://love2d.org/",
+    "description": "LÖVE is an open-source 2D game framework for Lua.",
     "version": "0.7.2",
     "license": "Zlib",
-    "url": "https://bitbucket.org/rude/love/downloads/love-0.7.2-win-x86.zip",
+    "url": "https://github.com/love2d/love/releases/download/0.7.2/love-0.7.2-win-x86.zip",
     "hash": "2a12fefb0b68823cf039f1532ac51e0f1aee799bd94e8ad81c124d3698029964",
     "extract_dir": "love-0.7.2-win-x86",
     "bin": [
@@ -15,15 +16,7 @@
     "shortcuts": [
         [
             "love.exe",
-            "LOVE 0.7"
+            "LÖVE 0.7"
         ]
-    ],
-    "checkver": {
-        "url": "https://bitbucket.org/rude/love/downloads/",
-        "regex": "love-(0.7[0-9.]+)-w"
-    },
-    "autoupdate": {
-        "url": "https://bitbucket.org/rude/love/downloads/love-$version-win-x86.zip",
-        "extract_dir": "love-$version-win-x86"
-    }
+    ]
 }

--- a/bucket/love8.json
+++ b/bucket/love8.json
@@ -1,15 +1,16 @@
 {
     "homepage": "https://love2d.org/",
+    "description": "LÖVE is an open-source 2D game framework for Lua.",
     "version": "0.8.0",
     "license": "Zlib",
     "architecture": {
         "64bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.8.0-win-x64.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.8.0/love-0.8.0-win-x64.zip",
             "hash": "8042e7b62e6da5cdc000641eaac144d378845fb78bfce7e880e86f7c2925f385",
             "extract_dir": "love-0.8.0-win-x64"
         },
         "32bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.8.0-win-x86.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.8.0/love-0.8.0-win-x86.zip",
             "hash": "cc9dbd6f174b55f17a404a5c3d331e1bf82748f0ea5a14edca4bcde862eb9ff1",
             "extract_dir": "love-0.8.0-win-x86"
         }
@@ -24,23 +25,7 @@
     "shortcuts": [
         [
             "love.exe",
-            "LOVE 0.8"
+            "LÖVE 0.8"
         ]
-    ],
-    "checkver": {
-        "url": "https://bitbucket.org/rude/love/downloads/",
-        "regex": "love-(0.8[0-9.]+)-w"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win-x64.zip",
-                "extract_dir": "love-$version-win-x64"
-            },
-            "32bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win-x86.zip",
-                "extract_dir": "love-$version-win-x86"
-            }
-        }
-    }
+    ]
 }

--- a/bucket/love9.json
+++ b/bucket/love9.json
@@ -1,15 +1,16 @@
 {
     "homepage": "https://love2d.org/",
+    "description": "LÖVE is an open-source 2D game framework for Lua.",
     "version": "0.9.2",
     "license": "Zlib",
     "architecture": {
         "64bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.9.2-win64.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.9.2/love-0.9.2-win64.zip",
             "hash": "51e73d8ab2f76b5c8ba4454d4af6a4934efe9437cea0a7cd7cebf5831c787a1c",
             "extract_dir": "love-0.9.2-win64"
         },
         "32bit": {
-            "url": "https://bitbucket.org/rude/love/downloads/love-0.9.2-win32.zip",
+            "url": "https://github.com/love2d/love/releases/download/0.9.2/love-0.9.2-win32.zip",
             "hash": "f635772f7755ff60b8a7b5af5f94b34a599ae4c772231c8d0fb32f79aabb37de",
             "extract_dir": "love-0.9.2-win32"
         }
@@ -24,23 +25,7 @@
     "shortcuts": [
         [
             "love.exe",
-            "LOVE 0.9"
+            "LÖVE 0.9"
         ]
-    ],
-    "checkver": {
-        "url": "https://bitbucket.org/rude/love/downloads/",
-        "regex": "love-(0.9[0-9.]+)-w"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win64.zip",
-                "extract_dir": "love-$version-win64"
-            },
-            "32bit": {
-                "url": "https://bitbucket.org/rude/love/downloads/love-$version-win32.zip",
-                "extract_dir": "love-$version-win32"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
Here are the changes:
- consistent descriptions and shortcuts
- fix dead download links (repo moved from bitbucket to github)
- removed autoupdate & checkvers because unlikely that updates will release for old versions, also couldn't find a way to checkver on github releases for versions that aren't the latest or via the atom xml which doesn't have every old release