### PR TITLE
gpac-nightly: Add version 1.1.0-DEV-rev1648

### DIFF
--- a/bucket/gpac-nightly.json
+++ b/bucket/gpac-nightly.json
@@ -1,0 +1,46 @@
+{
+    "version": "1.1.0-DEV-rev1648",
+    "description": "Multimedia framework developed for research and academic purposes",
+    "homepage": "https://gpac.wp.imt.fr/",
+    "license": "LGPL-2.1-or-later",
+    "suggest": {
+        "Visual C++ Redistributable": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "http://download.tsi.telecom-paristech.fr/gpac/new_builds/win64/gpac-1.1.0-DEV-rev1648-g045ccd3f-master-x64.exe#/dl.7z",
+            "hash": "ae2be653c327b22451e8f0f017e37cd058babbe5665d416012565141e74ee2ee"
+        },
+        "32bit": {
+            "url": "http://download.tsi.telecom-paristech.fr/gpac/new_builds/win32/gpac-1.1.0-DEV-rev1648-g045ccd3f-master-win32.exe#/dl.7z",
+            "hash": "b65d4c7975eb7880441aabe192f55cc720bcdeb4b4fecb67c1ee9997a431a437"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\`$*\", \"$dir\\uninstall.exe\" -Force -Recurse",
+        "if (!(Test-Path \"$persist_dir\\GPAC.cfg\")) {New-Item \"$dir\\GPAC.cfg\" -ItemType File | Out-Null}"
+    ],
+    "bin": [
+        "gpac.exe",
+        "mp4box.exe",
+        "mp4client.exe"
+    ],
+    "persist": [
+        "Storage",
+        "GPAC.cfg"
+    ],
+    "checkver": {
+        "url": "https://gpac.wp.imt.fr/downloads/gpac-nightly-builds/",
+        "regex": "win64/gpac-([\\d.]+\\-DEV\\-rev\\d+)-(?<commit>\\w+)-master-x64\\.exe"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "http://download.tsi.telecom-paristech.fr/gpac/new_builds/win64/gpac-$version-$matchCommit-master-x64.exe#/dl.7z"
+            },
+            "32bit": {
+                "url": "http://download.tsi.telecom-paristech.fr/gpac/new_builds/win32/gpac-$version-$matchCommit-master-win32.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related: https://github.com/ScoopInstaller/Main/pull/3226
Related: https://github.com/ScoopInstaller/Main/pull/1246

This adds the nightly version of **GPAC** to the bucket.