### PR TITLE
vscode & vscodium: Add previous versions 1.74.0 & 1.74.0.22342

### DIFF
--- a/bucket/vscode1740.json
+++ b/bucket/vscode1740.json
@@ -1,0 +1,60 @@
+{
+    "version": "1.74.0",
+    "description": "Lightweight but powerful source code editor",
+    "homepage": "https://code.visualstudio.com/",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://code.visualstudio.com/License/"
+    },
+    "notes": [
+        "Add Visual Studio Code as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
+        "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://update.code.visualstudio.com/1.74.0/win32-x64-archive/stable#/dl.7z",
+            "hash": "d2e2f34633da35b373731ba6147b69fd30cd301eaef6d4a7d9558fbc71f72ac1"
+        },
+        "32bit": {
+            "url": "https://update.code.visualstudio.com/1.74.0/win32-archive/stable#/dl.7z",
+            "hash": "7f0e4ce994028603a5a51c7c7e010afbcc1340030dd59c5ff5f7b5ec16fbb413"
+        },
+        "arm64": {
+            "url": "https://update.code.visualstudio.com/1.74.0/win32-arm64-archive/stable#/dl.7z",
+            "hash": "8f26a3e73a07d5975e714fbd5a455b5e0fbd51dbcab42bc0bae04c4bda2b06e7"
+        }
+    },
+    "env_add_path": "bin",
+    "shortcuts": [
+        [
+            "code.exe",
+            "Visual Studio Code"
+        ]
+    ],
+    "post_install": [
+        "$dirpath = \"$dir\".Replace('\\', '\\\\')",
+        "$exepath = \"$dir\\Code.exe\".Replace('\\', '\\\\')",
+        "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context' | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
+        "    $content = $content.Replace('$codedir', $dirpath)",
+        "    $content = $content.Replace('$code', $exepath)",
+        "    if ($global) {",
+        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
+        "  }",
+        "}",
+        "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.vscode\\extensions\")) {",
+        "    info '[Portable Mode] Copying extensions...'",
+        "    Copy-Item \"$env:USERPROFILE\\.vscode\\extensions\" \"$dir\\data\" -Recurse",
+        "}",
+        "if (!(Test-Path \"$dir\\data\\user-data\") -and (Test-Path \"$env:AppData\\Code\")) {",
+        "    info '[Portable Mode] Copying user data...'",
+        "    Copy-Item \"$env:AppData\\Code\" \"$dir\\data\\user-data\" -Recurse",
+        "}"
+    ],
+    "uninstaller": {
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }"
+    }
+}

--- a/bucket/vscodium174022342.json
+++ b/bucket/vscodium174022342.json
@@ -51,6 +51,6 @@
         "    info '[Portable Mode] Copying user data...'",
         "    Copy-Item \"$env:AppData\\VSCodium\" \"$dir\\data\\user-data\" -Recurse",
         "}"
-    ]
+    ],
     "pre_uninstall": "reg import \"$dir\\uninstall-associations.reg\"; reg import \"$dir\\uninstall-context.reg\"",
 }

--- a/bucket/vscodium174022342.json
+++ b/bucket/vscodium174022342.json
@@ -1,0 +1,55 @@
+{
+    "version": "1.74.0.22342",
+    "description": "Binary releases of VS Code without MS branding/telemetry/licensing.",
+    "homepage": "https://github.com/VSCodium/vscodium",
+    "license": "MIT",
+    "notes": [
+        "Add VSCodium as a context menu option by running: 'reg import \"$dir\\install-context.reg\"'",
+        "For file associations, run 'reg import \"$dir\\install-associations.reg\"'"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.74.0.22342/VSCodium-win32-x64-1.74.0.22342.zip",
+            "hash": "65fd0872bf619c5b8e98c7bd3b260467dcf9314c19ff0b601cc6d36188477d12"
+        },
+        "32bit": {
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.74.0.22342/VSCodium-win32-ia32-1.74.0.22342.zip",
+            "hash": "1024ff8a8a78f0f674e5f96f3b88b436e7bd2593efc6c3da555555179cd46c0e"
+        },
+        "arm64": {
+            "url": "https://github.com/VSCodium/vscodium/releases/download/1.74.0.22342/VSCodium-win32-arm64-1.74.0.22342.zip",
+            "hash": "42da06e2fc800f52d8d36a271981ed7470fc81c56a9351e0f56cfd7c430d1e89"
+        }
+    },
+    "env_add_path": "bin",
+    "shortcuts": [
+        [
+            "VSCodium.exe",
+            "VSCodium"
+        ]
+    ],
+    "post_install": [
+        "$dirpath = \"$dir\".Replace('\\', '\\\\')",
+        "$exepath = \"$dir\\VSCodium.exe\".Replace('\\', '\\\\')",
+        "'install-associations', 'uninstall-associations', 'install-context', 'uninstall-context' | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\extras\\scripts\\vscode\\$_.reg\"",
+        "    $content = $content.Replace('$codedir', $dirpath)",
+        "    $content = $content.Replace('$code', $exepath)",
+        "    $content = $content.Replace('&Code', '&VSCodium')",
+        "    if ($global) {",
+        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    $content | Set-Content -Path \"$dir\\$_.reg\"",
+        "  }",
+        "}",
+        "if (!(Test-Path \"$dir\\data\\extensions\") -and (Test-Path \"$env:USERPROFILE\\.vscode-oss\\extensions\")) {",
+        "    info '[Portable Mode] Copying extensions...'",
+        "    Copy-Item \"$env:USERPROFILE\\.vscode-oss\\extensions\" \"$dir\\data\" -Recurse",
+        "}",
+        "if (!(Test-Path \"$dir\\data\\user-data\") -and (Test-Path \"$env:AppData\\VSCodium\")) {",
+        "    info '[Portable Mode] Copying user data...'",
+        "    Copy-Item \"$env:AppData\\VSCodium\" \"$dir\\data\\user-data\" -Recurse",
+        "}"
+    ]
+}

--- a/bucket/vscodium174022342.json
+++ b/bucket/vscodium174022342.json
@@ -52,4 +52,5 @@
         "    Copy-Item \"$env:AppData\\VSCodium\" \"$dir\\data\\user-data\" -Recurse",
         "}"
     ]
+    "pre_uninstall": "reg import \"$dir\\uninstall-associations.reg\"; reg import \"$dir\\uninstall-context.reg\"",
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
VSCode and VSCodium currently have a bug where the installed extensions from the previous version are not recognized by the latest version. These manifests were made to combat these errors. The manifests have been downgraded to a previous version, where the user's installed extensions worked just fine.

If this issue gets patched, please remove these manifests.

See this issue for more info, https://github.com/microsoft/vscode/issues/169359

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
