### PR TITLE
spark-*: Add other versions with/without Hadoop

### DIFF
--- a/bucket/spark-hadoop2.json
+++ b/bucket/spark-hadoop2.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.3.0",
+    "description": "A unified analytics engine for large-scale data processing.",
+    "homepage": "https://spark.apache.org/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://www.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-hadoop2.tgz",
+    "hash": "sha512:ab4b7f6fde7f57183801652b5e6a5c522a51d67362a29f777b441408e89c0c5821d8c308c69201360105e00891a564384ba1dfb8769cb546d0567c91583c2a88",
+    "extract_dir": "spark-3.3.0-bin-hadoop2",
+    "env_add_path": "bin",
+    "env_set": {
+        "SPARK_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://spark.apache.org/downloads.html",
+        "regex": "version: ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop2.tgz",
+        "hash": {
+            "url": "$url.sha512",
+            "regex": "$basename: ([A-F0-9\\s]+)$"
+        },
+        "extract_dir": "spark-$version-bin-hadoop2"
+    }
+}

--- a/bucket/spark-scala2.13.json
+++ b/bucket/spark-scala2.13.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.3.0",
+    "description": "A unified analytics engine for large-scale data processing.",
+    "homepage": "https://spark.apache.org/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://www.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-hadoop3-scala2.13.tgz",
+    "hash": "sha512:4c09dac70e22bf1d5b7b2cabc1dd92aba13237f52a5b682c67982266fc7a0f5e0f964edff9bc76adbd8cb444eb1a00fdc59516147f99e4e2ce068420ff4881f0",
+    "extract_dir": "spark-3.3.0-bin-hadoop3-scala2.13",
+    "env_add_path": "bin",
+    "env_set": {
+        "SPARK_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://spark.apache.org/downloads.html",
+        "regex": "version: ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop3-scala2.13.tgz",
+        "hash": {
+            "url": "$url.sha512",
+            "regex": "$basename: ([A-F0-9\\s]+)$"
+        },
+        "extract_dir": "spark-$version-bin-hadoop3-scala2.13"
+    }
+}

--- a/bucket/spark-without-hadoop.json
+++ b/bucket/spark-without-hadoop.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.3.0",
+    "description": "A unified analytics engine for large-scale data processing.",
+    "homepage": "https://spark.apache.org/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://www.apache.org/dist/spark/spark-3.3.0/spark-3.3.0-bin-without-hadoop.tgz",
+    "hash": "sha512:ab8ba5cd9effda459878ff08d55f08e5a3f8d9d95b01747ada3d2d5fc46ac82aeb0ee0e878708e0f8bbb88b6dc73464425ff5ba1769322770802e5ef46ff1cac",
+    "extract_dir": "spark-3.3.0-bin-without-hadoop",
+    "env_add_path": "bin",
+    "env_set": {
+        "SPARK_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://spark.apache.org/downloads.html",
+        "regex": "version: ([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.apache.org/dist/spark/spark-$version/spark-$version-bin-without-hadoop.tgz",
+        "hash": {
+            "url": "$url.sha512",
+            "regex": "$basename: ([A-F0-9\\s]+)$"
+        },
+        "extract_dir": "spark-$version-bin-without-hadoop"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to Spark package in Main being out of date. Version 3.3.0 has been released but the current Main package is set up for the version with Hadoop 2, which is no longer the default. This PR moves the Main package here as `spark-hadoop2` so that the Main package can be updated to the default download with Hadoop 3.

This PR also adds a version with Hadoop 3 & Scala 2.13 and a version bundled without Hadoop, which are available [here](https://spark.apache.org/downloads.html)

After this is merged, [Main #3871](https://github.com/ScoopInstaller/Main/pull/3871) can be merged.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
