### PR TITLE
Fix Okular's shortcut in the start menu not being capitalised

### DIFF
--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "bin\\okular.exe",
-            "okular"
+            "Okular"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Fixes Okular's shortcut name not being capitalised in the start menu shortcut. Closes #409 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
