### PR TITLE
tinymediamanager3: Add version 3.1.16.1

### DIFF
--- a/bucket/tinymediamanager3.json
+++ b/bucket/tinymediamanager3.json
@@ -1,0 +1,37 @@
+{
+    "version": "3.1.16.1",
+    "description": "Completely free but older version(v3) of tinyMediaManager, a media management tool written to provide metadata for the Kodi Media Center (formerly known as XBMC), MediaPortal and Plex media server.",
+    "homepage": "https://www.tinymediamanager.org/",
+    "license": {
+        "identifier": "Apache-2.0",
+        "url": "https://github.com/tinyMediaManager/tinyMediaManager/blob/master/LICENSE"
+    },
+    "suggest": {
+        "JRE": "java/openjdk"
+    },
+    "url": "https://release.tinymediamanager.org/v3/dist/tmm_3.1.16.1_win.zip",
+    "hash": "216d841578c5b1199e426d95a22b24e2077d0bb9b67c21717246439e70e4f33e",
+    "bin": "tinyMediaManagerCMD.exe",
+    "shortcuts": [
+        [
+            "tinyMediaManager.exe",
+            "tinyMediaManager"
+        ]
+    ],
+    "persist": [
+        "logs",
+        "data",
+        "cache",
+        "backup"
+    ],
+    "checkver": {
+        "url": "https://release.tinymediamanager.org/",
+        "regex": "v3/dist/tmm_([\\d\\.]+)_win\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://release.tinymediamanager.org/v3/dist/tmm_$version_win.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
* related: https://github.com/ScoopInstaller/Extras/issues/4821

* tinyMediaManager switched to 64-bit in version 4, but it is **32-bit** in version 3.

* **why do we need this package**: From version 4, tinyMediaManager has changed its licensing model from donationware to subscription based. [tinyMediaManager blog](https://www.tinymediamanager.org/blog/v4-future/):
> Since the lion’s share of the work (development, maintenance, deployment, …) remains within the tinyMediaManager team, we decided to charge an annual fee for the ongoing work on the project (starting with v4).

> tinyMediaManager v3 will remain available and free, but only serious bugs will be fixed and no new features will be added. A mandatory upgrade to v4 will not be necessary, but we want to provide an easy transition for users which want to upgrade.

