### PR TITLE
oss-cad-suite-nightly: Add version 2022-03-29

### DIFF
--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -1,0 +1,37 @@
+{
+    "version": "2022-03-29",
+    "description": "Open source digital design and verification tools. Includes tools for RTL synthesis, formal hardware verification, place & route, FPGA programming, and testing with support for HDLs like Verilog, Migen and Amaranth.",
+    "homepage": "https://github.com/YosysHQ/oss-cad-suite-build",
+    "license": "ISC",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2022-03-29/oss-cad-suite-windows-x64-20220329.exe#/dl.7z",
+            "hash": "c2b10a627d960952a969c3cbdc9bf4109b7ee533c8b43a0c06df2c0cf3eacf45"
+        }
+    },
+    "extract_dir": "oss-cad-suite",
+    "pre_install": "Set-Content -Path \"$dir\\start.bat\" -Value \"@cmd /k $dir\\environment.bat\"",
+    "bin": [
+        [
+            "start.bat",
+            "oss-cad"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "start.bat",
+            "OSS CAD Suite"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases",
+        "regex": "tree\\/([\\d-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/$version/oss-cad-suite-windows-x64-$cleanVersion.exe#/dl.7z"
+            }
+        }
+    }
+}

--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2022-03-29",
+    "version": "2022-03-31",
     "description": "Open source digital design and verification tools. Includes tools for RTL synthesis, formal hardware verification, place & route, FPGA programming, and testing with support for HDLs like Verilog, Migen and Amaranth.",
     "homepage": "https://github.com/YosysHQ/oss-cad-suite-build",
     "license": "ISC",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2022-03-29/oss-cad-suite-windows-x64-20220329.exe#/dl.7z",
-            "hash": "c2b10a627d960952a969c3cbdc9bf4109b7ee533c8b43a0c06df2c0cf3eacf45"
+            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2022-03-31/oss-cad-suite-windows-x64-20220331.exe#/dl.7z",
+            "hash": "de3c9525aafd8a0981b31c92a2543744e49108ad79751a028ecb460baf891cf4"
         }
     },
     "extract_dir": "oss-cad-suite",
@@ -15,12 +15,6 @@
         [
             "start.bat",
             "oss-cad"
-        ]
-    ],
-    "shortcuts": [
-        [
-            "start.bat",
-            "OSS CAD Suite"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Adds OSS CAD Suite which only has a nightly release. I would like to add it because Main/yosys is out of date (0.9 while latest is 0.15) and this package includes it and seems to be released by the same people.
- Relates to Excavator failure to update yosys https://github.com/ScoopInstaller/Main/runs/5709628840?check_suite_focus=true#step:3:338 (I will make another PR to add a note to yosys)
- The package includes a batch file that changes the environment variables temporarily for the programs included. I decided to create a shim to that rather than persist the variables permanently because they would override Python, Qt, and GTK variables that other programs use.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
