### PR TITLE
xmind8: Add version 3.7.9

### DIFF
--- a/bucket/xmind8.json
+++ b/bucket/xmind8.json
@@ -1,0 +1,19 @@
+{
+    "version": "3.7.9",
+    "description": "A popular and classic mind mapping tool",
+    "homepage": "https://www.xmind.net/xmind8-pro/",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://www.xmind.net/terms/"
+    },
+    "url": "https://www.xmind.net/xmind/downloads/xmind-8-update9-windows.zip",
+    "hash": "126da4b6a5542f0b0846109d7163932ed32bdb6fb9c90382b4fc61c115ea80cf",
+    "extract_dir": "XMind 8 Update 9",
+    "shortcuts": [
+        [
+            "XMind.exe",
+            "XMind"
+        ]
+    ],
+    "persist": "workspace"
+}


### PR DESCRIPTION
[XMind 8](https://www.xmind.net/xmind8-pro/) is no longer updated, but is still available. [XMind](https://www.xmind.net/) is the recommended version.

Relates to https://github.com/ScoopInstaller/Extras/pull/3609

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
