### PR TITLE
logseq-nightly: Update to 0.8.8-20221007

### DIFF
--- a/bucket/logseq-nightly.json
+++ b/bucket/logseq-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.8.5-20220913",
+    "version": "0.8.8-20221007",
     "description": "A privacy-first platform for knowledge sharing and management",
     "homepage": "https://logseq.com",
     "license": "AGPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/logseq/logseq/releases/download/nightly/Logseq-win-x64-0.8.5+nightly.20220913.exe#/dl.7z",
-            "hash": "a5fd45a66d880da86502363c275e87d8a559d59b0109801a3e6e91ce3b7dead5"
+            "url": "https://github.com/logseq/logseq/releases/download/nightly/Logseq-win-x64-0.8.8+nightly.20221007.exe#/dl.7z",
+            "hash": "4392d15c31cb8dd9f67227209fd1dd18d07dbcde1bc8d699202326bf01438fdd"
         }
     },
     "pre_install": [
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/logseq/logseq/releases/tag/nightly",
+        "url": "https://api.github.com/repos/logseq/logseq/releases/tags/nightly",
         "regex": "Logseq-win-x64-(?<main>[\\d.]+)\\+nightly\\.(?<date>\\d{8})",
         "replace": "${main}-${date}"
     },

--- a/bucket/logseq-nightly.json
+++ b/bucket/logseq-nightly.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/logseq/logseq/releases/download/nightly/Logseq-win-x64-0.8.8+nightly.20221007.exe#/dl.7z",
-            "hash": "4392d15c31cb8dd9f67227209fd1dd18d07dbcde1bc8d699202326bf01438fdd"
+            "hash": "5b4074b96ed5513f4e32bb46fc44633b05ca3afde9c801d5f90bc6ca331668ac"
         }
     },
     "pre_install": [
@@ -30,7 +30,7 @@
                 "url": "https://github.com/logseq/logseq/releases/download/nightly/Logseq-win-x64-$matchMain+nightly.$matchDate.exe#/dl.7z",
                 "hash": {
                     "url": "$baseurl/SHA256SUMS.txt",
-                    "regex": "$sha256\\s{2}Logseq-win-x64"
+                    "regex": "$sha256\\s{2}Logseq-win-x64-$matchMain\\+nightly\\.$matchDate\\.exe"
                 }
             }
         }


### PR DESCRIPTION
fix checkver url

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).