### PR TITLE
musescore3-nightly: Add version 202205130434

### DIFF
--- a/bucket/musescore3-nightly.json
+++ b/bucket/musescore3-nightly.json
@@ -1,0 +1,42 @@
+{
+    "version": "202205130434",
+    "description": "Music notation editor with an easy-to-use WYSIWYG interface.",
+    "homepage": "https://musescore.org/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/3x/nightly/MuseScoreNightly-202205130434-3.x-2513676-x86_64.7z",
+            "hash": "5b6d6bd505a72b76c04d6333da55b91d180d9d0769b1b3018227feeaaf3d0d35"
+        }
+    },
+    "extract_dir": "MuseScoreNightly-202205130434-3.x-2513676-x86_64",
+    "bin": [
+        [
+            "bin\\MuseScore3.exe",
+            "MuseScore"
+        ],
+        [
+            "bin\\MuseScore3.exe",
+            "mscore"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\MuseScore3.exe",
+            "MuseScore 3 Nightly"
+        ]
+    ],
+    "checkver": {
+        "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/3x/nightly/",
+        "regex": "MuseScoreNightly-(\\d+)-3.x-(?<tag>[a-f0-9]+)-x86_64\\.7z",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://ftp.osuosl.org/pub/musescore-nightlies/windows/3x/nightly/MuseScoreNightly-$version-3.x-$matchTag-x86_64.7z"
+            }
+        },
+        "extract_dir": "MuseScoreNightly-$version-3.x-$matchTag-x86_64"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #526 where I said I would add this version too. Both this branch and the latest branch are offered on the development builds page: https://ftp.osuosl.org/pub/musescore-nightlies/. It's based on the `musescore-nightly` manifest. Sadly no hash extraction.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
