### PR TITLE
Update au.hash in response to Scoop#4619

### DIFF
--- a/bucket/kate.json
+++ b/bucket/kate.json
@@ -27,8 +27,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/kdeconnect.json
+++ b/bucket/kdeconnect.json
@@ -34,8 +34,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/neochat-nightly.json
+++ b/bucket/neochat-nightly.json
@@ -32,8 +32,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/okular-nightly.json
+++ b/bucket/okular-nightly.json
@@ -32,8 +32,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }

--- a/bucket/okular.json
+++ b/bucket/okular.json
@@ -27,8 +27,7 @@
             }
         },
         "hash": {
-            "url": "$url.sha256",
-            "regex": "$sha256"
+            "url": "$url.sha256"
         }
     }
 }


### PR DESCRIPTION
Since https://github.com/ScoopInstaller/Scoop/pull/4619 is now in `master`, we can simplify these manifests.