### PR TITLE
odin: Update version, fix autoupdate url, and change name to odin-dev

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -1,11 +1,11 @@
 {
-    "version": "2022-03",
+    "version": "2022-06",
     "description": "General-purpose programming language with distinct typing, built for high performance, modern systems, and built-in data-oriented data types.",
     "homepage": "https://odin-lang.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2022-03/odin-windows-dev-2022-03.zip",
+            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2022-06/odin-windows-amd64-dev-2022-06.zip",
             "hash": "ace2fc652e1d0b5b7292a8fdce086b8244b11752a65ee7d33b6f474f5b557449"
         }
     },
@@ -17,7 +17,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/odin-lang/Odin/releases/download/dev-$version/odin-windows-dev-$version.zip"
+                "url": "https://github.com/odin-lang/Odin/releases/download/dev-$version/odin-windows-amd64-dev-$version.zip"
             }
         }
     }

--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,6 +9,7 @@
             "hash": "71f1ca4a5c4d4aa2a6e811f4bf5ea135bb0d4381d82b83bfbc1db0f28c6caefa"
         }
     },
+    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",

--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/odin-lang/Odin/releases/download/dev-2022-06/odin-windows-amd64-dev-2022-06.zip",
-            "hash": "ace2fc652e1d0b5b7292a8fdce086b8244b11752a65ee7d33b6f474f5b557449"
+            "hash": "71f1ca4a5c4d4aa2a6e811f4bf5ea135bb0d4381d82b83bfbc1db0f28c6caefa"
         }
     },
     "bin": "odin.exe",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,6 +10,7 @@
             "hash": "71f1ca4a5c4d4aa2a6e811f4bf5ea135bb0d4381d82b83bfbc1db0f28c6caefa"
         }
     },
+    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -1,0 +1,25 @@
+{
+    "##": "Duplicate (alias) of the odin-dev package",
+    "version": "2022-06",
+    "description": "General-purpose programming language with distinct typing, built for high performance, modern systems, and built-in data-oriented data types.",
+    "homepage": "https://odin-lang.org/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2022-06/odin-windows-amd64-dev-2022-06.zip",
+            "hash": "ace2fc652e1d0b5b7292a8fdce086b8244b11752a65ee7d33b6f474f5b557449"
+        }
+    },
+    "bin": "odin.exe",
+    "checkver": {
+        "url": "https://github.com/odin-lang/Odin/releases/latest",
+        "regex": "/releases/tag/dev-([\\d-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/odin-lang/Odin/releases/download/dev-$version/odin-windows-amd64-dev-$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -7,7 +7,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/odin-lang/Odin/releases/download/dev-2022-06/odin-windows-amd64-dev-2022-06.zip",
-            "hash": "ace2fc652e1d0b5b7292a8fdce086b8244b11752a65ee7d33b6f474f5b557449"
+            "hash": "71f1ca4a5c4d4aa2a6e811f4bf5ea135bb0d4381d82b83bfbc1db0f28c6caefa"
         }
     },
     "bin": "odin.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

I was going through the GitHub Actions logs and noticed that the update for Odin was failing. This was because the autoupdate URL is no longer valid (it turns out the Odin team has changed the naming convention for their release artifacts). 

This PR updates the issue with the autoupdate URL. I also took the opportunity to manually update the version, as well as renaming `odin → odin-dev`. 

I'm a bit unsure whether doing this rename is a good idea (considering there might be other users already using `odin`. But I think `odin-dev` is a better name for it, since these are the dev releases. If we left it as `odin` then there might be confusion when/if somebody adds stable `odin` to Scoop/main. Let me know if this change is ok.

btw, since this is a small change I didn't create an issue for it, but please let me know if I need to create one :)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
