### PR TITLE
kdenlive-nightly: Add version 1116

### DIFF
--- a/bucket/kdenlive-nightly.json
+++ b/bucket/kdenlive-nightly.json
@@ -1,0 +1,33 @@
+{
+    "version": "1116",
+    "description": "Video editing software based on the MLT Framework, KDE and Qt",
+    "homepage": "https://kdenlive.org",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/lastSuccessfulBuild/artifact/kdenlive-master-1116-windows-mingw_64-gcc.7z",
+            "hash": "e1255f4e743a7b620d342d2041b034564333a70d426acdbf7bb79d4bba18a098"
+        }
+    },
+    "bin": "bin\\kdenlive.exe",
+    "shortcuts": [
+        [
+            "bin\\kdenlive.exe",
+            "Kdenlive Nightly"
+        ]
+    ],
+    "checkver": {
+        "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/",
+        "regex": "kdenlive-master-(\\d+)-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/lastSuccessfulBuild/artifact/kdenlive-master-$version-windows-mingw_64-gcc.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Adds Nightly version of Kdenlive in extras.
- Similar to okular-nightly: https://github.com/ScoopInstaller/Versions/blob/master/bucket/okular-nightly.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
