### PR TITLE
fix olive-editor-nightly (fixes #660)

### DIFF
--- a/bucket/olive-editor-nightly.json
+++ b/bucket/olive-editor-nightly.json
@@ -1,16 +1,16 @@
 {
-    "version": "7fea1476",
+    "version": "7a1e1cdb",
     "description": "Non-linear video editor aiming to provide a fully-featured alternative to high-end professional video editing software.",
     "homepage": "https://olivevideoeditor.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-7fea1476-Windows-x86_64.zip.zip",
-            "hash": "81228466414a51b778364cc7f5b2d3859bb57a72fff876a3218662bbd2329851"
+            "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-7a1e1cdb-Windows-x86_64-Portable.zip",
+            "hash": "3198e360223b71c264e5aa709e2c17ed756399cf813fdaca4c963b39f03a1762",
+            "extract_dir": "olive-editor"
         }
     },
     "pre_install": [
-        "Expand-7zipArchive -Path \"$dir\\Olive*.zip\" -ExtractDir 'olive-editor' -Removal",
         "if (!(Test-Path \"$persist_dir\\config.xml\")) {",
         "   '<Configuration></Configuration>' | Out-File -FilePath \"$dir\\config.xml\"",
         "   New-Item \"$dir\\shortcuts\" -ItemType File | Out-Null",
@@ -37,12 +37,12 @@
     ],
     "checkver": {
         "url": "https://nightly.link/olive-editor/olive/workflows/ci/master",
-        "regex": ">Olive-([\\d\\w]{8})-Windows-x86_64\\.zip</a>"
+        "regex": ">Olive-([\\d\\w]{8})-Windows-x86_64-Portable\\.zip</a>"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-$version-Windows-x86_64.zip.zip"
+                "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-$version-Windows-x86_64-Portable.zip"
             }
         }
     }

--- a/bucket/olive-editor-nightly.json
+++ b/bucket/olive-editor-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "7a1e1cdb",
+    "version": "490677fb",
     "description": "Non-linear video editor aiming to provide a fully-featured alternative to high-end professional video editing software.",
     "homepage": "https://olivevideoeditor.org",
     "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-7a1e1cdb-Windows-x86_64-Portable.zip",
-            "hash": "3198e360223b71c264e5aa709e2c17ed756399cf813fdaca4c963b39f03a1762",
+            "url": "https://nightly.link/olive-editor/olive/workflows/ci/master/Olive-490677fb-Windows-x86_64-Portable.zip",
+            "hash": "b63676f380ae9585216adc88fd5549cc01eeccf6074039141a5e7373d0f60ee3",
             "extract_dir": "olive-editor"
         }
     },
@@ -37,7 +37,7 @@
     ],
     "checkver": {
         "url": "https://nightly.link/olive-editor/olive/workflows/ci/master",
-        "regex": ">Olive-([\\d\\w]{8})-Windows-x86_64-Portable\\.zip</a>"
+        "regex": "Olive-([\\d\\w]{8})-Windows-x86_64-Portable\\.zip</a>"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

This fixes `olive-editor-nightly` install by updating the download URL following the new standards on their repo. Also removes the workaround for extracting the `.zip.zip` file, as that's no longer needed.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #660

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
