### PR TITLE
dotnet3-sdk: Update to v3.1.418, fix checkver

### DIFF
--- a/bucket/dotnet3-sdk.json
+++ b/bucket/dotnet3-sdk.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.417",
+    "version": "3.1.418",
     "homepage": "https://www.microsoft.com/net/",
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
     "license": "MIT",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.1.417/dotnet-sdk-3.1.417-win-x64.zip",
-            "hash": "sha512:df5d31b18062fb4fda710b27d951be3a5957b2515d8694151c6e7488a70edef85452a0810efbbc4ee81e05ba59f686fd682a5345286222cf0627401aacfb1d8a"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.1.418/dotnet-sdk-3.1.418-win-x64.zip",
+            "hash": "sha512:dc8193daab7229e3728c3958060c902e58407218bfaf7b35f984f32713584a6b933df3e03cf36f3fd152d778f4e072ee9dd8d7d7c7429804b72d50bfbc319a0c"
         },
         "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.1.417/dotnet-sdk-3.1.417-win-x86.zip",
-            "hash": "sha512:94ea50191270f20d9ca7426d66e3fc8a2bfa6bd21eaa90f457ba81c2e1ae37aae227e5359c889eaef47d9188a776121c1ecdf54ca3c8d2c3c54e6e1fc1ae6541"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/3.1.418/dotnet-sdk-3.1.418-win-x86.zip",
+            "hash": "sha512:b05f7e9a773ffca3dcaace324d72e4f9c0b63a3b8da28dd072e44b4c6a2c6b1f501f3eed28255c1d25263c1ad89489620e4d6e05de7a1965c5b11cf9ee23e978"
         }
     },
     "bin": "dotnet.exe",
@@ -23,8 +23,8 @@
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
     "checkver": {
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
-        "regex": "(?s)(?<rtv>[\\d.]+)[^\\d]*?(3[\\d.]+)[^\\d]*?NET"
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/3.1/releases.json",
+        "regex": "runtime\": \"(?<runtimever>[\\d.]+)\",\\s+\"latest-sdk\": \"([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {
@@ -36,7 +36,7 @@
             }
         },
         "hash": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$matchRtv-sha.txt"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$matchRuntimever-sha.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update: https://github.com/ScoopInstaller/Versions/runs/6296827221?check_suite_focus=true#step:3:196

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
