### PR TITLE
Remove 'extract_dir' from odin packages

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,7 +9,6 @@
             "hash": "207b75db26315ca362f01417ea1422522fdade78bfbf0aa7fd5607f5ac9cf903"
         }
     },
-    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",

--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -9,7 +9,6 @@
             "hash": "52e8c2bfc3cc102a42c33c1a9fea522662a06169754b4003641dd3509094f688"
         }
     },
-    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,7 +10,6 @@
             "hash": "207b75db26315ca362f01417ea1422522fdade78bfbf0aa7fd5607f5ac9cf903"
         }
     },
-    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

The odin maintainers used to put the windows executable inside a folder called `windows_artifacts` inside the zip file. Now, the windows executable is directly inside the root of the zip file, which means `extract_dir` is no longer necessary in the odin.json files.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
