### PR TITLE
Jetbrains apps: Add RC and EAP packages

### DIFF
--- a/bucket/clion-eap.json
+++ b/bucket/clion-eap.json
@@ -26,7 +26,7 @@
     },
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "persist": [
         "IDE\\bin\\idea.properties",

--- a/bucket/clion-eap.json
+++ b/bucket/clion-eap.json
@@ -1,0 +1,50 @@
+{
+    "version": "2021.3-213.5744.5",
+    "description": "Cross-Platform IDE for C and C++ by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/cpp/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.jetbrains.com/cpp/CLion-213.5744.5.win.zip",
+            "hash": "8dd8ab6741b55ea7052006e2ab8ed9a9448178d19584d3577f4297b80124af31",
+            "bin": [
+                [
+                    "IDE\\bin\\clion64.exe",
+                    "clion"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\clion64.exe",
+                    "JetBrains\\CLion (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "extract_to": "IDE",
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=CL&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/cpp/CLion-$preReleaseVersion.win.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/clion-rc.json
+++ b/bucket/clion-rc.json
@@ -1,0 +1,50 @@
+{
+    "version": "2021.3-213.5744.190",
+    "description": "Cross-Platform IDE for C and C++ by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/cpp/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.jetbrains.com/cpp/CLion-213.5744.190.win.zip",
+            "hash": "391fc534b1bc812f14cb99c2dd81c33cb4e086b109908ab3fead84ac5bdd94c0",
+            "bin": [
+                [
+                    "IDE\\bin\\clion64.exe",
+                    "clion"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\clion64.exe",
+                    "JetBrains\\CLion (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "extract_to": "IDE",
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=CL&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/cpp/CLion-$matchBuild.win.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/clion-rc.json
+++ b/bucket/clion-rc.json
@@ -26,7 +26,7 @@
     },
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "persist": [
         "IDE\\bin\\idea.properties",

--- a/bucket/datagrip-eap.json
+++ b/bucket/datagrip-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/datagrip-eap.json
+++ b/bucket/datagrip-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.9",
+    "description": "Cross-Platform IDE for Databases & SQL by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/datagrip/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/datagrip/datagrip-213.5744.9.exe#/dl.7z",
+    "hash": "28dfd9165f4625029782a6e8014f2420a65c0dab3d38754ec7d8cd1f465b0f4a",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\datagrip64.exe",
+                    "datagrip"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\datagrip64.exe",
+                    "JetBrains\\DataGrip (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\datagrip.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\datagrip.exe",
+                    "JetBrains\\DataGrip (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/datagrip/datagrip-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/datagrip-rc.json
+++ b/bucket/datagrip-rc.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.121",
+    "description": "Cross-Platform IDE for Databases & SQL by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/datagrip/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/datagrip/datagrip-213.5744.121.exe#/dl.7z",
+    "hash": "80e5fffc3dde7538b1f30ad5d77cb82d31e5a0f45023eaaa113d46c3857106ab",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\datagrip64.exe",
+                    "datagrip"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\datagrip64.exe",
+                    "JetBrains\\DataGrip (Release Candidate)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\datagrip.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\datagrip.exe",
+                    "JetBrains\\DataGrip (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=DG&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/datagrip/datagrip-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/datagrip-rc.json
+++ b/bucket/datagrip-rc.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/dataspell-eap.json
+++ b/bucket/dataspell-eap.json
@@ -21,7 +21,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/dataspell-eap.json
+++ b/bucket/dataspell-eap.json
@@ -1,0 +1,47 @@
+{
+    "version": "2021.3-213.5352.7",
+    "description": "Cross-Platform IDE for Data Scientists by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/dataspell/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.jetbrains.com/python/data-spell-213.5352.7.exe#/dl.7z",
+            "hash": "9e0b3e53850db0d5ea4a9b49ae5c487f807ae96a2f69eec4cb188fb82a94e29b",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\dataspell64.exe",
+                    "JetBrains\\DataSpell (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=DS&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/python/data-spell-$preReleaseVersion.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/dataspell-rc.json
+++ b/bucket/dataspell-rc.json
@@ -21,7 +21,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/dataspell-rc.json
+++ b/bucket/dataspell-rc.json
@@ -1,0 +1,47 @@
+{
+    "version": "2021.3-213.5744.170",
+    "description": "Cross-Platform IDE for Data Scientists by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/dataspell/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.jetbrains.com/python/dataspell-213.5744.170.exe#/dl.7z",
+            "hash": "ed83574f3add789024c045ffb284ddcbbcb611f52c40f885d57b6b91cdaa9a3c",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\dataspell64.exe",
+                    "JetBrains\\DataSpell (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=DS&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/python/dataspell-$preReleaseVersion.exe#/dl.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/goland-eap.json
+++ b/bucket/goland-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.26",
+    "description": "Cross-Platform IDE for Go by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/goland/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/go/goland-213.5744.26.exe#/dl.7z",
+    "hash": "185947fd7b92fabfd43a55730b6c1283f8428094fe1514867533ea81c5c0ac6b",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\goland64.exe",
+                    "goland"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\goland64.exe",
+                    "JetBrains\\GoLand (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\goland.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\goland.exe",
+                    "JetBrains\\GoLand (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=GO&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/go/goland-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/goland-eap.json
+++ b/bucket/goland-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/goland-rc.json
+++ b/bucket/goland-rc.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.186",
+    "description": "Cross-Platform IDE for Go by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/goland/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/go/goland-213.5744.186.exe#/dl.7z",
+    "hash": "cb93231596e6d02b0c5fb6e89af9ca0fa1fd02e843b7034ba058d39c72aa7742",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\goland64.exe",
+                    "goland"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\goland64.exe",
+                    "JetBrains\\GoLand (Release Candidate)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\goland.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\goland.exe",
+                    "JetBrains\\GoLand (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=GO&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/go/goland-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/goland-rc.json
+++ b/bucket/goland-rc.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/idea-eap.json
+++ b/bucket/idea-eap.json
@@ -10,7 +10,7 @@
     "hash": "f9ef04ca50b76f138f38eaf5ebee7a08a52067075da4b66b670d08e30c2e33be",
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "architecture": {
         "64bit": {

--- a/bucket/idea-rc.json
+++ b/bucket/idea-rc.json
@@ -1,13 +1,13 @@
 {
-    "version": "2021.3.1-213.6461.21",
-    "description": "Cross-Platform IDE for Java by JetBrains. (Community Edition, Early Access Program)",
+    "version": "2021.3.1-213.6461.48",
+    "description": "Cross-Platform IDE for Java by JetBrains. (Release Candidate)",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
         "identifier": "Apache-2.0",
         "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIC-213.6461.21.win.zip",
-    "hash": "f9ef04ca50b76f138f38eaf5ebee7a08a52067075da4b66b670d08e30c2e33be",
+    "url": "https://download.jetbrains.com/idea/ideaIC-213.6461.48.win.zip",
+    "hash": "881d594bccf6cc4f9f0ce817290ca98c3577d865cdb9576d3f7bbd2e9500a6e3",
     "extract_to": "IDE",
     "installer": {
         "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
@@ -23,7 +23,7 @@
             "shortcuts": [
                 [
                     "IDE\\bin\\idea64.exe",
-                    "JetBrains\\IDEA"
+                    "JetBrains\\IDEA (Release Candidate)"
                 ]
             ]
         },
@@ -32,7 +32,7 @@
             "shortcuts": [
                 [
                     "IDE\\bin\\idea.exe",
-                    "JetBrains\\IDEA"
+                    "JetBrains\\IDEA (Release Candidate)"
                 ]
             ]
         }
@@ -42,7 +42,7 @@
         "profile"
     ],
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&platform=zip&type=eap",
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&platform=zip&type=rc",
         "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
         "replace": "${ver}-${build}"
     },

--- a/bucket/idea-rc.json
+++ b/bucket/idea-rc.json
@@ -10,7 +10,7 @@
     "hash": "881d594bccf6cc4f9f0ce817290ca98c3577d865cdb9576d3f7bbd2e9500a6e3",
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "architecture": {
         "64bit": {

--- a/bucket/idea-ultimate-eap.json
+++ b/bucket/idea-ultimate-eap.json
@@ -1,39 +1,53 @@
 {
-    "version": "213.6461.21",
-    "description": "Early Access Program for IntelliJ IDEA Ultimate Edition",
+    "version": "2021.3.1-213.6461.48",
+    "description": "Cross-Platform IDE for Java by JetBrains. (Early Access Program)",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
-        "identifier": "Shareware",
-        "url": "https://www.jetbrains.com/legal/agreements/user_eap.html"
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIU-213.6461.21.win.zip",
-    "hash": "2a9694d64bebdee70218529e3c11918c89ea02aee4b0115df3e5b7c0ace368c1",
+    "url": "https://download.jetbrains.com/idea/ideaIU-213.6461.48.win.zip",
+    "hash": "eb2a18590a994c6c5d1cd67c310ae659aed84ccec06af70c06df4cbb5861016a",
+    "extract_to": "IDE",
+    "installer": {
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+    },
     "architecture": {
         "64bit": {
-            "bin": "bin\\idea64.exe",
+            "bin": [
+                [
+                    "IDE\\bin\\idea64.exe",
+                    "idea"
+                ]
+            ],
             "shortcuts": [
                 [
-                    "bin\\idea64.exe",
-                    "IntelliJ IDEA Ultimate EAP"
+                    "IDE\\bin\\idea64.exe",
+                    "JetBrains\\IDEA Ultimate (Early Access Program)"
                 ]
             ]
         },
         "32bit": {
-            "bin": "bin\\idea.exe",
+            "bin": "IDE\\bin\\idea.exe",
             "shortcuts": [
                 [
-                    "bin\\idea.exe",
-                    "IntelliJ IDEA Ultimate EAP"
+                    "IDE\\bin\\idea.exe",
+                    "JetBrains\\IDEA Ultimate (Early Access Program)"
                 ]
             ]
         }
     },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&type=eap",
-        "jsonpath": "$..build"
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIU-$version.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIU-$preReleaseVersion.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate-eap.json
+++ b/bucket/idea-ultimate-eap.json
@@ -10,7 +10,7 @@
     "hash": "eb2a18590a994c6c5d1cd67c310ae659aed84ccec06af70c06df4cbb5861016a",
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "architecture": {
         "64bit": {

--- a/bucket/idea-ultimate-rc.json
+++ b/bucket/idea-ultimate-rc.json
@@ -1,13 +1,13 @@
 {
-    "version": "2021.3.1-213.6461.21",
-    "description": "Cross-Platform IDE for Java by JetBrains. (Community Edition, Early Access Program)",
+    "version": "2021.3.1-213.6461.48",
+    "description": "Cross-Platform IDE for Java by JetBrains. (Release Candidate)",
     "homepage": "https://www.jetbrains.com/idea/",
     "license": {
-        "identifier": "Apache-2.0",
-        "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/idea/ideaIC-213.6461.21.win.zip",
-    "hash": "f9ef04ca50b76f138f38eaf5ebee7a08a52067075da4b66b670d08e30c2e33be",
+    "url": "https://download.jetbrains.com/idea/ideaIU-213.6461.48.win.zip",
+    "hash": "eb2a18590a994c6c5d1cd67c310ae659aed84ccec06af70c06df4cbb5861016a",
     "extract_to": "IDE",
     "installer": {
         "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
@@ -23,7 +23,7 @@
             "shortcuts": [
                 [
                     "IDE\\bin\\idea64.exe",
-                    "JetBrains\\IDEA"
+                    "JetBrains\\IDEA Ultimate (Release Candidate)"
                 ]
             ]
         },
@@ -32,7 +32,7 @@
             "shortcuts": [
                 [
                     "IDE\\bin\\idea.exe",
-                    "JetBrains\\IDEA"
+                    "JetBrains\\IDEA Ultimate (Release Candidate)"
                 ]
             ]
         }
@@ -42,12 +42,12 @@
         "profile"
     ],
     "checkver": {
-        "url": "https://data.services.jetbrains.com/products/releases?code=IIC&latest=true&platform=zip&type=eap",
+        "url": "https://data.services.jetbrains.com/products/releases?code=IIU&latest=true&platform=zip&type=rc",
         "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/idea/ideaIC-$preReleaseVersion.win.zip",
+        "url": "https://download.jetbrains.com/idea/ideaIU-$preReleaseVersion.win.zip",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/idea-ultimate-rc.json
+++ b/bucket/idea-ultimate-rc.json
@@ -10,7 +10,7 @@
     "hash": "eb2a18590a994c6c5d1cd67c310ae659aed84ccec06af70c06df4cbb5861016a",
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "architecture": {
         "64bit": {

--- a/bucket/mps-eap.json
+++ b/bucket/mps-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/mps-eap.json
+++ b/bucket/mps-eap.json
@@ -1,0 +1,42 @@
+{
+    "version": "2021.3-213.5744.587-EAP1",
+    "description": "Domain-Specific language creator by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/mps/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/mps/2021.3/MPS-2021.3-EAP1.exe#/dl.7z",
+    "hash": "bfacae0d6fb0e021eac24fe946e2ada62efcfccdc744941821a0d52d940b7149",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "bin": "IDE\\bin\\mps.bat",
+    "shortcuts": [
+        [
+            "IDE\\bin\\mps.bat",
+            "JetBrains\\MPS (Early Access Program)",
+            "",
+            "IDE\\bin\\mps.ico"
+        ]
+    ],
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=MPS&latest=true&platform=zip&type=eap",
+        "regex": "EAP(?<eap>\\d+)\\.exe.*majorVersion\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}-EAP${eap}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/mps/$matchHead/MPS-$matchHead-EAP$matchEap.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/phpstorm-eap.json
+++ b/bucket/phpstorm-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.38",
+    "description": "Cross-Platform IDE for PHP by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/phpstorm/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/webide/PhpStorm-213.5744.38.exe#/dl.7z",
+    "hash": "31dadd250d9962b91c03e9dd54541c872baf9f8bff76270e00f41a815169c416",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\phpstorm64.exe",
+                    "phpstorm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\phpstorm64.exe",
+                    "JetBrains\\PhpStorm (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\phpstorm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\phpstorm.exe",
+                    "JetBrains\\PhpStorm (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/webide/PhpStorm-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/phpstorm-eap.json
+++ b/bucket/phpstorm-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/phpstorm-rc.json
+++ b/bucket/phpstorm-rc.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.206",
+    "description": "Cross-Platform IDE for PHP by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/phpstorm/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/webide/PhpStorm-213.5744.206.exe#/dl.7z",
+    "hash": "f9b2252632748c2369f495e33d5528db2422c728a6d3488ef101e734aa8c2cab",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\phpstorm64.exe",
+                    "phpstorm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\phpstorm64.exe",
+                    "JetBrains\\PhpStorm"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\phpstorm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\phpstorm.exe",
+                    "JetBrains\\PhpStorm"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PS&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/webide/PhpStorm-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/phpstorm-rc.json
+++ b/bucket/phpstorm-rc.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/pycharm-eap.json
+++ b/bucket/pycharm-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/pycharm-eap.json
+++ b/bucket/pycharm-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5605.23",
+    "description": "Cross-Platform IDE for Python by JetBrains. (Community Edition, Early Access Program)",
+    "homepage": "https://www.jetbrains.com/pycharm/",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
+    },
+    "url": "https://download.jetbrains.com/python/pycharm-community-213.5605.23.exe#/dl.7z",
+    "hash": "4132d6e71ca8947c8d9eb75ee9b3705cc2bd13dc019b5a6ed29f880e894ec1f6",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "pycharm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "JetBrains\\PyCharm (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\pycharm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm.exe",
+                    "JetBrains\\PyCharm (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/python/pycharm-community-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/pycharm-professional-eap.json
+++ b/bucket/pycharm-professional-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5605.23",
+    "description": "Cross-Platform IDE for Python by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/pycharm/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/python/pycharm-professional-213.5605.23.exe#/dl.7z",
+    "hash": "e1bccd049b87d5a4c05d29511023d6454d28e745b1298e4ae21d0bd4faee0576",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "pycharm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "JetBrains\\PyCharm Professional (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\pycharm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm.exe",
+                    "JetBrains\\PyCharm Professional (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/python/pycharm-professional-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/pycharm-professional-eap.json
+++ b/bucket/pycharm-professional-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/pycharm-professional-rc.json
+++ b/bucket/pycharm-professional-rc.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/pycharm-professional-rc.json
+++ b/bucket/pycharm-professional-rc.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.209",
+    "description": "Cross-Platform IDE for Python by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/pycharm/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/python/pycharm-professional-213.5744.209.exe#/dl.7z",
+    "hash": "2c6be2220bca4b1a7da59c110b780bd86916b30cad765ad7850d87f60a8056b5",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "pycharm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "JetBrains\\PyCharm Professional (Release Candidate)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\pycharm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm.exe",
+                    "JetBrains\\PyCharm Professional (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PCP&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/python/pycharm-professional-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/pycharm-rc.json
+++ b/bucket/pycharm-rc.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.209",
+    "description": "Cross-Platform IDE for Python by JetBrains. (Community Edition, Release Candidate)",
+    "homepage": "https://www.jetbrains.com/pycharm/",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://sales.jetbrains.com/hc/en-gb/articles/115001015290-Where-can-I-find-the-EULA-End-User-License-Agreement-"
+    },
+    "url": "https://download.jetbrains.com/python/pycharm-community-213.5744.209.exe#/dl.7z",
+    "hash": "364c62bd6f11e3cc6b26fb922756d252aa0738b0186400e3df25d1a08da58b0e",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "pycharm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm64.exe",
+                    "JetBrains\\PyCharm (Release Candidate)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\pycharm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\pycharm.exe",
+                    "JetBrains\\PyCharm (Release Candidate)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=PCC&latest=true&platform=zip&type=rc",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/python/pycharm-community-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/pycharm-rc.json
+++ b/bucket/pycharm-rc.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/rider-eap.json
+++ b/bucket/rider-eap.json
@@ -26,7 +26,7 @@
     },
     "extract_to": "IDE",
     "installer": {
-        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
+        "script": "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "persist": [
         "IDE\\bin\\idea.properties",

--- a/bucket/rider-eap.json
+++ b/bucket/rider-eap.json
@@ -26,9 +26,7 @@
     },
     "extract_to": "IDE",
     "installer": {
-        "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
-        ]
+        "script": "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
     },
     "persist": [
         "IDE\\bin\\idea.properties",

--- a/bucket/rider-eap.json
+++ b/bucket/rider-eap.json
@@ -1,0 +1,53 @@
+{
+    "version": "2021.3-EAP10-213.5744.263",
+    "description": "Cross-Platform IDE for .NET by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/rider/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://download.jetbrains.com/rider/JetBrains.Rider-2021.3-EAP10-213.5744.263.Checked.win.zip",
+            "hash": "34a537a8e73bd784324e0f9b3bf147fce3e47ff1d3901731bb9ca4715e700c71",
+            "bin": [
+                [
+                    "IDE\\bin\\rider64.exe",
+                    "rider"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\rider64.exe",
+                    "JetBrains\\Rider"
+                ]
+            ]
+        }
+    },
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=RD&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\w.-]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://download.jetbrains.com/rider/JetBrains.Rider-$version.Checked.win.zip",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/rider-eap.json
+++ b/bucket/rider-eap.json
@@ -27,8 +27,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
-            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir"
         ]
     },
     "persist": [

--- a/bucket/rubymine-eap.json
+++ b/bucket/rubymine-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.194",
+    "description": "Cross-Platform IDE for Ruby on Rails by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/ruby/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/ruby/RubyMine-213.5744.194.exe#/dl.7z",
+    "hash": "a1c98b80e7c2c7aaf9012b469cded9882b4724251a5d26936c7d84648854d190",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\rubymine64.exe",
+                    "rubymine"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\rubymine64.exe",
+                    "JetBrains\\RubyMine (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\rubymine.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\rubymine.exe",
+                    "JetBrains\\RubyMine (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=RM&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/ruby/RubyMine-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/rubymine-eap.json
+++ b/bucket/rubymine-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/bucket/teamcity-eap.json
+++ b/bucket/teamcity-eap.json
@@ -1,0 +1,37 @@
+{
+    "version": "2020.2.EAP3-85274",
+    "description": "Continuous Integration server by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/teamcity/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "notes": "TeamCity can be started from anywhere using 'teamcity' command.",
+    "url": "https://download.jetbrains.com/teamcity/eap/TeamCity-85274.exe#/dl.7z",
+    "hash": "a5b0493a5e261ff34a4cd6b021116e5a8c92e58ad8ebd95702482e52c1b89d50",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\`$*\" -Recurse",
+            "$ver_path = \"$dir\\bin\"",
+            "$cont = @(",
+            "    \"Push-Location \"\"$ver_path\"\"\"",
+            "    '& .\\teamcity-server.bat @args'",
+            "    'Pop-Location'",
+            ")",
+            "Set-Content \"$dir\\teamcity.ps1\" $cont -Encoding Ascii"
+        ]
+    },
+    "bin": "teamcity.ps1",
+    "persist": "conf",
+    "checkver": {
+        "url": "https://confluence.jetbrains.com/display/TW/ChangeLog",
+        "regex": "\\s+([\\d.]+)\\s+EAP(?<eap>\\d+)\\s+\\(build\\s+(?<build>[\\d.]+)\\)\\s+Release\\s+Notes</a>",
+        "replace": "$1.EAP${eap}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/teamcity/eap/TeamCity-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/teamcity-rc.json
+++ b/bucket/teamcity-rc.json
@@ -1,0 +1,37 @@
+{
+    "version": "2020.2.RC-85437",
+    "description": "Continuous Integration server by JetBrains. (Release Candidate)",
+    "homepage": "https://www.jetbrains.com/teamcity/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "notes": "TeamCity can be started from anywhere using 'teamcity' command.",
+    "url": "https://download.jetbrains.com/teamcity/eap/TeamCity-85437.exe#/dl.7z",
+    "hash": "6886990f544c77b98c1e95eca995e1543d35863872d4c0d4abc138b6f0924327",
+    "installer": {
+        "script": [
+            "Remove-Item \"$dir\\`$*\" -Recurse",
+            "$ver_path = \"$dir\\bin\"",
+            "$cont = @(",
+            "    \"Push-Location \"\"$ver_path\"\"\"",
+            "    '& .\\teamcity-server.bat @args'",
+            "    'Pop-Location'",
+            ")",
+            "Set-Content \"$dir\\teamcity.ps1\" $cont -Encoding Ascii"
+        ]
+    },
+    "bin": "teamcity.ps1",
+    "persist": "conf",
+    "checkver": {
+        "url": "https://confluence.jetbrains.com/display/TW/ChangeLog",
+        "regex": "([\\d.]+)\\s+RC(?<rc>\\d+)?\\s+\\(build\\s+(?<build>[\\d.]+)\\)\\s+Release\\s+Notes</a>",
+        "replace": "$1.RC${rc}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/teamcity/eap/TeamCity-$preReleaseVersion.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/webstorm-eap.json
+++ b/bucket/webstorm-eap.json
@@ -6,7 +6,7 @@
         "identifier": "Proprietary",
         "url": "https://www.jetbrains.com/store/license.html"
     },
-    "url": "https://download.jetbrains.com/webstorm/WebStorm-213.5744.37.exe#/cosi.7z",
+    "url": "https://download.jetbrains.com/webstorm/WebStorm-213.5744.37.exe#/dl.7z",
     "hash": "76996e3fccbbd412ba011475f1f8e1ea68c987cca2e08e6e98d86c3a337c100f",
     "extract_to": "IDE",
     "installer": {

--- a/bucket/webstorm-eap.json
+++ b/bucket/webstorm-eap.json
@@ -50,7 +50,7 @@
         "replace": "${ver}-${build}"
     },
     "autoupdate": {
-        "url": "https://download.jetbrains.com/webstorm/WebStorm-$preReleaseVersion.exe#/cosi.7z",
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-$preReleaseVersion.exe#/dl.7z",
         "hash": {
             "url": "$url.sha256"
         }

--- a/bucket/webstorm-eap.json
+++ b/bucket/webstorm-eap.json
@@ -1,0 +1,58 @@
+{
+    "version": "2021.3-213.5744.37",
+    "description": "Cross-Platform IDE for JavaScript by JetBrains. (Early Access Program)",
+    "homepage": "https://www.jetbrains.com/webstorm/",
+    "license": {
+        "identifier": "Proprietary",
+        "url": "https://www.jetbrains.com/store/license.html"
+    },
+    "url": "https://download.jetbrains.com/webstorm/WebStorm-213.5744.37.exe#/cosi.7z",
+    "hash": "76996e3fccbbd412ba011475f1f8e1ea68c987cca2e08e6e98d86c3a337c100f",
+    "extract_to": "IDE",
+    "installer": {
+        "script": [
+            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
+        ]
+    },
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "IDE\\bin\\webstorm64.exe",
+                    "webstorm"
+                ]
+            ],
+            "shortcuts": [
+                [
+                    "IDE\\bin\\webstorm64.exe",
+                    "JetBrains\\WebStorm (Early Access Program)"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "IDE\\bin\\webstorm.exe",
+            "shortcuts": [
+                [
+                    "IDE\\bin\\webstorm.exe",
+                    "JetBrains\\WebStorm (Early Access Program)"
+                ]
+            ]
+        }
+    },
+    "persist": [
+        "IDE\\bin\\idea.properties",
+        "profile"
+    ],
+    "checkver": {
+        "url": "https://data.services.jetbrains.com/products/releases?code=WS&latest=true&platform=zip&type=eap",
+        "regex": "version\":\"(?<ver>[\\d.]+)\".*\"build\":\"(?<build>[\\d.]+)\"",
+        "replace": "${ver}-${build}"
+    },
+    "autoupdate": {
+        "url": "https://download.jetbrains.com/webstorm/WebStorm-$preReleaseVersion.exe#/cosi.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/webstorm-eap.json
+++ b/bucket/webstorm-eap.json
@@ -11,7 +11,7 @@
     "extract_to": "IDE",
     "installer": {
         "script": [
-            "& \"$bucketsdir\\extras\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
+            "& \"$bucketsdir\\versions\\scripts\\jetbrains\\portable.ps1\" $dir $persist_dir",
             "Remove-Item \"$dir\\IDE\\`$*\" -Force -Recurse"
         ]
     },

--- a/scripts/jetbrains/portable.ps1
+++ b/scripts/jetbrains/portable.ps1
@@ -1,0 +1,15 @@
+param([Parameter(Mandatory)][String] $dir, [Parameter(Mandatory)][String] $persist_dir)
+
+if (!(Test-Path "$persist_dir\IDE\bin\idea.properties")) {
+    info 'Copying idea.properties file...'
+
+    $current = (Split-Path $dir | Join-Path -ChildPath 'current') -replace '\\', '/'
+
+    $CONT = Get-Content "$dir\IDE\bin\idea.properties"
+    $CONT = $CONT -replace '^#\s*(idea.config.path=).*$', "`$1$current/profile/config"
+    $CONT = $CONT -replace '^#\s*(idea.system.path=).*$', "`$1$current/profile/system"
+    $CONT = $CONT -replace '^#\s*(idea.plugins.path=).*$', '$1${idea.config.path}/plugins'
+    $CONT = $CONT -replace '^#\s*(idea.log.path=).*$', '$1${idea.system.path}/log'
+
+    Set-Content -LiteralPath "$dir\IDE\bin\idea.properties" -Value $CONT -Encoding 'Ascii' -Force
+}


### PR DESCRIPTION
This adds RC (release condidate) and EAP (early access program) of **JetBrains** apps to the bucket.

Notes:
* I have (1) run autoupdate locally, (2) installed, and (3) run the software of all these packages, to make sure they work properly.