### PR TITLE
snipaste-beta: Persist config file manually

### DIFF
--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -13,11 +13,9 @@
             "hash": "sha1:5023432a7611f72efd1f6ba84613b61b5eccec62"
         }
     },
-    "pre_install": "if (!(Test-Path \"$persist_dir\\config.ini\")) { Set-Content \"$dir\\config.ini\" '' -Encoding ASCII }",
-    "persist": [
-        "history",
-        "config.ini"
-    ],
+    "pre_install": "if (Test-Path \"$persist_dir\\config.ini\") { Copy-Item \"$persist_dir\\config.ini\" \"$dir\\config.ini\" }",
+    "persist": "history",
+    "pre_uninstall": "Copy-Item \"$dir\\config.ini\" \"$persist_dir\\config.ini\"",
     "bin": "Snipaste.exe",
     "shortcuts": [
         [

--- a/bucket/snipaste-beta.json
+++ b/bucket/snipaste-beta.json
@@ -15,7 +15,7 @@
     },
     "pre_install": "if (Test-Path \"$persist_dir\\config.ini\") { Copy-Item \"$persist_dir\\config.ini\" \"$dir\\config.ini\" }",
     "persist": "history",
-    "pre_uninstall": "Copy-Item \"$dir\\config.ini\" \"$persist_dir\\config.ini\"",
+    "pre_uninstall": "if (Test-Path \"$dir\\config.ini\") { Copy-Item \"$dir\\config.ini\" \"$persist_dir\\config.ini\" }",
     "bin": "Snipaste.exe",
     "shortcuts": [
         [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #799 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Referring to [this manifest](https://github.com/ScoopInstaller/Versions/blob/ddc675272ff0dd987dd65c7dd7ba58c5be7c0680/bucket/smplayer-with-smtube.json#L35-L38), `config.ini` is persisted manually by command `Copy-Item`.
And also, `config.ini` is removed from the `persist` block, in case there would be conflict of two implementations of **persist**.