### PR TITLE
Add 1password-cli v1

### DIFF
--- a/bucket/1password-cli1.json
+++ b/bucket/1password-cli1.json
@@ -16,5 +16,5 @@
             "hash": "a8e2ef405af14b8fb3482ed7f8b66a3f1383a2a86062589e3acc6bc446b13006"
         }
     },
-    "bin": [ [ "op.exe", "op1" ] ]
+    "bin": "op.exe"
 }

--- a/bucket/1password-cli1.json
+++ b/bucket/1password-cli1.json
@@ -1,0 +1,20 @@
+{
+    "version": "1.12.4",
+    "description": "The 1Password command-line tool makes your 1Password account accessible entirely from the command line (v1)",
+    "homepage": "https://developer.1password.com/docs/cli/v1/usage",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://1password.com/legal/terms-of-service/"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_amd64_v1.12.4.zip",
+            "hash": "d14b7a864ebabc9b5ed95ea6b13e676a5795ede54b6187b4233249694478b1c9"
+        },
+        "32bit": {
+            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_386_v1.12.4.zip",
+            "hash": "a8e2ef405af14b8fb3482ed7f8b66a3f1383a2a86062589e3acc6bc446b13006"
+        }
+    },
+    "bin": [ [ "op.exe", "op1" ] ]
+}


### PR DESCRIPTION
Version 2 of 1password-cli breaks backward compatibility and introduce new CLI syntax. Having older version available is useful for those who don't want or can't upgrade to version 2 right now.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
