### PR TITLE
windowsdesktop-runtime-lts: Fix download URLs

### DIFF
--- a/bucket/windowsdesktop-runtime-lts.json
+++ b/bucket/windowsdesktop-runtime-lts.json
@@ -9,11 +9,11 @@
     "notes": "You can now remove this installer with 'scoop uninstall windowsdesktop-runtime-lts'",
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/windowsdesktop-runtime-6.0.1-win-x64.exe",
+            "url": "https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/6.0.1/windowsdesktop-runtime-6.0.1-win-x64.exe",
             "hash": "sha512:36dc038f6ed20b964238d6f1cb8d2248fdf120f53ab412c23d77981a0bc4133be731df7b4d5fec7d29a127ab6d3f0e93a3062eeb3691837d7442e085ee884ebd"
         },
         "32bit": {
-            "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/6.0.1/windowsdesktop-runtime-6.0.1-win-x86.exe",
+            "url": "https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/6.0.1/windowsdesktop-runtime-6.0.1-win-x86.exe",
             "hash": "sha512:69d5ebc7e8421cd10164fadcf41f05e79c4c5e4fa88107b682ff44e2081e7d7c3427f775ffdba568f532aae24f9773043cdb6354828a8379e54a5404b1739f79"
         }
     },
@@ -22,20 +22,20 @@
         "script": "Invoke-ExternalCommand \"$dir\\$fname\" -ArgumentList '/install', '/quiet', '/norestart' -RunAs | Out-Null"
     },
     "checkver": {
-        "url": "https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/LTS/latest.version",
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/WindowsDesktop/LTS/latest.version",
         "regex": "([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/$version/windowsdesktop-runtime-$version-win-x64.exe",
+                "url": "https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$version/windowsdesktop-runtime-$version-win-x64.exe",
                 "hash": {
                     "url": "https://dotnet.microsoft.com/download/dotnet-core/thank-you/runtime-desktop-$version-windows-x64-installer",
                     "regex": "value=\"$sha512\""
                 }
             },
             "32bit": {
-                "url": "https://dotnetcli.azureedge.net/dotnet/Runtime/$version/windowsdesktop-runtime-$version-win-x86.exe",
+                "url": "https://dotnetcli.azureedge.net/dotnet/WindowsDesktop/$version/windowsdesktop-runtime-$version-win-x86.exe",
                 "hash": {
                     "url": "https://dotnet.microsoft.com/download/dotnet-core/thank-you/runtime-desktop-$version-windows-x86-installer",
                     "regex": "value=\"$sha512\""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

.NET Desktop Runtime has change its download URLs for version 6

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #388

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
