### PR TITLE
ffmpeg-nightly: Fix checkver, moved to `/latest` builds, Update to version 1669382325

### DIFF
--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -1,13 +1,13 @@
 {
-    "version": "109226",
+    "version": "1669382325",
     "description": "A complete, cross-platform solution to record, convert and stream audio and video.",
     "homepage": "https://ffmpeg.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2022-11-25-12-36/ffmpeg-N-109226-g2ad199ae31-win64-gpl.zip",
-            "hash": "4137171c69a1870c4541a6b9941d1e0f8b02204306f6d341202c6f3b1c4a698e",
-            "extract_dir": "ffmpeg-N-109226-g2ad199ae31-win64-gpl"
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
+            "hash": "05c89ae6d9d7a269b92fc4e370f7e4cad7522b33a62a519c4d45fd4455aedc5b",
+            "extract_dir": "ffmpeg-master-latest-win64-gpl"
         }
     },
     "bin": [
@@ -16,14 +16,13 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://github.com/BtbN/FFmpeg-Builds/releases",
-        "regex": "/autobuild-(?<time>[\\d-]+)/ffmpeg-N-(?<version>\\d+)-g(?<hash>[a-z\\d]+)-win64-gpl\\.zip"
+        "script": "Get-Date (Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest).published_at -UFormat %s",
+        "regex": "^(\\d+)$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-$matchTime/ffmpeg-N-$version-g$matchHash-win64-gpl.zip",
-                "extract_dir": "ffmpeg-N-$version-g$matchHash-win64-gpl"
+                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
             }
         }
     }


### PR DESCRIPTION
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
Closes #795