### PR TITLE
multipar-beta: Remove deprecated bin

### DIFF
--- a/bucket/multipar-beta.json
+++ b/bucket/multipar-beta.json
@@ -9,8 +9,7 @@
         "par1j.exe",
         "par2j.exe",
         "par2j64.exe",
-        "sfv_md5.exe",
-        "tool\\par2_rename.exe"
+        "sfv_md5.exe"
     ],
     "shortcuts": [
         [
@@ -18,6 +17,7 @@
             "MultiPar"
         ]
     ],
+    "notes": "Some Python script files are provided in .\\tool folder.",
     "pre_install": "if (!(Test-Path \"$persist_dir\\MultiPar.ini\")) { New-Item \"$dir\\MultiPar.ini\" -ItemType File | Out-Null }",
     "persist": "MultiPar.ini",
     "checkver": {

--- a/bucket/multipar-beta.json
+++ b/bucket/multipar-beta.json
@@ -3,8 +3,10 @@
     "description": "A tool for creating and using parchive files to detect damage in data files and repair them if necessary.",
     "homepage": "https://hp.vector.co.jp/authors/VA021385/",
     "license": "Freeware",
+    "notes": "Some Python script files are provided in $dir\\tool folder.",
     "url": "https://github.com/Yutaka-Sawada/MultiPar/releases/download/v1.3.2.5/MultiPar1325.zip",
     "hash": "md5:6870a1522e326a9945f3cbfe6006fa73",
+    "pre_install": "if (!(Test-Path \"$persist_dir\\MultiPar.ini\")) { New-Item \"$dir\\MultiPar.ini\" -ItemType File | Out-Null }",
     "bin": [
         "par1j.exe",
         "par2j.exe",
@@ -17,8 +19,6 @@
             "MultiPar"
         ]
     ],
-    "notes": "Some Python script files are provided in .\\tool folder.",
-    "pre_install": "if (!(Test-Path \"$persist_dir\\MultiPar.ini\")) { New-Item \"$dir\\MultiPar.ini\" -ItemType File | Out-Null }",
     "persist": "MultiPar.ini",
     "checkver": {
         "github": "https://github.com/Yutaka-Sawada/MultiPar"


### PR DESCRIPTION
`par2_rename.exe` is removed and some python scripts are added in version 1.3.2.5.
