### PR TITLE
btop4win-lhm: Add version 1.0.2

### DIFF
--- a/bucket/btop4win-lhm.json
+++ b/bucket/btop4win-lhm.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.0.2",
+    "description": "A monitor of system resources, btop++ ported to Windows - version with full monitoring capabilities",
+    "homepage": "https://github.com/aristocratos/btop4win",
+    "license": "Apache-2.0",
+    "notes": "This version of btop4win requires admin privileges to run.",
+    "suggest": {
+        "vcredist2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/aristocratos/btop4win/releases/download/v1.0.2/btop4win-LHM-x64.zip",
+            "hash": "898b0725918e58926851304195e795b881abd1c2353b0537e62ea1a273777a66"
+        }
+    },
+    "extract_dir": "btop4win",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\btop.conf\")) { New-Item \"$dir\\btop.conf\" | Out-Null }",
+    "bin": "btop4win.exe",
+    "shortcuts": [
+        [
+            "btop4win.exe",
+            "btop4win"
+        ]
+    ],
+    "persist": [
+        "themes",
+        "btop.conf"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/aristocratos/btop4win/releases/download/v$version/btop4win-LHM-x64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/pull/9200

btop4win version with full monitoring capabilities but requires admin rights to run.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
