### PR TITLE
ipfilter-nightly: Unix timestamp checkver

### DIFF
--- a/bucket/ipfilter-nightly.json
+++ b/bucket/ipfilter-nightly.json
@@ -1,14 +1,13 @@
 {
-    "version": "2022-11-21",
+    "version": "1669046600",
     "description": "Protects privacy and security when using Bit Torrent by blocking a list of potentially malicious peers.",
     "homepage": "https://www.ipfilter.app/",
     "license": "MIT",
     "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip",
     "hash": "e610ca93d62c9bba5c0f45a87bb8072969656de65aca2602a89fdf7cfd230450",
     "checkver": {
-        "url": "https://api.github.com/repositories/487352/releases/tags/lists",
-        "jsonpath": "$.assets[0].updated_at",
-        "regex": "([\\d-]+)T"
+        "script": "Get-Date (Invoke-RestMethod https://api.github.com/repositories/487352/releases/tags/lists).assets[0].updated_at -UFormat %s",
+        "regex": "^(\\d+)$"
     },
     "autoupdate": {
         "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip"


### PR DESCRIPTION
Changed date format to unix timestamp for better accuracy

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).