### PR TITLE
vscode-insiders: fix autoupdate/checkver

### DIFF
--- a/bucket/vscode-insiders.json
+++ b/bucket/vscode-insiders.json
@@ -1,5 +1,5 @@
 {
-    "version": "nightly",
+    "version": "1.75.0-insider",
     "description": "Visual Studio Code is a lightweight but powerful source code editor (Insiders, Portable Edition).",
     "homepage": "https://code.visualstudio.com/",
     "license": {
@@ -8,17 +8,19 @@
     },
     "notes": [
         "Visual Studio Code now supports Portable Mode! Please move the following directories:",
-        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:SCOOP\\persist\\vscode-insiders-portable\\data\\extensions\"",
-        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:SCOOP\\persist\\vscode-insiders-portable\\data\\user-data\"",
+        "From \"$env:USERPROFILE\\.vscode-insiders\\extensions\" to \"$env:SCOOP\\persist\\vscode-insiders\\data\\extensions\"",
+        "From \"$env:APPDATA\\Code - Insiders\" to \"$env:SCOOP\\persist\\vscode-insiders\\data\\user-data\"",
         "Add Visual Studio Code as a context menu option by running: '$dir\\install-context.reg'",
         "For file associations, run '$dir\\install-associations.reg'"
     ],
     "architecture": {
         "64bit": {
-            "url": "https://update.code.visualstudio.com/latest/win32-x64-archive/insider#/dl.7z"
+            "url": "https://update.code.visualstudio.com/latest/win32-x64-archive/insider#/dl.7z",
+            "hash": "817768e1651bd64fd064df0a1a9606f58e7d66432a2ecc5eb171bf4d0bd6d793"
         },
         "32bit": {
-            "url": "https://update.code.visualstudio.com/latest/win32-archive/insider#/dl.7z"
+            "url": "https://update.code.visualstudio.com/latest/win32-archive/insider#/dl.7z",
+            "hash": "e98b69636bed6a4bc0eb0156f350b130e361bbddab659ae8f1a7e179d57ec710"
         }
     },
     "post_install": [
@@ -44,5 +46,27 @@
             "Visual Studio Code - Insiders"
         ]
     ],
-    "persist": "data"
+    "persist": "data",
+    "checkver": {
+        "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
+        "jsonpath": "$.productVersion"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://update.code.visualstudio.com/latest/win32-x64-archive/insider#/dl.7z",
+                "hash": {
+                    "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
+                    "jsonpath": "$.sha256hash"
+                }
+            },
+            "32bit": {
+                "url": "https://update.code.visualstudio.com/latest/win32-archive/insider#/dl.7z",
+                "hash": {
+                    "url": "https://update.code.visualstudio.com/api/update/win32-archive/insider/latest",
+                    "jsonpath": "$.sha256hash"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Incorporated similar method of checkver/autoupdate from VSCode stable manifest from extras bucket (https://github.com/ScoopInstaller/Extras/blob/master/bucket/vscode.json)

Also referenced the VSCode team's release API "docs" at https://update.code.visualstudio.com/swagger.json

This manifest change sets the `version` property according to the published version from the release pipeline, then uses their release API during checkver to set scoop's `$version` variable. 

No changes to the URLs in autoupdate are needed (or possible because the static download URL for insider versions don't follow the same URL scheme as the stable version) since the alias `latest` is always sufficient to redirect to the underlying download location.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #837

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
