### PR TITLE
duplicati-canary: Fix `notes`, and fix `pre_uninstall`

### DIFF
--- a/bucket/duplicati-canary.json
+++ b/bucket/duplicati-canary.json
@@ -4,15 +4,14 @@
     "description": "A free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers. This is the Canary release.",
     "license": "LGPL-2.1",
     "notes": [
-        "If you want Dupilicati to run at the startup of your system, run: (REQUIRES ADMINSTRATOR PRIVELLAGES)",
-        "& \"$dir\\Duplicati.WindowsService.exe\" install",
+        "If you want Dupilicati to run at the startup of your system, run: (requires administrator privileges)",
+        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'install' -WindowStyle 'Hidden'",
         "",
-        "To remove Duplicati startup, run: (REQUIRES ADMINSTRATOR PRIVELLAGES)",
-        "& \"$dir\\Duplicati.WindowsService.exe\" uninstall"
+        "To remove Duplicati from startup, run: (requires administrator privileges)",
+        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'uninstall' -WindowStyle 'Hidden'"
     ],
     "url": "https://github.com/duplicati/duplicati/releases/download/v2.0.6.104-2.0.6.104_canary_2022-06-15/duplicati-2.0.6.104_canary_2022-06-15.zip",
-    "hash": "955C6D466A0BB86D9B8F56006FF3B64ED2ACAE2D5816EBECAA8FE0351145CC3D",
-    "pre_install": "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
+    "hash": "955c6d466a0bb86d9b8f56006ff3b64ed2acae2d5816ebecaa8fe0351145cc3d",
     "bin": [
         "Duplicati.CommandLine.exe",
         [
@@ -31,8 +30,8 @@
         ]
     ],
     "pre_uninstall": [
-        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "if (Get-Service -Name 'Duplicati' -ErrorAction 'SilentlyContinue') {",
+        "    if (!(is_admin)) { error \"Admin rights required to remove Duplicati service\"; break }",
         "    Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'uninstall' -WindowStyle 'Hidden'",
         "}"
     ],

--- a/bucket/duplicati-canary.json
+++ b/bucket/duplicati-canary.json
@@ -5,10 +5,10 @@
     "license": "LGPL-2.1",
     "notes": [
         "If you want Dupilicati to run at the startup of your system, run: (requires administrator privileges)",
-        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'install' -WindowStyle 'Hidden'",
+        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'install'",
         "",
         "To remove Duplicati from startup, run: (requires administrator privileges)",
-        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'uninstall' -WindowStyle 'Hidden'"
+        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'uninstall'"
     ],
     "url": "https://github.com/duplicati/duplicati/releases/download/v2.0.6.104-2.0.6.104_canary_2022-06-15/duplicati-2.0.6.104_canary_2022-06-15.zip",
     "hash": "955c6d466a0bb86d9b8f56006ff3b64ed2acae2d5816ebecaa8fe0351145cc3d",

--- a/bucket/duplicati-canary.json
+++ b/bucket/duplicati-canary.json
@@ -4,14 +4,15 @@
     "description": "A free, open source, backup client that securely stores encrypted, incremental, compressed backups on cloud storage services and remote file servers. This is the Canary release.",
     "license": "LGPL-2.1",
     "notes": [
-        "If you want Dupilicati to run at the startup of your system, run:",
+        "If you want Dupilicati to run at the startup of your system, run: (REQUIRES ADMINSTRATOR PRIVELLAGES)",
         "& \"$dir\\Duplicati.WindowsService.exe\" install",
         "",
-        "To remove Duplicati startup, run:",
+        "To remove Duplicati startup, run: (REQUIRES ADMINSTRATOR PRIVELLAGES)",
         "& \"$dir\\Duplicati.WindowsService.exe\" uninstall"
     ],
     "url": "https://github.com/duplicati/duplicati/releases/download/v2.0.6.104-2.0.6.104_canary_2022-06-15/duplicati-2.0.6.104_canary_2022-06-15.zip",
     "hash": "955C6D466A0BB86D9B8F56006FF3B64ED2ACAE2D5816EBECAA8FE0351145CC3D",
+    "pre_install": "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
     "bin": [
         "Duplicati.CommandLine.exe",
         [
@@ -30,6 +31,7 @@
         ]
     ],
     "pre_uninstall": [
+        "if (!(is_admin)) { error \"$app requires admin rights to $cmd\"; break }",
         "if (Get-Service -Name 'Duplicati' -ErrorAction 'SilentlyContinue') {",
         "    Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Wait -Verb 'RunAs' -ArgumentList 'uninstall' -WindowStyle 'Hidden'",
         "}"

--- a/bucket/duplicati-canary.json
+++ b/bucket/duplicati-canary.json
@@ -5,10 +5,10 @@
     "license": "LGPL-2.1",
     "notes": [
         "If you want Dupilicati to run at the startup of your system, run: (requires administrator privileges)",
-        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'install'",
+        "start \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'install'",
         "",
         "To remove Duplicati from startup, run: (requires administrator privileges)",
-        "Start-Process \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'uninstall'"
+        "start \"$dir\\Duplicati.WindowsService.exe\" -Verb 'RunAs' -ArgumentList 'uninstall'"
     ],
     "url": "https://github.com/duplicati/duplicati/releases/download/v2.0.6.104-2.0.6.104_canary_2022-06-15/duplicati-2.0.6.104_canary_2022-06-15.zip",
     "hash": "955c6d466a0bb86d9b8f56006ff3b64ed2acae2d5816ebecaa8fe0351145cc3d",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/pull/9533

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
