### PR TITLE
tinymediamanager3: Update Version 3.1.17

### DIFF
--- a/bucket/tinymediamanager3.json
+++ b/bucket/tinymediamanager3.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.1.16.1",
+    "version": "3.1.17",
     "description": "Completely free but older version(v3) of tinyMediaManager, a media management tool written to provide metadata for the Kodi Media Center (formerly known as XBMC), MediaPortal and Plex media server.",
     "homepage": "https://www.tinymediamanager.org/",
     "license": {
@@ -9,8 +9,8 @@
     "suggest": {
         "JRE": "java/openjdk"
     },
-    "url": "https://release.tinymediamanager.org/v3/dist/tmm_3.1.16.1_win.zip",
-    "hash": "216d841578c5b1199e426d95a22b24e2077d0bb9b67c21717246439e70e4f33e",
+    "url": "https://release.tinymediamanager.org/v3/dist/tmm_3.1.17_win.zip",
+    "hash": "3443e95d23f2d51ede18e794c2d7cd67ff5fcdbb4374de0e4ddcb485e916a063",
     "bin": "tinyMediaManagerCMD.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
I think we can remove the checker.  
`https://release.tinymediamanager.org/v3/dist/` cannot be accessed.