### PR TITLE
postman9: Remove unnecessary URL and Hash.

### DIFF
--- a/bucket/postman9.json
+++ b/bucket/postman9.json
@@ -13,8 +13,6 @@
             "hash": "29CD778C52D64C4AFAB765ADDA1849308D86F363579C4BE0C15C041447F099AB"
         }
     },
-    "url": "https://dl.pstmn.io/download/9.31.0/Postman-win64-9.31.0-full.nupkg",
-    "hash": "29CD778C52D64C4AFAB765ADDA1849308D86F363579C4BE0C15C041447F099AB",
     "extract_dir": "lib\\net45",
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
![(VSCodium)I5A6q7_10-09-2022](https://user-images.githubusercontent.com/101912712/194787842-80c086db-ab39-454c-99be-df2866535d73.jpg)
I found this mistake while I was checking the manifest of postman9.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
