### PR TITLE
arduino-ide-rc: Add version 2.0.0-rc6

### DIFF
--- a/bucket/arduino-ide-rc.json
+++ b/bucket/arduino-ide-rc.json
@@ -1,0 +1,29 @@
+{
+    "version": "2.0.0-rc6",
+    "description": "Official Arduino IDE (Release Candidate)",
+    "homepage": "https://github.com/arduino/arduino-ide",
+    "license": "AGPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/arduino/arduino-ide/releases/download/2.0.0-rc6/arduino-ide_2.0.0-rc6_Windows_64bit.zip",
+            "hash": "d9dbe1a3193d762ffb89ed28459515ec86dd3a85742197f2099c3a111389fecd"
+        }
+    },
+    "shortcuts": [
+        [
+            "Arduino IDE.exe",
+            "Arduino IDE"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/arduino/arduino-ide/releases",
+        "regex": "tag/([\\d.]+(-rc\\d+)?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/arduino/arduino-ide/releases/download/$version/arduino-ide_$version_Windows_64bit.zip"
+            }
+        }
+    }
+}

--- a/bucket/arduino-ide-rc.json
+++ b/bucket/arduino-ide-rc.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.0-rc6",
     "description": "Official Arduino IDE (Release Candidate)",
-    "homepage": "https://github.com/arduino/arduino-ide",
+    "homepage": "https://www.arduino.cc/en/software",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {


### PR DESCRIPTION
closes #504

This adds [Arduino IDE](https://www.arduino.cc/en/software) version 2.0 (currently in RC stage)

**NOTES**:
* The stable version (version 1.8.19) exists in *Extras* bucket. (`extras/arduino`).
* I named the package as `arduino-ide` rather than `arduino` because the repo name for ver 2.0 is ["arduino-ide"](https://github.com/arduino/arduino-ide).
* *persist* is not needed because config is at `$Env:AppData\Arduino IDE`.
* [stable.yml](https://github.com/arduino/arduino-ide/releases/download/2.0.0-rc6/stable.yml) only contains SHA-512 hash for exe installer, but not for the ZIP file.