### PR TITLE
goneovim-nightly: Fix version

### DIFF
--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "nightly-1-g190004b",
+    "version": "nightly-20220821",
     "description": "Neovim GUI which uses a Golang Qt backend",
     "homepage": "https://github.com/akiyosi/goneovim",
     "license": "MIT",
@@ -22,9 +22,9 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
-        "jsonpath": "$.target_commitish",
-        "regex": "([0-9a-f]{7}).*",
-        "replace": "nightly-1-g${1}"
+        "jsonpath": "$.assets[?(@.name=='goneovim-windows.zip')].updated_at",
+        "regex": "(?<year>\\d{4})\\D(?<month>\\d{2})\\D(?<day>\\d{2}).*",
+        "replace": "nightly-${year}${month}${day}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -22,8 +22,8 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
-        "jsonpath": "$.assets[?(@.name=='goneovim-windows.zip')].updated_at",
-        "regex": "(?<year>\\d{4})\\D(?<month>\\d{2})\\D(?<day>\\d{2}).*",
+        "jsonpath": "$.assets[?(@.name=='goneovim-windows.zip')]",
+        "regex": "updated_at.*(?<year>\\d{4})\\D(?<month>\\d{2})\\D(?<day>\\d{2})",
         "replace": "nightly-${year}${month}${day}"
     },
     "autoupdate": {


### PR DESCRIPTION
The current version is not in ascending order so `scoop update` will not detect the update. Therefore, replace it with the update date.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
