### PR TITLE
ferdium-nightly: fix failed hash verification

### DIFF
--- a/bucket/ferdium-nightly.json
+++ b/bucket/ferdium-nightly.json
@@ -3,7 +3,7 @@
     "description": "All-in-one messaging apps for various services",
     "homepage": "https://github.com/ferdium/ferdium-app",
     "license": "Apache-2.0",
-    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.9/Ferdium-6.0.0-nightly.9.exe#/dl.7z",
+    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.9/Ferdium-Setup-6.0.0-nightly.9.exe#/dl.7z",
     "hash": "sha512:8ebe86212e6a85cb09c47bd3bae6fe309c92beb1e03c4a962dc4d730e9b32c3c8dbf0d68febe0a4c74b772966826da481083b16926b4bc38c229c77827e3299b",
     "architecture": {
         "64bit": {
@@ -17,7 +17,7 @@
             }
         }
     },
-    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse -Force",
+    "post_install": "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\Uninstall*.exe\" -Recurse -Force",
     "shortcuts": [
         [
             "Ferdium.exe",
@@ -29,7 +29,7 @@
         "regex": "/releases/tag/(?:v|V)?([\\d\\-nightly.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-$version.exe#/dl.7z",
+        "url": "https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-Setup-$version.exe#/dl.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512:\\s+$base64"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
### Description
`$baseurl/latest.yml` only have hashes for `Ferdium-Setup-$version.exe` and not `Ferdium-$version.exe`. This PR switches the manifest to using the setup executable, so we can take advantage of hash extraction.

Related to #497

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
