### PR TITLE
processhacker-nightly: Update to version 3.0.4953, Update checkver

### DIFF
--- a/bucket/processhacker-nightly.json
+++ b/bucket/processhacker-nightly.json
@@ -1,17 +1,17 @@
 {
-    "version": "3.0.4905",
+    "version": "3.0.4953",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://processhacker.sourceforge.io/nightly.php",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/v3.0.4905/processhacker-3.0.4905-bin.zip",
-            "hash": "56a35bf65e5c88cc52f9c93678dd44770f3f3b61d066436addde6fd91997e34c",
+            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/3.0.4953/processhacker-3.0.4953-bin.zip",
+            "hash": "a5c3eecb80afc94cd28511dbca55b297dbd414ec061d309b1777730bbd8933ea",
             "extract_dir": "64bit"
         },
         "32bit": {
-            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/v3.0.4905/processhacker-3.0.4905-bin.zip",
-            "hash": "56a35bf65e5c88cc52f9c93678dd44770f3f3b61d066436addde6fd91997e34c",
+            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/3.0.4953/processhacker-3.0.4953-bin.zip",
+            "hash": "a5c3eecb80afc94cd28511dbca55b297dbd414ec061d309b1777730bbd8933ea",
             "extract_dir": "32bit"
         }
     },

--- a/bucket/processhacker-nightly.json
+++ b/bucket/processhacker-nightly.json
@@ -38,9 +38,9 @@
     ],
     "checkver": {
         "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases",
-        "regex": "/tag/v([\\d.]+)"
+        "regex": "/tag/([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/v$version/processhacker-$version-bin.zip"
+        "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/$version/processhacker-$version-bin.zip"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

They removed the `v` prefix in tags starting with https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/tag/3.0.4922.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
