### PR TITLE
keepassxc2.6.6: Add version 2.6.6

### DIFF
--- a/bucket/keepassxc2.6.6.json
+++ b/bucket/keepassxc2.6.6.json
@@ -1,0 +1,32 @@
+{
+    "version": "2.6.6",
+    "description": "Community fork of KeePass",
+    "homepage": "https://keepassxc.org",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.6.6/KeePassXC-2.6.6-Win64-Portable.zip",
+            "hash": "45a4cd19f02ad617808aa814fac2ed61b59eff467d8c464d94ba5304d7ccabc0",
+            "extract_dir": "KeePassXC-2.6.6-Win64"
+        },
+        "32bit": {
+            "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.6.6/KeePassXC-2.6.6-Win32-Portable.zip",
+            "hash": "afa03c371d55b113322438c53ec217e6ca1bf750bf72881126b93e23e85f83fb",
+            "extract_dir": "KeePassXC-2.6.6-Win32"
+        }
+    },
+    "post_install": "if (Test-Path \"$persist_dir\\keepassxc.ini\") { Move-Item \"$persist_dir\\keepassxc.ini\" \"$dir\\config\" -Force }",
+    "persist": "config",
+    "bin": [
+        "KeePassXC.exe",
+        "keepassxc-cli.exe",
+        "keepassxc-proxy.exe"
+    ],
+    "shortcuts": [
+        [
+            "KeePassXC.exe",
+            "KeePassXC"
+        ]
+    ],
+    "notes": "KeepassXC for 32-bit Windows is no longer supported after v2.6.6, if you are running a 64-bit system, please download `keepassxc` from Scoop Extras bucket."
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to [Extras#8184](https://github.com/ScoopInstaller/Extras/pull/8184)

KeepassXC for 32-bit Windows is no longer supported after v2.6.6, so move keepassxc version v2.6.6 to Version Bucket.

The checkver and autoupdate had been removed.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
