### PR TITLE
de4dot: Add version 3.1.41592.3405

### DIFF
--- a/bucket/de4dot-net35.json
+++ b/bucket/de4dot-net35.json
@@ -1,0 +1,21 @@
+{
+    "version": "3.1.41592.3405",
+    "description": ".NET deobfuscator and unpacker. (for .NET 3.5 applications)",
+    "homepage": "https://github.com/de4dot/de4dot",
+    "license": "GPL-3.0-or-later",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/de4dot/de4dot-net35.zip",
+    "hash": "edfa47b3c2d6367a7aca5ac51d0fa12a9a7d809f689acdf7a6466895e2bce9e6",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "de4dot-x64.exe",
+                    "de4dot"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "de4dot.exe"
+        }
+    }
+}

--- a/bucket/de4dot-net45.json
+++ b/bucket/de4dot-net45.json
@@ -1,0 +1,21 @@
+{
+    "version": "3.1.41592.3405",
+    "description": ".NET deobfuscator and unpacker. (for .NET 4.5 applications)",
+    "homepage": "https://github.com/de4dot/de4dot",
+    "license": "GPL-3.0-or-later",
+    "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/de4dot/de4dot-net45.zip",
+    "hash": "2d8942d0a63fab2d8e78827488c5cb7e2b6a8108ab2e5c3194359779a611f5ba",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                [
+                    "de4dot-x64.exe",
+                    "de4dot"
+                ]
+            ]
+        },
+        "32bit": {
+            "bin": "de4dot.exe"
+        }
+    }
+}

--- a/bucket/de4dot-netcoreapp3.1.json
+++ b/bucket/de4dot-netcoreapp3.1.json
@@ -1,0 +1,13 @@
+{
+    "version": "3.1.41592.3405",
+    "description": ".NET deobfuscator and unpacker. (for .NET Core 3.1 applications)",
+    "homepage": "https://github.com/de4dot/de4dot",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/de4dot/de4dot-netcoreapp3.1.zip",
+            "hash": "a74ad2e188fcf0d32fda33011a3d812eaca27649c9c3e87d80ef0fdaac8193b1"
+        }
+    },
+    "bin": "de4dot.exe"
+}


### PR DESCRIPTION
**[de4dot](https://github.com/de4dot/de4dot)** is a .NET deobfuscator and unpacker. It is now archived, but still [being used by some projects](https://github.com/de4dot/de4dot/network/dependents?package_id=UGFja2FnZS0xNTc3NDA1NTg%3D).

* There are 3 variants of the app (for different .NET versions). I put all of them in `Versions` bucket because I am not sure which one should be considered the **"main"** one.

* `de4dot-net35` and `de4dot-net45` provides both **32-bit** and **64-bit** binaries, but `de4dot-netcoreapp3.1` only has the 64-bit one.

* The version number `3.1.41592.3405` can be found either in **file info** of the executable, or [build config file](https://github.com/de4dot/de4dot/blob/master/De4DotCommon.props).

* *de4dot* provides pre-built binaries via Github actions, but it is **no longer reachable** since the actions are outdated. I built the binaries by the following steps:
    (1) Fork [the repo](https://github.com/de4dot/de4dot).
    (2) Install Visual Studio 2022 with *MSBuild* and *VS2015 build tools* on my local computer.
    (3) Run the build action with [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners). Note that local-side programs should run under **VS Developer command prompt** or **VS Developer Powershell**.