### PR TITLE
1password-cli1: Update to version 1.12.5, Add checkver/autoupdate

### DIFF
--- a/bucket/1password-cli1.json
+++ b/bucket/1password-cli1.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.12.4",
+    "version": "1.12.5",
     "description": "The 1Password command-line tool makes your 1Password account accessible entirely from the command line (v1)",
     "homepage": "https://developer.1password.com/docs/cli/v1/usage",
     "license": {
@@ -8,13 +8,27 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_amd64_v1.12.4.zip",
-            "hash": "d14b7a864ebabc9b5ed95ea6b13e676a5795ede54b6187b4233249694478b1c9"
+            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.5/op_windows_amd64_v1.12.5.zip",
+            "hash": "146ed49680ac0b97aa3960fc904144a05ac0a9bc78eaa7590a650068ee8e5bf0"
         },
         "32bit": {
-            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.4/op_windows_386_v1.12.4.zip",
-            "hash": "a8e2ef405af14b8fb3482ed7f8b66a3f1383a2a86062589e3acc6bc446b13006"
+            "url": "https://cache.agilebits.com/dist/1P/op/pkg/v1.12.5/op_windows_386_v1.12.5.zip",
+            "hash": "dac6d21379e72d41921ce8d434692be7c3e9d4ee3807e18685025ae315953a55"
         }
     },
-    "bin": "op.exe"
+    "bin": "op.exe",
+    "checkver": {
+        "url": "https://app-updates.agilebits.com/product_history/CLI",
+        "regex": "/op_windows_amd64_v([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cache.agilebits.com/dist/1P/op/pkg/v$version/op_windows_amd64_v$version.zip"
+            },
+            "32bit": {
+                "url": "https://cache.agilebits.com/dist/1P/op/pkg/v$version/op_windows_386_v$version.zip"
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Updated 1password-cli1 (v1) to include autoupdate/checkver based on the manifest of 1password-cli v2 (in main bucket)
- Bumped version from 1.12.4 to 1.12.5
- Validated autoupdate with checkver.ps1, and validated install of latest 1.12.5 version