### PR TITLE
discord-ptb: Update to version 1.0.1015-19, Fix autoupdate

### DIFF
--- a/bucket/discord-ptb.json
+++ b/bucket/discord-ptb.json
@@ -19,8 +19,8 @@
         "log"
     ],
     "checkver": {
-        "url": "https://github.com/portapps/discord-ptb-portable",
-        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
+        "github": "https://github.com/portapps/discord-ptb-portable",
+        "regex": "tag/([\\d.-]+)"
     },
     "autoupdate": {
         "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win32-$version.7z",

--- a/bucket/discord-ptb.json
+++ b/bucket/discord-ptb.json
@@ -1,29 +1,31 @@
 {
-    "version": "0.0.64",
+    "version": "1.0.9005-12",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://discordapp.com/terms"
     },
-    "url": "http://dl-ptb.discordapp.net/apps/win/DiscordPTB-0.0.64-full.nupkg#/dl.7z",
-    "hash": "sha1:97056625edb306658645ba408d255a069bc83498",
-    "extract_dir": "lib\\net45",
-    "bin": "DiscordPTB.exe",
+    "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9005-12/discord-portable-win32-1.0.9005-12.7z",
+    "hash": "d29eca140e69c2f93ca7291cdadb6d47158dd4c4110ed9475a7c3d4686855eca",
     "shortcuts": [
         [
-            "DiscordPTB.exe",
+            "discord-portable.exe",
             "Discord PTB"
         ]
     ],
+    "persist": [
+        "data",
+        "log"
+    ],
     "checkver": {
-        "url": "https://discordapp.com/api/updates/ptb/RELEASES",
-        "regex": "DiscordPTB-([\\d.]+)"
+        "url": "https://github.com/portapps/discord-ptb-portable",
+        "regex": "/releases/tag/(?:v|V)?([\\d.-]+)"
     },
     "autoupdate": {
-        "url": "http://dl-ptb.discordapp.net/apps/win/DiscordPTB-$version-full.nupkg#/dl.7z",
+        "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win32-$version.7z",
         "hash": {
-            "url": "https://discordapp.com/api/updates/ptb/RELEASES"
+            "url": "$baseurl/checksums.txt"
         }
     }
 }

--- a/bucket/discord-ptb.json
+++ b/bucket/discord-ptb.json
@@ -1,16 +1,16 @@
 {
-    "version": "1.0.9005-12",
+    "version": "1.0.1015-19",
     "description": "Free Voice and Text Chat",
     "homepage": "https://discordapp.com/",
     "license": {
         "identifier": "Freeware",
         "url": "https://discordapp.com/terms"
     },
-    "url": "https://github.com/portapps/discord-portable/releases/download/1.0.9005-12/discord-portable-win32-1.0.9005-12.7z",
-    "hash": "d29eca140e69c2f93ca7291cdadb6d47158dd4c4110ed9475a7c3d4686855eca",
+    "url": "https://github.com/portapps/discord-ptb-portable/releases/download/1.0.1015-19/discord-ptb-portable-win32-1.0.1015-19.7z",
+    "hash": "f31c799f3e9545feba479d88ce305bda3104d6dadf7b66a61a8ad2216e15036e",
     "shortcuts": [
         [
-            "discord-portable.exe",
+            "discord-ptb-portable.exe",
             "Discord PTB"
         ]
     ],
@@ -23,7 +23,7 @@
         "regex": "tag/([\\d.-]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/portapps/discord-portable/releases/download/$version/discord-portable-win32-$version.7z",
+        "url": "https://github.com/portapps/discord-ptb-portable/releases/download/$version/discord-ptb-portable-win32-$version.7z",
         "hash": {
             "url": "$baseurl/checksums.txt"
         }


### PR DESCRIPTION
* related: #598

* Using **PortApps** as file source (same as `extras/discord`) because the files extracted from official installer (https://dl-ptb.discordapp.net/distro/app/ptb/win/x86/1.0.1017/DiscordPTBSetup.exe) would not work without setting up the service.