### PR TITLE
dataspell-eap: Update to 2022.1-221.4994.58, fix autoupdate

### DIFF
--- a/bucket/dataspell-eap.json
+++ b/bucket/dataspell-eap.json
@@ -1,5 +1,5 @@
 {
-    "version": "2021.3-213.5352.7",
+    "version": "2022.1-221.4994.58",
     "description": "Cross-Platform IDE for Data Scientists by JetBrains. (Early Access Program)",
     "homepage": "https://www.jetbrains.com/dataspell/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://download.jetbrains.com/python/data-spell-213.5352.7.exe#/dl.7z",
-            "hash": "9e0b3e53850db0d5ea4a9b49ae5c487f807ae96a2f69eec4cb188fb82a94e29b",
+            "url": "https://download.jetbrains.com/python/dataspell-221.4994.58.exe#/dl.7z",
+            "hash": "18165f9fa85aedc61a2eba8b34a83832d8f18099b7d784906bc942df28c7a0ad",
             "shortcuts": [
                 [
                     "IDE\\bin\\dataspell64.exe",
@@ -37,7 +37,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://download.jetbrains.com/python/data-spell-$preReleaseVersion.exe#/dl.7z"
+                "url": "https://download.jetbrains.com/python/dataspell-$preReleaseVersion.exe#/dl.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Excavator unable to update due to file url change: https://github.com/ScoopInstaller/Versions/runs/6384644377?check_suite_focus=true#step:3:263

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
