### PR TITLE
ffmpeg-yt-dlp: Add version 5.0.1-5-20220504

### DIFF
--- a/bucket/ffmpeg-yt-dlp.json
+++ b/bucket/ffmpeg-yt-dlp.json
@@ -1,0 +1,59 @@
+{
+    "version": "5.0.1-5-20220504",
+    "description": "FFMpeg builds of latest release branch with patches necessary for smooth integration with yt-dlp",
+    "homepage": "https://github.com/yt-dlp/FFmpeg-Builds",
+    "license": "MIT",
+    "suggest": {
+        "yt-dlp": "yt-dlp"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2022-05-04-13-04/ffmpeg-n5.0.1-5-g85c24fbda1-win64-gpl-5.0.zip",
+            "hash": "58d46ca105f0a2a1774c6e76a6472daf6285cdf402cc1f42253288a6a4ad4250",
+            "extract_dir": "ffmpeg-n5.0.1-5-g85c24fbda1-win64-gpl-5.0"
+        },
+        "32bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2022-05-04-13-04/ffmpeg-n5.0.1-5-g0d03b17ca7-win32-gpl-5.0.zip",
+            "hash": "4c4da08c03f50193803d2eebd9f7d3977a5af1a86384b3d72a065148aa54090a",
+            "extract_dir": "ffmpeg-n5.0.1-5-g0d03b17ca7-win32-gpl-5.0"
+        }
+    },
+    "bin": [
+        "bin\\ffmpeg.exe",
+        "bin\\ffplay.exe",
+        "bin\\ffprobe.exe"
+    ],
+    "checkver": {
+        "script": [
+            "# 32-bit file is either listed above or below the 64-bit one. Therefore we need a checkver script to match it.",
+            "$url = 'https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases'",
+            "$regex_64bit = 'autobuild-(?<buildtime>(?<builddate>\\d{4}-\\d{2}-\\d{2})-\\d{2}-\\d{2})/(?<filename>ffmpeg-n(?<ffmpegver>[\\d.-]+)-\\w+-win64-gpl-[\\d.]+)\\.zip'",
+            "$regex_32bit = $regex_64bit.replace('win64', 'win32')",
+            "$cont = $(Invoke-WebRequest($url)).Content | ConvertFrom-Json",
+            "$file_urls = @()",
+            "$cont[1].assets | ForEach-Object { $file_urls += $_.browser_download_url }",
+            "$file_urls | ForEach-Object {",
+            "    if ($_ -match $regex_64bit) {",
+            "        $ffmpegver = $matches.ffmpegver",
+            "        $buildtime = $matches.buildtime",
+            "        $builddate = $matches.builddate.Replace('-', '')",
+            "        $filename64bit = $matches.filename",
+            "    } elseif ($_ -match $regex_32bit) { $filename32bit = $matches.filename }",
+            "}",
+            "Write-Output $ffmpegver-$builddate $buildtime $filename64bit $filename32bit"
+        ],
+        "regex": "([\\w.-]+) (?<buildtime>[\\w.-]+) (?<filename64bit>[\\w.-]+) (?<filename32bit>[\\w.-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/$matchFilename64bit.zip",
+                "extract_dir": "$matchFilename64bit"
+            },
+            "32bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/$matchFilename32bit.zip",
+                "extract_dir": "$matchFilename32bit"
+            }
+        }
+    }
+}


### PR DESCRIPTION
supersedes https://github.com/ScoopInstaller/Main/pull/3549
closes https://github.com/ScoopInstaller/Extras/issues/7788

**NOTES**:
* The repo provides both latest **master** and **release** branches of *FFMpeg*. I choose the release branch because it is more stable.
* Stability of the url / hash: I think it is safe to add this to the bucket because:
    (1) Each new build is now put in a new release tag.
    (2) Links for old builds are still valid.
See [release page](https://github.com/yt-dlp/FFmpeg-Builds/releases) for details.