### PR TITLE
dotnet6-sdk: Add arm64 architecture

### DIFF
--- a/bucket/dotnet6-sdk.json
+++ b/bucket/dotnet6-sdk.json
@@ -14,6 +14,10 @@
         "32bit": {
             "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.403/dotnet-sdk-6.0.403-win-x86.zip",
             "hash": "sha512:a37400428f755929bc75a6f8b0aa0aea7f631b1ae3727a38682c7dec312d586d21357c071f3180a0333ed339e7e1b3dbc9f7666a8a3d12c27fdc35f821e5a849"
+        },
+        "arm64": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/6.0.403/dotnet-sdk-6.0.403-win-arm64.zip",
+            "hash": "sha512:f3213ac5e7551102be48ca5c65fe098714a79a03ed3111d368ad07eb85ac22fea4c05a356fe742feb231e76f4d3e510954d4235631e0686d19bb0cb2f02b7e4a"
         }
     },
     "bin": "dotnet.exe",
@@ -33,6 +37,9 @@
             },
             "32bit": {
                 "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x86.zip"
+            },
+            "arm64": {
+                "url": "https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-arm64.zip"
             }
         },
         "hash": {


### PR DESCRIPTION

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
