### PR TITLE
helm2: Update to version 2.17.0, fix checkver

### DIFF
--- a/bucket/helm2.json
+++ b/bucket/helm2.json
@@ -17,19 +17,5 @@
             "helm.exe",
             "helm2"
         ]
-    ],
-    "checkver": {
-        "url": "https://api.github.com/repos/helm/helm/tags?per_page=100",
-        "regex": "tags/v(2\\.[\\d.]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://get.helm.sh/helm-v$version-windows-amd64.zip"
-            }
-        },
-        "hash": {
-            "url": "$url.sha256"
-        }
-    }
+    ]
 }

--- a/bucket/helm2.json
+++ b/bucket/helm2.json
@@ -2,11 +2,12 @@
     "homepage": "https://helm.sh",
     "description": "The package manager for Kubernetes",
     "license": "Apache-2.0",
-    "version": "2.16.12",
+    "notes": "Helm 2 reached End of Life on November 13, 2020. To migrate to v3, read the guide here: https://helm.sh/docs/topics/v2_v3_migration/",
+    "version": "2.17.0",
     "architecture": {
         "64bit": {
-            "url": "https://get.helm.sh/helm-v2.16.12-windows-amd64.zip",
-            "hash": "7be170892b6fa4980c2fb119677ac1651bf663490590bad0cfd6c5f88274528d"
+            "url": "https://get.helm.sh/helm-v2.17.0-windows-amd64.zip",
+            "hash": "048147ef523f88753ba34170f2f6acd01ac6ec688c6f5973b0e5ffb0b113a232"
         }
     },
     "extract_dir": "windows-amd64",
@@ -18,8 +19,8 @@
         ]
     ],
     "checkver": {
-        "github": "https://github.com/kubernetes/helm",
-        "regex": "tag/v(2\\.[\\d.]+)"
+        "url": "https://api.github.com/repos/helm/helm/tags?per_page=100",
+        "regex": "tags/v(2\\.[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update: https://github.com/ScoopInstaller/Versions/runs/6384644377?check_suite_focus=true#step:3:227
- Added End of Life note.
- Should we remove checkver too?

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
