### PR TITLE
musescore-nightly: Update to version 202205130439

### DIFF
--- a/bucket/musescore-nightly.json
+++ b/bucket/musescore-nightly.json
@@ -1,40 +1,42 @@
 {
-    "version": "2020-09-21-0924-master-5dabcda",
+    "version": "202205130439",
     "description": "Music notation editor with an easy-to-use WYSIWYG interface.",
     "homepage": "https://musescore.org/",
-    "license": "GPL-2.0-only",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/MuseScoreNightly-2020-09-21-0924-master-5dabcda-x86_64.7z",
-            "hash": "8ff2f9ea6b575f3364125662dfb7749ade9ce1a321e28368047448f412686903"
+            "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/4x/nightly/MuseScoreNightly-202205130439-master-001f7a6-x86_64.7z",
+            "hash": "98648b446bd40188d2687335b4ad5861b6650241e68aee37631218d40e511eff"
         }
     },
-    "extract_dir": "MuseScoreNightly",
+    "extract_dir": "MuseScoreNightly-202205130439-master-001f7a6-x86_64",
     "bin": [
         [
-            "bin\\nightly.exe",
+            "bin\\MuseScore4.exe",
             "MuseScore"
         ],
         [
-            "bin\\nightly.exe",
+            "bin\\MuseScore4.exe",
             "mscore"
         ]
     ],
     "shortcuts": [
         [
-            "bin\\nightly.exe",
-            "MuseScore"
+            "bin\\MuseScore4.exe",
+            "MuseScore Nightly"
         ]
     ],
     "checkver": {
-        "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/",
-        "regex": "MuseScoreNightly-([\\w-]+)-x86_64\\.7z"
+        "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/4x/nightly/",
+        "regex": "MuseScoreNightly-(\\d+)-master-(?<tag>[a-f0-9]+)-x86_64\\.7z",
+        "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/MuseScoreNightly-$version-x86_64.7z"
+                "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/4x/nightly/MuseScoreNightly-$version-master-$matchTag-x86_64.7z"
             }
-        }
+        },
+        "extract_dir": "MuseScoreNightly-$version-master-$matchTag-x86_64"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Relates to Excavator stuck on version from 2020! https://github.com/ScoopInstaller/Versions/runs/6413290805?check_suite_focus=true#step:3:245
- Fixed checkver and autoupdate
- Fixed bin and shortcuts file name
- Added extract_dir to autoupdate
- Updated license to GPL 3

- Will need to be updated once 5.x branch begins releases, I will also make a PR for the 3.x nightly

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
