### PR TITLE
anaconda3-2022.05: Add version 2022.05

### DIFF
--- a/bucket/anaconda3-2022.05.json
+++ b/bucket/anaconda3-2022.05.json
@@ -1,0 +1,66 @@
+{
+    "version": "2022.05",
+    "description": "The most popular Python distribution for data science.",
+    "homepage": "https://www.anaconda.com/",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\""
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/archive/Anaconda3-2022.05-Windows-x86_64.exe#/setup.exe",
+            "hash": "2766eb102f9d65da36d262b651777358de39fbe5f1a74f9854a2e5e29caeeeec"
+        },
+        "32bit": {
+            "url": "https://repo.anaconda.com/archive/Anaconda3-2022.05-Windows-x86.exe#/setup.exe",
+            "hash": "cd8c688349bcd1f429e3b383620fb0d19f52be0f765b2eae78d63b41aefb2e73"
+        }
+    },
+    "installer": {
+        "script": [
+            "Write-Host 'Installing Anaconda 3. This can take up to 30 minutes on an HDD.' -ForegroundColor Magenta",
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "Start-Process \"$dir\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=1', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Anaconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": "Scripts",
+    "persist": "envs",
+    "checkver": {
+        "url": "https://docs.anaconda.com/anaconda/install/hashes/win-3-64/",
+        "regex": "Anaconda3-([\\d.]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86_64.exe#/setup.exe",
+                "hash": {
+                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86_64.exe-hash/",
+                    "regex": "$sha256"
+                }
+            },
+            "32bit": {
+                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86.exe#/setup.exe",
+                "hash": {
+                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/",
+                    "regex": "$sha256"
+                }
+            }
+        }
+    }
+}

--- a/bucket/anaconda3-2022.05.json
+++ b/bucket/anaconda3-2022.05.json
@@ -40,27 +40,5 @@
         ]
     ],
     "env_add_path": "Scripts",
-    "persist": "envs",
-    "checkver": {
-        "url": "https://docs.anaconda.com/anaconda/install/hashes/win-3-64/",
-        "regex": "Anaconda3-([\\d.]+)-Windows"
-    },
-    "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86_64.exe#/setup.exe",
-                "hash": {
-                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86_64.exe-hash/",
-                    "regex": "$sha256"
-                }
-            },
-            "32bit": {
-                "url": "https://repo.anaconda.com/archive/Anaconda3-$version-Windows-x86.exe#/setup.exe",
-                "hash": {
-                    "url": "http://docs.anaconda.com/anaconda/install/hashes/Anaconda3-$version-Windows-x86.exe-hash/",
-                    "regex": "$sha256"
-                }
-            }
-        }
-    }
+    "persist": "envs"
 }


### PR DESCRIPTION
Last version that supports Windows 32-bit

See: https://docs.anaconda.com/anaconda/install/old-os/

"Windows 32-bit - Use Anaconda versions 2022.05 and earlier."

I suggest we put a note in the Extras current version after merging this.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/commit/49118356111cc4a5f08b35c406787910f83c5919

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
