### PR TITLE
msys2-20200517: Remove checkver

### DIFF
--- a/bucket/msys2-20200517.json
+++ b/bucket/msys2-20200517.json
@@ -58,19 +58,5 @@
         ]
     ],
     "persist": "home",
-    "notes": "Please run 'msys2' now for the MSYS2 setup to complete!",
-    "checkver": {
-        "url": "https://github.com/msys2/msys2-installer",
-        "regex": "\/releases\/tag\/(?:v|V)?([\\d.-]+)"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/msys2/msys2-installer/releases/download/$version/msys2-base-x86_64-$cleanVersion.tar.xz"
-            },
-            "32bit": {
-                "url": "https://github.com/msys2/msys2-installer/releases/download/$version/msys2-base-i686-$cleanVersion.tar.xz"
-            }
-        }
-    }
+    "notes": "Please run 'msys2' now for the MSYS2 setup to complete!"
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator looking for updates despite the fact this app shouldn't be updated as higher versions do not have a 32bit release. See: https://github.com/ScoopInstaller/Versions/pull/209
> This PR adds version 20200517 of msys2 as requested, which is the last version that includes i686 package.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
