### PR TITLE
kdeconnect-nightly: Add version 1291

### DIFF
--- a/bucket/kdeconnect-nightly.json
+++ b/bucket/kdeconnect-nightly.json
@@ -1,0 +1,38 @@
+{
+    "version": "1291",
+    "description": "Communications and data transfer between devices over local networks",
+    "homepage": "https://apps.kde.org/kdeconnect",
+    "license": "LGPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-master-1291-windows-msvc2019_64-cl.7z",
+            "hash": "3763ff01f0b6603747dce45f0051eb52fe13503f7d1afac348f764d47019533b"
+        }
+    },
+    "bin": [
+        [
+            "bin\\kdeconnect-cli.exe",
+            "kdeconnect-cli"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "bin\\kdeconnect-app.exe",
+            "KDE Connect Nightly"
+        ]
+    ],
+    "checkver": {
+        "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/",
+        "regex": "kdeconnect-kde-master-(\\d+)-windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-master-$version-windows-msvc2019_64-cl.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Relates to [Extras/#9304](https://github.com/ScoopInstaller/Extras/pull/9304)

Based on [okular-nightly.json](https://github.com/ScoopInstaller/Versions/blob/master/bucket/okular-nightly.json)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).