### PR TITLE
yt-dlp-daily: Add version 2022.11.06.334

### DIFF
--- a/bucket/yt-dlp-daily.json
+++ b/bucket/yt-dlp-daily.json
@@ -1,0 +1,39 @@
+{
+    "version": "2022.11.06.334",
+    "description": "Unofficial daily builds for yt-dlp - a youtube-dl fork with additional features and fixes.",
+    "homepage": "https://github.com/ytdl-patched/yt-dlp",
+    "license": "Unlicense",
+    "suggest": {
+        "ffmpeg": "ffmpeg-nightly"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ytdl-patched/yt-dlp/releases/download/2022.11.06.334/yt-dlp.exe",
+            "hash": "sha512:e81e966c1a2dac6ca4352da3bb3b0d68b8117dbea96f30abd6f3c218bf98641ac4a393f636ef9a1992916f3e4d2047282a3cd739b5a9ec33c2ed7c046ca9f2bc"
+        },
+        "32bit": {
+            "url": "https://github.com/ytdl-patched/yt-dlp/releases/download/2022.11.06.334/yt-dlp_x86.exe#/yt-dlp.exe",
+            "hash": "sha512:629e9a94d882de69ac94d39740beb598180b7d86766b14a1437265a986f2f7c89270d631caf625582e6f7f9de85f7074c8d69397a40a4820db20598133b93487"
+        }
+    },
+    "bin": "yt-dlp.exe",
+    "pre_install": "if (-not (Test-Path \"$persist_dir\\yt-dlp.conf\")) { New-Item \"$dir\\yt-dlp.conf\" -ItemType file | Out-Null }",
+    "persist": [
+        "yt-dlp.conf",
+        "ytdlp_plugins"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ytdl-patched/yt-dlp/releases/download/$version/yt-dlp.exe"
+            },
+            "32bit": {
+                "url": "https://github.com/ytdl-patched/yt-dlp/releases/download/$version/yt-dlp_x86.exe#/yt-dlp.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA2-512SUMS"
+        }
+    }
+}


### PR DESCRIPTION
[It's in main](https://github.com/ScoopInstaller/Main/blob/master/bucket/yt-dlp.json)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).