### PR TITLE
chore: firefox-nightly portable config

### DIFF
--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -17,16 +17,21 @@
     "bin": [
         [
             "firefox.exe",
-            "firefox-nightly"
+            "firefox-nightly",
+            "-profile \"$dir\\profile\""
         ]
     ],
     "shortcuts": [
         [
             "firefox.exe",
-            "Firefox Nightly"
+            "Firefox Nightly",
+            "-profile \"$dir\\profile\""
         ]
     ],
-    "persist": "distribution",
+    "persist": [
+        "distribution",
+        "profile"
+    ],
     "checkver": {
         "url": "https://aus5.mozilla.org/update/6/Firefox/60.0/_/WINNT_x86_64-msvc-x64/en-US/nightly/_/_/_/_/update.xml",
         "regex": "appVersion=\"([\\w.]+)\".*?buildID=\"((?<yyyy>\\d{4})(?<mm>\\d{2})(?<dd>\\d{2})(?<hr>\\d{2})(?<mi>\\d{2})(?<se>\\d{2}))",


### PR DESCRIPTION
Updated `firefox-nightly` to use a persistent profile directory 

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!-- or -->
Relates to ScoopInstaller/Extras#7573

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
