### PR TITLE
putty-cac: Update to version 0.77u1

### DIFF
--- a/bucket/putty-cac.json
+++ b/bucket/putty-cac.json
@@ -46,7 +46,7 @@
     ],
     "checkver": {
         "github": "https://github.com/NoMoreFood/putty-cac",
-        "regex": "tree/([\\w.]+)"
+        "regex": "/releases/tag/([\\w.]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/putty-cac.json
+++ b/bucket/putty-cac.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.76u1",
+    "version": "0.77u1",
     "description": "PuTTY CAC is a fork of the PuTTY, a popular Secure Shell (SSH) terminal. PuTTY CAC adds the ability to use the Windows Certificate API (CAPI) or a Public Key Cryptography Standards (PKCS) library to perform SSH public key authentication using a private key associated with a certificate that is stored on a hardware token.",
     "homepage": "https://github.com/NoMoreFood/putty-cac",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.76u1/binaries/puttycac-64bit-0.76u1.zip",
-            "hash": "4d4d514e776fe7f413b673b4aadead4a038182b745b1b6a1a86d9eab3de445c2"
+            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.77u1/binaries/puttycac-64bit-0.77u1.zip",
+            "hash": "683409b131a5352bd8084a2b44aa180fbf367f35593120dc08cac723640344d7"
         },
         "32bit": {
-            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.76u1/binaries/puttycac-0.76u1.zip",
-            "hash": "1ddece989f5d552d4594a0c0733b42f5b42a5f149aae6708d8d8d574ede1dce4"
+            "url": "https://raw.githubusercontent.com/NoMoreFood/putty-cac/0.77u1/binaries/puttycac-0.77u1.zip",
+            "hash": "955baa6141f34dfaae158733bfc4f8f292d1e4326052f18c0a4b1569c96c12e6"
         }
     },
     "bin": [


### PR DESCRIPTION
Update putty-cac to version 0.77u1. Existing `checkver` and `autoupdate` should work, though.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
