### PR TITLE
greenshot-unstable: Update to 1.3.249, fix checkver

### DIFF
--- a/bucket/greenshot-unstable.json
+++ b/bucket/greenshot-unstable.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.3.220",
+    "version": "1.3.249",
     "description": "Light-weight screenshot software.",
     "homepage": "https://getgreenshot.org",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.220/Greenshot-INSTALLER-1.3.220-UNSTABLE.exe",
-    "hash": "35c755bba5786ad397e5a11b4f4520ebbc8a8229aeb39819889eef5cff0fa01c",
+    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.249/Greenshot-INSTALLER-1.3.249-UNSTABLE.exe",
+    "hash": "66b5c99d23ddd381f03bf511bf4ad7ac283849afb2b65ef8355b1ccbaa07de63",
     "innosetup": true,
     "pre_install": "if (!(Test-Path \"$persist_dir\\greenshot.ini\")) { New-Item -ItemType File \"$dir\\greenshot.ini\" | Out-Null }",
     "bin": "Greenshot.exe",
@@ -16,7 +16,7 @@
     ],
     "persist": "greenshot.ini",
     "checkver": {
-        "url": "https://getgreenshot.org/version-history",
+        "url": "https://getgreenshot.org/version-history/",
         "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE"
     },
     "autoupdate": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update due to lack of trailing slash in url: https://github.com/ScoopInstaller/Versions/runs/6384644377?check_suite_focus=true#step:3:196
- Was stuck at release from 16 Dec 2021: https://github.com/greenshot/greenshot/releases/tag/v1.3.220

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
