### PR TITLE
ipfilter-nightly: Add version 2022-07-30

### DIFF
--- a/bucket/ipfilter-nightly.json
+++ b/bucket/ipfilter-nightly.json
@@ -1,0 +1,16 @@
+{
+    "version": "2022-07-30",
+    "description": "Protects privacy and security when using Bit Torrent by blocking a list of potentially malicious peers.",
+    "homepage": "https://www.ipfilter.app/",
+    "license": "MIT",
+    "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip",
+    "hash": "6e1608ac027619ba1e1469b02fa6ed78f883c9a0c725fed0740b411f40f68394",
+    "checkver": {
+        "url": "https://api.github.com/repositories/487352/releases/tags/lists",
+        "jsonpath": "$.assets[0].updated_at",
+        "regex": "([\\d-]+)T"
+    },
+    "autoupdate": {
+        "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip"
+    }
+}


### PR DESCRIPTION
[It's in extras](https://github.com/ScoopInstaller/Extras/blob/master/bucket/ipfilter-updater.json)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).