### PR TITLE
ngrok2: Add version 2.3.40

### DIFF
--- a/bucket/ngrok2.json
+++ b/bucket/ngrok2.json
@@ -1,0 +1,38 @@
+{
+    "version": "2.3.40",
+    "description": "Spend more time programming. One command for an instant, secure URL to your localhost server through any NAT or firewall.",
+    "homepage": "https://ngrok.com/",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://ngrok.com/tos"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://bin.equinox.io/a/8exBtGpBr59/ngrok-2.3.40-windows-amd64.zip",
+            "hash": "778cbe4d5f1c868a5687a97206bf39b017a76fc44eaead95a11cf8a415c2e505"
+        },
+        "32bit": {
+            "url": "https://bin.equinox.io/a/cfjNxTRk1tM/ngrok-2.3.40-windows-386.zip",
+            "hash": "c1f32114f71fb05cf4f66e5c9a49f2d451891990f9e75f56b3dd8bb2cff520f4"
+        }
+    },
+    "bin": "ngrok.exe",
+    "checkver": {
+        "url": "https://dl.equinox.io/ngrok/ngrok/stable/archive",
+        "regex": "/a/(?<hash64bit>\\w+)/ngrok-([\\d.]+)-windows-amd64.zip(?:.|\\n)+?/a/(?<hash32bit>\\w+)/ngrok-([\\d.]+)-windows-386.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://bin.equinox.io/a/$matchHash64bit/ngrok-$version-windows-amd64.zip"
+            },
+            "32bit": {
+                "url": "https://bin.equinox.io/a/$matchHash32bit/ngrok-$version-windows-386.zip"
+            }
+        },
+        "hash": {
+            "url": "https://dl.equinox.io/ngrok/ngrok/stable/archive",
+            "regex": "$url(?:.|\\n)+?value=\"(\\w+)"
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Main/issues/3603.

ngrok version 3 has breaking changes listed here: https://ngrok.com/docs/guides/upgrade-v2-v3. For that reason it would be good to keep the 2.x branch in case anyone needs it. I haven't found any documentation that says v2 is no longer receiving updates so I've left the original checkver/autoupdate.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
