### PR TITLE
neovim-nightly: Fix chechver

### DIFF
--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.0-dev-98-g1c478391c",
+    "version": "0.9.0-dev-150-g2f9b94a26",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {
@@ -12,7 +12,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip",
-            "hash": "f8e50936b054d5cc1a211c2e9d2b505d149cdfd141b9c98a709a50d30da2087b"
+            "hash": "a8cb94faea9d7ef752c25b2aa34fc7d12ec46490168d6bfcb1a143d9d4bd65e2"
         }
     },
     "extract_dir": "nvim-win64",
@@ -28,7 +28,8 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/neovim/neovim/releases",
-        "regex": "NVIM v([\\w.-]+)"
+        "regex": "NVIM v([\\w.-]+)\\+([\\w.-]+)",
+        "replace": "${1}-${2}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.9.0-dev-150-g2f9b94a26",
+    "version": "0.9.0-dev-152-g1887d8d7d",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {
@@ -12,7 +12,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/neovim/neovim/releases/download/nightly/nvim-win64.zip",
-            "hash": "a8cb94faea9d7ef752c25b2aa34fc7d12ec46490168d6bfcb1a143d9d4bd65e2"
+            "hash": "5716eb0af96dd1b3d74e9dc1f57b2e0fa19664f8c4c6d95b005ad06393ccfce1"
         }
     },
     "extract_dir": "nvim-win64",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Fix checkver to get new version format (add back '+' in the middle) by reverting the changes introduced by c7e95134d15b73b1886556d43f4b272a7ae62500

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #719. ghomb mentions that "the Scoop repository has the latest version 0.9.0-dev-98-g1c478391c while the Neovim repository has the latest version of v0.9.0-dev-143+ga288b4f21."

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).