### PR TITLE
goneovim: Change version to nightly

### DIFF
--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "nightly-1-geebb6c0",
+    "version": "nightly",
     "description": "Neovim GUI which uses a Golang Qt backend",
     "homepage": "https://github.com/akiyosi/goneovim",
     "license": "MIT",
@@ -8,8 +8,7 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows.zip",
-            "hash": "db29b1a1e2364ee2ac3447200478bbae2219548e825c45544b7fe1e59d2c6e81"
+            "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows.zip"
         }
     },
     "extract_dir": "goneovim-windows",
@@ -19,18 +18,5 @@
             "goneovim.exe",
             "Goneovim-nightly"
         ]
-    ],
-    "checkver": {
-        "url": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
-        "jsonpath": "$.target_commitish",
-        "regex": "([0-9a-f]{7}).*",
-        "replace": "nightly-1-g${1}"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows.zip"
-            }
-        }
-    }
+    ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The goneovim nightly version does not work well with automatic updates because the binary is updated even if the hash commit does not change.
Therefore, change the version to nightly.

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
