### PR TITLE
avidemux-nightly: add version 220130

### DIFF
--- a/bucket/avidemux-nightly.json
+++ b/bucket/avidemux-nightly.json
@@ -1,0 +1,41 @@
+{
+    "version": "220130",
+    "description": "Video editor designed for simple cutting, filtering and encoding tasks",
+    "homepage": "http://fixounet.free.fr/avidemux/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.avidemux.org/nightly/win64/avidemux_2.8.1 r220130_win64.exe#/dl.7z",
+            "hash": "1ef81cbbb975e0c9ae53e2687db0573d3b51285be9086dad1244853fe183f59f"
+        }
+    },
+    "bin": [
+        [
+            "avidemux_cli.exe",
+            "avidemux"
+        ]
+    ],
+    "post_install": "'$PLUGINSDIR', 'uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse -Force }",
+    "shortcuts": [
+        [
+            "avidemux.exe",
+            "Avidemux Nightly"
+        ],
+        [
+            "avidemux_jobs.exe",
+            "Avidemux Nightly Jobs"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.avidemux.org/nightly/win64/",
+        "regex": "(?<win64bit>avidemux_[\\d.]+ r(?<version>\\d+)_win64.exe)",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.avidemux.org/nightly/win64/$matchWin64bit#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/avidemux-nightly.json
+++ b/bucket/avidemux-nightly.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://www.avidemux.org/nightly/win64/avidemux_2.8.1 r220130_win64.exe#/dl.7z",
+            "url": "https://www.avidemux.org/nightly/win64/avidemux_2.8.1%20r220130_win64.exe#/dl.7z",
             "hash": "1ef81cbbb975e0c9ae53e2687db0573d3b51285be9086dad1244853fe183f59f"
         }
     },
@@ -28,13 +28,13 @@
     ],
     "checkver": {
         "url": "https://www.avidemux.org/nightly/win64/",
-        "regex": "(?<win64bit>avidemux_[\\d.]+ r(?<version>\\d+)_win64.exe)",
+        "regex": "(?<win64bit>avidemux_[\\d.]+) r(?<version>\\d+)_win64.exe",
         "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.avidemux.org/nightly/win64/$matchWin64bit#/dl.7z"
+                "url": "https://www.avidemux.org/nightly/win64/$matchWin64bit%20r$version_win64.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to https://github.com/ScoopInstaller/Extras/pull/7926
- So users can test the next version of Avidemux
- No hashes available

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
