### PR TITLE
gn: Use first 6 chars of instanceID as version

### DIFF
--- a/bucket/gn.json
+++ b/bucket/gn.json
@@ -1,5 +1,5 @@
 {
-    "version": "qGN3VImiZx7eJqi6ER9-ZPt3RASJhtJm0CgN4oVbAQcC",
+    "version": "qGN3VI",
     "description": "GN is a meta-build system that generates build files for Ninja.",
     "homepage": "https://gn.googlesource.com/gn",
     "license": "BSD-3-Clause",
@@ -16,12 +16,13 @@
     "bin": "gn.exe",
     "checkver": {
         "url": "https://chrome-infra-packages.appspot.com/p/gn/gn/windows-amd64/+/latest",
-        "regex": "Instance ID\\S+\\s+<td class=\"user-select-all\">([\\w-]+)"
+        "regex": "Instance ID\\S+\\s+<td class=\"user-select-all\">(?<instanceId>(?<short>[\\w-]{6})[\\w-]+)",
+        "replace": "${short}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://chrome-infra-packages.appspot.com/dl/gn/gn/windows-amd64/+/$version#/gn-windows-amd64.zip",
+                "url": "https://chrome-infra-packages.appspot.com/dl/gn/gn/windows-amd64/+/$matchInstanceid#/gn-windows-amd64.zip",
                 "hash": {
                     "url": "https://chrome-infra-packages.appspot.com/p/gn/gn/windows-amd64/+/latest",
                     "regex": "<b>SHA256</b>\\S+\\s+<td class=\"user-select-all\">$sha256"


### PR DESCRIPTION
This makes **"version"** more readable and less confusing.
(`qGN3VImiZx7eJqi6ER9-ZPt3RASJhtJm0CgN4oVbAQcC` -> `qGN3VI`)