### PR TITLE
goneovim-nightly: fix version

### DIFF
--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "nightly-e91775f",
+    "version": "nightly-1-ge91775f",
     "description": "Neovim GUI which uses a Golang Qt backend",
     "homepage": "https://github.com/akiyosi/goneovim",
     "license": "MIT",
@@ -24,7 +24,7 @@
         "url": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
         "jsonpath": "$.target_commitish",
         "regex": "([0-9a-f]{7}).*",
-        "replace": "nightly-${1}"
+        "replace": "nightly-1-g${1}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

gooneovim-nightly will set the output of `git describe --tags` to the version.
refs: https://github.com/akiyosi/goneovim/blob/master/.github/workflows/ci.yaml#L87

`git describe --tags` will output the following format

```
<tagname>-<the number of additional commits>-g<commit hash>
```

refs: https://git-scm.com/docs/git-describe

Since goneovim-nightly builds HEAD, the number of additional commits is `1`. Therefore, the version should be set to `nightly-1-g<commit hash>`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
