### PR TITLE
(ipfilter,ffmpeg)-nightly: Add try/catch to `checkver.script`

### DIFF
--- a/bucket/autohotkey1.1.json
+++ b/bucket/autohotkey1.1.json
@@ -1,0 +1,42 @@
+{
+    "version": "1.1.36.02",
+    "description": "The ultimate automation scripting language for Windows.",
+    "homepage": "https://www.autohotkey.com/",
+    "license": "GPL-2.0-or-later",
+    "url": "https://www.autohotkey.com/download/1.1/AutoHotkey_1.1.36.02.zip",
+    "hash": "4482dbfe5481cc4fa8efb42bc9b24801c842cf7102608c0503bf198a627af6a2",
+    "architecture": {
+        "64bit": {
+            "bin": [
+                "autohotkeyu64.exe",
+                [
+                    "autohotkeyu64.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ],
+            "post_install": "Copy-Item \"$dir\\Compiler\\Unicode 64-bit.bin\" \"$dir\\Compiler\\AutoHotkeySC.bin\""
+        },
+        "32bit": {
+            "bin": [
+                "autohotkeyu32.exe",
+                [
+                    "autohotkeyu32.exe",
+                    "autohotkey"
+                ],
+                "compiler\\ahk2exe.exe"
+            ],
+            "post_install": "Copy-Item \"$dir\\Compiler\\Unicode 32-bit.bin\" \"$dir\\Compiler\\AutoHotkeySC.bin\""
+        }
+    },
+    "checkver": {
+        "url": "https://www.autohotkey.com/download/1.1/version.txt",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.autohotkey.com/download/1.1/AutoHotkey_$version.zip",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -16,8 +16,8 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "script": "Get-Date (Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest).published_at -UFormat %s",
-        "regex": "^(\\d+)$"
+        "script": "try { Get-Date (Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest).published_at -UFormat %s } catch { '' }",
+        "regex": "\\A(\\d+)\\Z"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "729",
+    "version": "1671715260",
     "description": "A complete, cross-platform solution to record, convert and stream audio and video.",
     "homepage": "https://ffmpeg.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
-            "hash": "4e63a8b743417b5df6a2fe28f92fcd4c1c540cd615a9941de8055491d0605111",
+            "hash": "f5fdd9d579dd302b2000b615da3ab217865b07c4e8f19cef753aaaf6f7b6ba5e",
             "extract_dir": "ffmpeg-master-latest-win64-gpl"
         }
     },

--- a/bucket/ipfilter-nightly.json
+++ b/bucket/ipfilter-nightly.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip",
     "hash": "0d8bf0d34482ba443b7736a1d64b2ccf93ba76816d0005261cbdfef66b387ca0",
     "checkver": {
-        "script": "Get-Date (Invoke-RestMethod https://api.github.com/repositories/487352/releases/tags/lists).assets[0].updated_at -UFormat %s",
-        "regex": "^(\\d+)$"
+        "script": "try { Get-Date (Invoke-RestMethod https://api.github.com/repositories/487352/releases/tags/lists).assets[0].updated_at -UFormat %s } catch { '' }",
+        "regex": "\\A(\\d+)\\Z"
     },
     "autoupdate": {
         "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip"

--- a/bucket/ipfilter-nightly.json
+++ b/bucket/ipfilter-nightly.json
@@ -1,10 +1,10 @@
 {
-    "version": "6.0.404",
+    "version": "1671724907",
     "description": "Protects privacy and security when using Bit Torrent by blocking a list of potentially malicious peers.",
     "homepage": "https://www.ipfilter.app/",
     "license": "MIT",
     "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip",
-    "hash": "0d8bf0d34482ba443b7736a1d64b2ccf93ba76816d0005261cbdfef66b387ca0",
+    "hash": "c5389fb17d05664f944d8e9be20b6a80986f0d1dbd566eac215bc5fd460280f7",
     "checkver": {
         "script": "try { Get-Date (Invoke-RestMethod https://api.github.com/repositories/487352/releases/tags/lists).assets[0].updated_at -UFormat %s } catch { '' }",
         "regex": "\\A(\\d+)\\Z"


### PR DESCRIPTION
Minor: stricter `checkver.regex`

Reason: When `checkver.script` fails due to gh rate limits, it falls back to the default `checkver`

[Example](https://github.com/ScoopInstaller/Versions/commit/d23b52ae7488f563a9307df84b4c84ef77271c1e)
[Example 2](https://github.com/ScoopInstaller/Versions/commit/42cab9c3fa46de8ecf6f16c5383f760662aa84fa)
[Example 3](https://github.com/ScoopInstaller/Versions/commit/0a8f4aea3dd97b563085550df40fb9615b8c0684)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).