### PR TITLE
gimp-dev: add version 2.99.8

### DIFF
--- a/bucket/gimp-dev.json
+++ b/bucket/gimp-dev.json
@@ -58,7 +58,7 @@
     "shortcuts": [
         [
             "bin\\gimp-2.99.exe",
-            "GIMP"
+            "GIMP Development Version"
         ]
     ],
     "checkver": {
@@ -89,7 +89,7 @@
         "shortcuts": [
             [
                 "bin\\gimp-$majorVersion.$minorVersion.exe",
-                "GIMP"
+                "GIMP Development Version"
             ]
         ]
     }

--- a/bucket/gimp-dev.json
+++ b/bucket/gimp-dev.json
@@ -1,0 +1,96 @@
+{
+    "version": "2.99.8",
+    "description": "GNU Image Manipulation Program",
+    "homepage": "https://www.gimp.org",
+    "license": "GPL-3.0-only",
+    "url": "https://download.gimp.org/mirror/pub/gimp/v2.99/windows/gimp-2.99.8-setup.exe",
+    "hash": "c8ba9ad9e9325244042237a4e05ae1e46cc31b0226d287aefcf836e6c8f216db",
+    "innosetup": true,
+    "installer": {
+        "script": [
+            "$version = ($fname -split '-' | Select-Object -First 1 -Skip 1).Split('.')",
+            "$shortver = $version[0] + '.' + $version[1]",
+            "Push-Location \"$dir\"",
+            "Get-ChildItem -Filter '*.debug' -Recurse | Remove-Item -Recurse",
+            "if ($architecture -eq '64bit') {",
+            "   Rename-Item \"lib\\gimp\\$shortver\\plug-ins\\twain\\twain,3.exe\" 'twain.exe'",
+            "   Remove-Item \"lib\\gimp\\$shortver\\plug-ins\\twain\\twain,1.exe\"",
+            "   Get-ChildItem -Filter '*,1*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
+            "   Get-ChildItem -Filter '*,*' -Recurse | Remove-Item",
+            "} else {",
+            "   Rename-Item \"lib\\gimp\\$shortver\\plug-ins\\twain\\twain,1.exe\" 'twain.exe'",
+            "   Remove-Item \"lib\\gimp\\$shortver\\plug-ins\\twain\\twain,3.exe\"",
+            "   Get-ChildItem -Filter '*,1*' -Recurse | Remove-Item",
+            "   Get-ChildItem -Filter '*,*' -Recurse | Rename-Item -NewName { $_.name -Replace ',\\d','' }",
+            "}",
+            "$defpath = \"`nPATH=`${gimp_installation_dir}\\bin`n\"",
+            "$defenv = Get-Content \"lib\\gimp\\$shortver\\environ\\default.env\" -Raw",
+            "$defenv += $defpath",
+            "$defenv += \"PYTHONPATH=`${gimp_installation_dir}\\lib\\gimp\\$shortver\\python;`${gimp_plug_in_dir}\\plug-ins\\python-console\"",
+            "$defenv | Set-Content \"lib\\gimp\\$shortver\\environ\\default.env\"",
+            "# Only worked for versions <2.99, installer no longer supplies 'pygimp.env'",
+            "# $pyenv = (Get-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\" -Raw) + '__COMPAT_LAYER=HIGHDPIAWARE'",
+            "# $pyenv | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
+            "'__COMPAT_LAYER=HIGHDPIAWARE' | Set-Content \"lib\\gimp\\$shortver\\environ\\pygimp.env\"",
+            "$pyint = Get-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\" -Raw",
+            "$pyint = $pyint -Replace '(python|python2)=(.*)', \"`$1=$dir\\bin\\pythonw.exe\"",
+            "$pyint = $pyint -Replace 'py::python2', 'py::python'",
+            "$pyint | Set-Content \"lib\\gimp\\$shortver\\interpreters\\pygimp.interp\"",
+            "Pop-Location"
+        ]
+    },
+    "bin": [
+        "bin\\gimp-console-2.99.exe",
+        [
+            "bin\\gimp-console-2.99.exe",
+            "gimp-console"
+        ],
+        [
+            "bin\\gimp-console-2.99.exe",
+            "gimp"
+        ],
+        "bin\\gimptool-2.99.exe",
+        [
+            "bin\\gimptool-2.99.exe",
+            "gimptool"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\gimp-2.99.exe",
+            "GIMP"
+        ]
+    ],
+    "checkver": {
+        "url": "https://testing.gimp.org/downloads/devel/",
+        "regex": "The current development release of GIMP is \\<b\\>([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://download.gimp.org/mirror/pub/gimp/v$majorVersion.$minorVersion/windows/gimp-$matchHead-setup$matchTail.exe",
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
+        },
+        "bin": [
+            "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+            [
+                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+                "gimp-console"
+            ],
+            [
+                "bin\\gimp-console-$majorVersion.$minorVersion.exe",
+                "gimp"
+            ],
+            "bin\\gimptool-$majorVersion.$minorVersion.exe",
+            [
+                "bin\\gimptool-$majorVersion.$minorVersion.exe",
+                "gimptool"
+            ]
+        ],
+        "shortcuts": [
+            [
+                "bin\\gimp-$majorVersion.$minorVersion.exe",
+                "GIMP"
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes #361
- Based on https://github.com/ScoopInstaller/Extras/blob/master/bucket/gimp.json
- Commented out the section for pygimp.env in installer because no longer present in v2.99+

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
