### PR TITLE
ferdium-nightly: Fix URL, update to 6.0.0-nightly.85

### DIFF
--- a/bucket/ferdium-nightly.json
+++ b/bucket/ferdium-nightly.json
@@ -3,7 +3,7 @@
     "description": "All-in-one messaging apps for various services",
     "homepage": "https://github.com/ferdium/ferdium-app",
     "license": "Apache-2.0",
-    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.84/Ferdium-Setup-6.0.0-nightly.84.exe#/dl.7z",
+    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.84/Ferdium-win-AutoSetup-6.0.0-nightly.84.exe#/dl.7z",
     "hash": "sha512:5db45765882c52863ba5b5e7cbdf1ea45ef212a5b187d75a1c6a7299d7b6ecc5b350bd44fd23c35d2dae05455b1a982a221555d1b379f3302bcd1dbc10365b29",
     "architecture": {
         "64bit": {
@@ -29,7 +29,7 @@
         "regex": "/releases/tag/(?:v|V)?([\\d\\-nightly.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-Setup-$version.exe#/dl.7z",
+        "url": "https://github.com/ferdium/ferdium-app/releases/download/v$version/Ferdium-win-AutoSetup-$version.exe#/dl.7z",
         "hash": {
             "url": "$baseurl/latest.yml",
             "regex": "sha512:\\s+$base64"

--- a/bucket/ferdium-nightly.json
+++ b/bucket/ferdium-nightly.json
@@ -1,10 +1,10 @@
 {
-    "version": "6.0.0-nightly.84",
+    "version": "6.0.0-nightly.85",
     "description": "All-in-one messaging apps for various services",
     "homepage": "https://github.com/ferdium/ferdium-app",
     "license": "Apache-2.0",
-    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.84/Ferdium-win-AutoSetup-6.0.0-nightly.84.exe#/dl.7z",
-    "hash": "sha512:5db45765882c52863ba5b5e7cbdf1ea45ef212a5b187d75a1c6a7299d7b6ecc5b350bd44fd23c35d2dae05455b1a982a221555d1b379f3302bcd1dbc10365b29",
+    "url": "https://github.com/ferdium/ferdium-app/releases/download/v6.0.0-nightly.85/Ferdium-win-AutoSetup-6.0.0-nightly.85.exe#/dl.7z",
+    "hash": "sha512:edb481e20c1daaaf51789afc57594442cffcd50345b606e83a5a39f7563a64336647f87ba3932d3d37a0c6a8dad4598b6d6d83f6032a7359ef714691de4b6f5f",
     "architecture": {
         "64bit": {
             "installer": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Update URL to match new naming convention introduced in ferdium-nightly 6.0.0-nightly.84, and update manifest to 6.0.0-nightly.85. Closes #569 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
