### PR TITLE
logseq-nightly: Add version 0.5.8-20220108

### DIFF
--- a/bucket/logseq-nightly.json
+++ b/bucket/logseq-nightly.json
@@ -1,0 +1,37 @@
+{
+    "version": "0.5.8-20220108",
+    "description": "A privacy-first platform for knowledge sharing and management",
+    "homepage": "https://logseq.com",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/logseq/logseq/releases/download/nightly/logseq-win-x64-0.5.8+nightly.20220108.exe#/dl.7z",
+            "hash": "15ee81d2e76b40c03b86364ac35fbc1831bb78ac22246447572d4eafad9ca7d3"
+        }
+    },
+    "pre_install": [
+        "Expand-7ZipArchive \"$dir\\Logseq-*-full.nupkg\" -ExtractDir 'lib\\net45' -Removal",
+        "Remove-Item \"$dir\\lib\", \"$dir\\Update*\", \"$dir\\*.gif\", \"$dir\\*.ico\", \"$dir\\RELEASES*\" -Recurse"
+    ],
+    "shortcuts": [
+        [
+            "Logseq.exe",
+            "Logseq"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/logseq/logseq/releases/tag/nightly",
+        "regex": "Logseq-win-x64-(?<main>[\\d.]+)\\+nightly\\.(?<date>\\d{8})",
+        "replace": "${main}-${date}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/logseq/logseq/releases/download/nightly/logseq-win-x64-$matchMain+nightly.$matchDate.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/SHA256SUMS.txt"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to [Extras/logseq.json](https://github.com/ScoopInstaller/Extras/blob/master/bucket/logseq.json) and this PR is about its [Nightly version](https://github.com/logseq/logseq/releases/tag/nightly).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
