### PR TITLE
odin-nightly: Add version 2022-06-28

### DIFF
--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -1,0 +1,26 @@
+{
+    "version": "2022-06-28",
+    "description": "General-purpose programming language with distinct typing, built for high performance, modern systems, and built-in data-oriented data types.",
+    "homepage": "https://odin-lang.org/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://f001.backblazeb2.com/file/odin-binaries/nightly/odin-windows-amd64-nightly%2B2022-06-28.zip",
+            "hash": "6664fc996dc01340fe7da0d1599ecc01ec972d8f923f34d69ce0930497ac1ac6"
+        }
+    },
+    "extract_dir": "windows_artifacts",
+    "bin": "odin.exe",
+    "checkver": {
+        "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",
+        "regex": "nightly%2B([\\d\\-]+).zip",
+        "reverse": true
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://f001.backblazeb2.com/file/odin-binaries/nightly/odin-windows-amd64-nightly%2B$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Since we've got Odin Dev version, I noticed the website offers a nightly version too. The page for downloads is here: https://odin-lang.org/docs/nightly/ but it requires JavaScript to load the links, so the checkver gets it directly from the source which is a json file. Same otherwise as `odin-dev`.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
