### PR TITLE
*mozilla: use $persist_dir instead of $dir in profile path

### DIFF
--- a/bucket/firefox-beta.json
+++ b/bucket/firefox-beta.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox-beta -CreateProfile \"Scoop-Beta $dir\\profile\"",
+    "post_install": "firefox-beta -CreateProfile \"Scoop-Beta $persist_dir\\profile\"",
     "bin": [
         [
             "firefox.exe",

--- a/bucket/firefox-developer.json
+++ b/bucket/firefox-developer.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox-dev -CreateProfile \"Scoop-Dev $dir\\profile\"",
+    "post_install": "firefox-dev -CreateProfile \"Scoop-Dev $persist_dir\\profile\"",
     "bin": [
         [
             "firefox.exe",

--- a/bucket/firefox-nightly.json
+++ b/bucket/firefox-nightly.json
@@ -20,7 +20,7 @@
         }
     },
     "extract_dir": "core",
-    "post_install": "firefox-nightly -CreateProfile \"Scoop-Nightly $dir\\profile\"",
+    "post_install": "firefox-nightly -CreateProfile \"Scoop-Nightly $persist_dir\\profile\"",
     "bin": [
         [
             "firefox.exe",


### PR DESCRIPTION
use $persist_dir instead of $dir in profile path, then profile path can still be used in other versions after uninstalling the apps. (if it is compatible)

- this change only affects fresh installations.
- for users who have generated a scoop portable profile before this update, you will need to manually edit this file **OR** delete it and reinstall the application to change the profile path, if you want use uninstalled app's profile:
```
$HOME\AppData\Roaming\Mozilla\Firefox\profiles.ini
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
