### PR TITLE
greenshot-unstable: Update to version 1.3.270

### DIFF
--- a/bucket/greenshot-unstable.json
+++ b/bucket/greenshot-unstable.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.3.249",
+    "version": "1.3.270",
     "description": "Light-weight screenshot software.",
     "homepage": "https://getgreenshot.org",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.249/Greenshot-INSTALLER-1.3.249-UNSTABLE.exe",
-    "hash": "66b5c99d23ddd381f03bf511bf4ad7ac283849afb2b65ef8355b1ccbaa07de63",
+    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.270/Greenshot-INSTALLER-1.3.270-UNSTABLE.exe",
+    "hash": "51a2eadde551927a8d86bbd6100d9304e7f505f70f8b8499b2b7059f757ebbe4",
     "innosetup": true,
     "pre_install": "if (!(Test-Path \"$persist_dir\\greenshot.ini\")) { New-Item -ItemType File \"$dir\\greenshot.ini\" | Out-Null }",
     "bin": "Greenshot.exe",
@@ -16,7 +16,7 @@
     ],
     "persist": "greenshot.ini",
     "checkver": {
-        "url": "https://getgreenshot.org/version-history/",
+        "url": "https://github.com/greenshot/greenshot/releases",
         "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE"
     },
     "autoupdate": {


### PR DESCRIPTION
Official website (https://getgreenshot.org/version-history/) is quite a few versions behind, so I updated the `checkver` URL to GitHub releases.

<!-- Provide a general summary of your changes in the title above -->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
