### PR TITLE
dotnet5-sdk: Update to v5.0.408, fix checkver

### DIFF
--- a/bucket/dotnet5-sdk.json
+++ b/bucket/dotnet5-sdk.json
@@ -1,5 +1,5 @@
 {
-    "version": "5.0.407",
+    "version": "5.0.408",
     "homepage": "https://www.microsoft.com/net/",
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
     "license": "MIT",
@@ -8,12 +8,12 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.407/dotnet-sdk-5.0.407-win-x64.zip",
-            "hash": "sha512:13ae5ecad3633844da8ad224445e2be9bc604c3adb80ccaf433c30fc0cce955492f0fa80a394831b41e30b7dbba3992b92500e10ba55a19ba1b8f95758610aa8"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.408/dotnet-sdk-5.0.408-win-x64.zip",
+            "hash": "sha512:3845485401695b325d9afee67e33c6b3a45902476e408dd74ebc8815ad2c4f4b5d70a6b993e87ff587d0d9b0e5a3d66eaf3dd6bf715b0012ffee70501a716485"
         },
         "32bit": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.407/dotnet-sdk-5.0.407-win-x86.zip",
-            "hash": "sha512:caa091439a238e8172253ad43c7d63676d49796aaee83377005c9f3626344c5a2fcb9289285c621041103c4f2b854d8fe78e95e700dfd5d913a5da2feb04d4c9"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/5.0.408/dotnet-sdk-5.0.408-win-x86.zip",
+            "hash": "sha512:a942c354eabed62a4ceb8aaea48664235c9627e818c18504ea482a6a9eb8400b1744f7c40e24bae8e50a665aff20f66a7e378dfa4018c08fb76fa883ce85a8f7"
         }
     },
     "bin": "dotnet.exe",
@@ -23,8 +23,8 @@
         "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
     },
     "checkver": {
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
-        "regex": "(?s)(?<rtv>[\\d.]+)[^\\d]*?(5[\\d.]+)[^\\d]*?NET"
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/5.0/releases.json",
+        "regex": "runtime\": \"(?<runtimever>[\\d.]+)\",\\s+\"latest-sdk\": \"([\\d.]+)\""
     },
     "autoupdate": {
         "architecture": {
@@ -36,7 +36,7 @@
             }
         },
         "hash": {
-            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$matchRtv-sha.txt"
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/checksums/$matchRuntimever-sha.txt"
         }
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator unable to update: https://github.com/ScoopInstaller/Versions/runs/6413290805?check_suite_focus=true#step:3:207

- Based on checkver from dotnet3-sdk: https://github.com/ScoopInstaller/Versions/blob/master/bucket/dotnet3-sdk.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
