### PR TITLE
CloudCompare: Add version 2.13.alpha

### DIFF
--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -22,7 +22,11 @@
         "regex": "Latest\\s+.*(alpha|beta).*\\s+release.+(?<version>[\\d.]+[a-z]+)"
     },
     "autoupdate": {
-        "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",
-        "extract_dir": "CloudCompare_v$matchVersion_bin_x64"
+        "architecture": {
+            "64bit": {
+                "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",
+                "extract_dir": "CloudCompare_v$matchVersion_bin_x64"
+            }
+        }
     }
 }

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -16,12 +16,14 @@
             "CloudCompare"
         ]
     ],
+    "##": "Latest <span class="highlight">beta</span> release: 2.13.alpha (01/09/2023)",
     "checkver": {
         "url": "https://cloudcompare.org/release/",
-        "regex": "Latest (alpha|beta) release.+\\(?(\\d+\\.\\d+\\.[a-z]+) "
+        "regex": "Latest\\s+.*(alpha|beta).*\\s+release.+(?<version>[\\d.]+[a-z]+)"
+        
     },
     "autoupdate": {
-        "url": "https://cloudcompare.org/release/CloudCompare_v$version_bin_x64.7z",
+        "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",
         "extract_dir": "CloudCompare_v$version_bin_x64"
     }
 }

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cloudcompare.org/release/CloudCompare_v2.13.alpha_bin_x64.7z",
-            "hash": "md5:d5595527584383c4753a405434773112"
+            "hash": "ad892a4c7957ac99af8ff58382dee6730c05a35d491a0017150118a17732bee6"
         }
     },
     "extract_dir": "CloudCompare_v2.13.alpha_bin_x64",

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -24,8 +24,8 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",
-                "extract_dir": "CloudCompare_v$matchVersion_bin_x64"
+                "url": "https://cloudcompare.org/release/CloudCompare_v$version_bin_x64.7z",
+                "extract_dir": "CloudCompare_v$version_bin_x64"
             }
         }
     }

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -19,7 +19,7 @@
     "##": "Latest <span class=\"highlight\">beta</span> release: 2.13.alpha (01/09/2023)",
     "checkver": {
         "url": "https://cloudcompare.org/release/",
-        "regex": "Latest\\s+.*(alpha|beta).*\\s+release.+(?<version>[\\d.]+[a-z]+)"
+        "regex": "Latest\\s+.*(?<ignore>alpha|beta).*\\s*release:\\s*([\\d.]+[a-z]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -1,0 +1,27 @@
+{
+    "version": "2.13.alpha",
+    "description": "3D point cloud and mesh processing software",
+    "homepage": "https://cloudcompare.org/",
+    "license": "GPL-2.0-or-later,LGPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://cloudcompare.org/release/CloudCompare_v2.13.alpha_bin_x64.7z",
+            "hash": "md5:d5595527584383c4753a405434773112"
+        }
+    },
+    "extract_dir": "CloudCompare_v2.13.alpha_bin_x64",
+    "shortcuts": [
+        [
+            "CloudCompare.exe",
+            "CloudCompare"
+        ]
+    ],
+    "checkver": {
+        "url": "https://cloudcompare.org/release/",
+        "regex": "Latest (alpha|beta) release.+\\(?(\\d+\\.\\d+\\.[a-z]+) "
+    },
+    "autoupdate": {
+        "url": "https://cloudcompare.org/release/CloudCompare_v$version_bin_x64.7z",
+        "extract_dir": "CloudCompare_v$version_bin_x64"
+    }
+}

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -20,7 +20,6 @@
     "checkver": {
         "url": "https://cloudcompare.org/release/",
         "regex": "Latest\\s+.*(alpha|beta).*\\s+release.+(?<version>[\\d.]+[a-z]+)"
-        
     },
     "autoupdate": {
         "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -16,7 +16,7 @@
             "CloudCompare"
         ]
     ],
-    "##": "Latest <span class="highlight">beta</span> release: 2.13.alpha (01/09/2023)",
+    "##": "Latest <span class=\"highlight\">beta</span> release: 2.13.alpha (01/09/2023)",
     "checkver": {
         "url": "https://cloudcompare.org/release/",
         "regex": "Latest\\s+.*(alpha|beta).*\\s+release.+(?<version>[\\d.]+[a-z]+)"

--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -23,6 +23,6 @@
     },
     "autoupdate": {
         "url": "https://cloudcompare.org/release/CloudCompare_v$matchVersion_bin_x64.7z",
-        "extract_dir": "CloudCompare_v$version_bin_x64"
+        "extract_dir": "CloudCompare_v$matchVersion_bin_x64"
     }
 }


### PR DESCRIPTION
- technically it's sometimes alpha and sometimes beta, so I'd say we combine them
- stable release is under Scoop Extras: https://github.com/ScoopInstaller/Extras/blob/1027c39d3d724e3dba4440c2adb8b237d84416da/bucket/cloudcompare.json

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
