### PR TITLE
mpv.net-beta: Update to version 6.0.3.2, update URLs

### DIFF
--- a/bucket/mpv.net-beta.json
+++ b/bucket/mpv.net-beta.json
@@ -1,12 +1,12 @@
 {
-    "version": "6.0.3.1",
+    "version": "6.0.3.2",
     "description": "A modern media player for Windows that works just like mpv",
     "homepage": "https://github.com/stax76/mpv.net/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/stax76/mpv.net/releases/download/v6.0.3.1/mpv.net-6.0.3.1-beta.zip",
-            "hash": "a3c78644cb19c559c5b73f148df4b8c80f6287d9b713ea93426c3d52ace52c20"
+            "url": "https://github.com/stax76/mpv.net/releases/download/v6.0.3.2-beta/mpv.net-6.0.3.2-beta.zip",
+            "hash": "81975f82de761320e06f11f59a6983348c64d110f89a8a1779ba8a4a80813176"
         }
     },
     "bin": "mpvnet.com",
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/stax76/mpv.net/releases/download/v$version/mpv.net-$matchStable$version$matchBeta.zip"
+                "url": "https://github.com/stax76/mpv.net/releases/download/v$version$matchBeta/mpv.net-$matchStable$version$matchBeta.zip"
             }
         }
     }

--- a/bucket/mpv.net-beta.json
+++ b/bucket/mpv.net-beta.json
@@ -1,11 +1,11 @@
 {
     "version": "6.0.3.2",
     "description": "A modern media player for Windows that works just like mpv",
-    "homepage": "https://github.com/stax76/mpv.net/",
+    "homepage": "https://github.com/mpvnet-player/mpv.net/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/stax76/mpv.net/releases/download/v6.0.3.2-beta/mpv.net-6.0.3.2-beta.zip",
+            "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v6.0.3.2-beta/mpv.net-6.0.3.2-beta.zip",
             "hash": "81975f82de761320e06f11f59a6983348c64d110f89a8a1779ba8a4a80813176"
         }
     },
@@ -25,7 +25,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/stax76/mpv.net/releases/download/v$version$matchBeta/mpv.net-$matchStable$version$matchBeta.zip"
+                "url": "https://github.com/mpvnet-player/mpv.net/releases/download/v$version$matchBeta/mpv.net-$matchStable$version$matchBeta.zip"
             }
         }
     }


### PR DESCRIPTION
They now add "-beta" to the end of the beta GitHub releases as well it seems