### PR TITLE
nheko@nightly: allow 1- or 2-digit regex to fix autoupdate failure

### DIFF
--- a/bucket/nheko-nightly.json
+++ b/bucket/nheko-nightly.json
@@ -21,7 +21,7 @@
     "checkver": {
         "script": [
             "$url = 'https://matrix-static.neko.dev/room/!TshDrgpBNBDmfDeEGN:neko.dev/'",
-            "$regex = '(?sm)download/neko\\.dev/([A-Za-z]+).*?nheko-master-([0-9a-f]+)-win64\\.zip.*?(\\d{2} [A-Za-z]{3} \\d{4})'",
+            "$regex = '(?sm)download/neko\\.dev/([A-Za-z]+).*?nheko-master-([0-9a-f]+)-win64\\.zip.*?(\\d{1,2} [A-Za-z]{3} \\d{4})'",
             "",
             "$cont = (Invoke-WebRequest $url).Content",
             "$matches = [regex]::Matches($cont, $regex)",

--- a/bucket/nheko-nightly.json
+++ b/bucket/nheko-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "20220830-57f505",
+    "version": "20220912-9c3ca9",
     "description": "Desktop client for Matrix using Qt and C++17.",
     "homepage": "https://nheko-reborn.github.io/",
     "license": "GPL-3.0-or-later",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://matrix.neko.dev/_matrix/media/r0/download/neko.dev/ZfuWPfstZFKZmzLyiHHVySJs#/dl.zip",
-            "hash": "fa335276f96571090f437db6c83a02e428f65a7eecef54bbfd24434dbf4e5266"
+            "url": "https://matrix.org/_matrix/media/r0/download/neko.dev/rWoNnSGcYjBbhuPDyHiVXpPK#/dl.zip",
+            "hash": "5355a680dfb25d8c12a7a84faed329226887a1492dc4e06ad38f8057ad191ccc"
         }
     },
     "shortcuts": [
@@ -20,7 +20,7 @@
     ],
     "checkver": {
         "script": [
-            "$url = 'https://matrix-static.neko.dev/room/!TshDrgpBNBDmfDeEGN:neko.dev/'",
+            "$url = 'https://view.matrix.org/room/!TshDrgpBNBDmfDeEGN:neko.dev'",
             "$regex = '(?sm)download/neko\\.dev/([A-Za-z]+).*?nheko-master-([0-9a-f]+)-win64\\.zip.*?(\\d{1,2} [A-Za-z]{3} \\d{4})'",
             "",
             "$cont = (Invoke-WebRequest $url).Content",
@@ -38,7 +38,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://matrix.neko.dev/_matrix/media/r0/download/neko.dev/$matchFileurl#/dl.zip"
+                "url": "https://matrix.org/_matrix/media/r0/download/neko.dev/$matchFileurl#/dl.zip"
             }
         }
     }

--- a/bucket/nheko-nightly.json
+++ b/bucket/nheko-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "20220912-9c3ca9",
+    "version": "20220913-59eb09",
     "description": "Desktop client for Matrix using Qt and C++17.",
     "homepage": "https://nheko-reborn.github.io/",
     "license": "GPL-3.0-or-later",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://matrix.org/_matrix/media/r0/download/neko.dev/rWoNnSGcYjBbhuPDyHiVXpPK#/dl.zip",
-            "hash": "5355a680dfb25d8c12a7a84faed329226887a1492dc4e06ad38f8057ad191ccc"
+            "url": "https://matrix.org/_matrix/media/r0/download/neko.dev/SwSgJBzICYTzUSJxzOlVDPix#/dl.zip",
+            "hash": "0487aed794339c02411f0832b3b736d6acd9e1f34fa9587bc3236a07f50db6d8"
         }
     },
     "shortcuts": [
@@ -21,15 +21,15 @@
     "checkver": {
         "script": [
             "$url = 'https://view.matrix.org/room/!TshDrgpBNBDmfDeEGN:neko.dev'",
-            "$regex = '(?sm)download/neko\\.dev/([A-Za-z]+).*?nheko-master-([0-9a-f]+)-win64\\.zip.*?(\\d{1,2} [A-Za-z]{3} \\d{4})'",
+            "$regex = '(?sm)download/neko\\.dev/([A-Za-z]+)((?!download/neko\\.dev/).)*?nheko-master-([0-9a-f]+)-win64\\.zip.*?(\\d{1,2} [A-Za-z]{3} \\d{4})'",
             "",
             "$cont = (Invoke-WebRequest $url).Content",
             "$matches = [regex]::Matches($cont, $regex)",
             "if (!$matches) { error \"Could not match regex in $url\"; break }",
             "$match = $matches[$matches.Count-1]",
             "",
-            "$date = (Get-Date $match.Groups[3].Value).ToString('yyyyMMdd')",
-            "$commitSha = $match.Groups[2].Value.SubString(0,6)",
+            "$date = (Get-Date $match.Groups[4].Value).ToString('yyyyMMdd')",
+            "$commitSha = $match.Groups[3].Value.SubString(0,6)",
             "$fileUrl = $match.Groups[1].Value",
             "Write-Output $date-$commitSha $fileUrl"
         ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Previously, autoupdate failed for nheko (and nheko failure caused failure of all other auto-updates) due to regex not matching. This PR allows for single-digit dates in regex so that matching is successful. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #642 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
