### PR TITLE
openssl10|-light: Rename to openssl1 and update to 1.1.1o

### DIFF
--- a/bucket/openssl1-light.json
+++ b/bucket/openssl1-light.json
@@ -1,19 +1,19 @@
 {
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
-    "version": "1.0.2u",
+    "version": "1.1.1o",
     "license": {
         "identifier": "OpenSSL|SSLeay",
         "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
     },
-    "description": "TLS/SSL toolkit (1.0.x branch)",
+    "description": "TLS/SSL toolkit (Light, 1.x branch)",
     "architecture": {
         "32bit": {
-            "url": "https://slproweb.com/download/Win32OpenSSL-1_0_2u.exe",
-            "hash": "c0ad49f6b37f94408f954fa69065fa2db61c00ebfc211d946c1070e8ba8ec801"
+            "url": "https://slproweb.com/download/Win32OpenSSL_Light-1_1_1o.exe",
+            "hash": "ce0813ffb38de8eae398c41b5b3f1e24e5b89fc0e005cbfb3d229ae960433238"
         },
         "64bit": {
-            "url": "https://slproweb.com/download/Win64OpenSSL-1_0_2u.exe",
-            "hash": "46ec55a9227b0ce8a7e332bae0363d9d765c721d4a233830f8177f06170c0de0"
+            "url": "https://slproweb.com/download/Win64OpenSSL_Light-1_1_1o.exe",
+            "hash": "a43e2d90ee7dd16e5076e553530a2dacf646fa8d96639ec37714c25f79947c63"
         }
     },
     "innosetup": true,
@@ -21,14 +21,14 @@
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\openssl.cfg"
     },
-    "checkver": ">Win32 OpenSSL v(1\\.0\\.[\\w]+)<",
+    "checkver": "Win32 OpenSSL v(1\\.[\\d.\\w]+)\\s+Light<",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://slproweb.com/download/Win64OpenSSL-$underscoreVersion.exe"
+                "url": "https://slproweb.com/download/Win64OpenSSL_Light-$underscoreVersion.exe"
             },
             "32bit": {
-                "url": "https://slproweb.com/download/Win32OpenSSL-$underscoreVersion.exe"
+                "url": "https://slproweb.com/download/Win32OpenSSL_Light-$underscoreVersion.exe"
             }
         },
         "hash": {

--- a/bucket/openssl1.json
+++ b/bucket/openssl1.json
@@ -1,19 +1,19 @@
 {
     "homepage": "https://slproweb.com/products/Win32OpenSSL.html",
-    "version": "1.0.2u",
+    "version": "1.1.1o",
     "license": {
         "identifier": "OpenSSL|SSLeay",
         "url": "https://www.openssl.org/source/license-openssl-ssleay.txt"
     },
-    "description": "TLS/SSL toolkit (Light, 1.0.x branch)",
+    "description": "TLS/SSL toolkit (1.x branch)",
     "architecture": {
         "32bit": {
-            "url": "https://slproweb.com/download/Win32OpenSSL_Light-1_0_2u.exe",
-            "hash": "74b35d33970414a9cb67b08240ace398250666653a321878b2334215e0dd2bfd"
+            "url": "https://slproweb.com/download/Win32OpenSSL-1_1_1o.exe",
+            "hash": "d670a9133ae04c09283fd998867a5a0a30db200734a0d228eb4b2975cb500cd4"
         },
         "64bit": {
-            "url": "https://slproweb.com/download/Win64OpenSSL_Light-1_0_2u.exe",
-            "hash": "17790d32ac17d43cabe77c2542a586f95b2741f9dcf8a043e95bf9a834718047"
+            "url": "https://slproweb.com/download/Win64OpenSSL-1_1_1o.exe",
+            "hash": "c28c9a4bab0095d4eeb24e6697b3d4867857bfbef32243817667a9cfa20c546d"
         }
     },
     "innosetup": true,
@@ -21,14 +21,14 @@
     "env_set": {
         "OPENSSL_CONF": "$dir\\bin\\openssl.cfg"
     },
-    "checkver": ">Win32 OpenSSL v(1\\.0\\.[\\w]+)\\s+Light<",
+    "checkver": "Win32 OpenSSL v(1\\.[\\d.\\w]+)<",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://slproweb.com/download/Win64OpenSSL_Light-$underscoreVersion.exe"
+                "url": "https://slproweb.com/download/Win64OpenSSL-$underscoreVersion.exe"
             },
             "32bit": {
-                "url": "https://slproweb.com/download/Win32OpenSSL_Light-$underscoreVersion.exe"
+                "url": "https://slproweb.com/download/Win32OpenSSL-$underscoreVersion.exe"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to #524
- OpenSSL 1.x branch is now higher than 1.0 so the manifests needed to be renamed and the checkvers needed to be fixed

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
