### PR TITLE
php80-xdebug: Add version 3.2.0

### DIFF
--- a/bucket/php80-xdebug.json
+++ b/bucket/php80-xdebug.json
@@ -1,0 +1,45 @@
+{
+    "version": "3.2.0-8.0",
+    "description": "A popular general-purpose scripting language that is especially suited to web development. (version 8.0)",
+    "homepage": "https://xdebug.org/",
+    "license": {
+        "identifier": "Xdebug-1.01",
+        "url": "https://xdebug.org/license.php"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://xdebug.org/files/php_xdebug-3.2.0-8.0-vs16-x86_64.dll#/php_xdebug.dll",
+            "hash": "5e9442d24df01f0aff16f2496791963ee4f05f0f1ca0e917eb18164d4edaf35c"
+        }
+    },
+    "post_install": [
+        "$phpconfd = \"$persist_dir\\..\\php80\\cli\\conf.d\"",
+        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        "if(!(test-path $phpconfd\\xdebug.ini)) {",
+        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
+        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
+        "} else {",
+        "    Write-Host -f Yellow \"PHP 8.0 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
+        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "}"
+    ],
+    "notes": [
+        "Xdebug is already enabled if PHP 8.0 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
+    "checkver": {
+        "url": "https://xdebug.org/download/historical",
+        "regex": "php_xdebug-([\\d.]+-8.0)-vs16-x86_64.dll"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll"
+            }
+        },
+        "hash": {
+            "url": "https://xdebug.org/download/historical",
+            "regex": "([a-fA-F0-9]{64}).+?$basename"
+        }
+    }
+}

--- a/bucket/php81-xdebug.json
+++ b/bucket/php81-xdebug.json
@@ -1,0 +1,45 @@
+{
+    "version": "3.2.0-8.1",
+    "description": "A popular general-purpose scripting language that is especially suited to web development. (version 8.1)",
+    "homepage": "https://xdebug.org/",
+    "license": {
+        "identifier": "Xdebug-1.01",
+        "url": "https://xdebug.org/license.php"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://xdebug.org/files/php_xdebug-3.2.0-8.1-vs16-x86_64.dll#/php_xdebug.dll",
+            "hash": "73829cb63664be27cd243220f4412fd605a159f1b7b2b604d636d704f5794613"
+        }
+    },
+    "post_install": [
+        "$phpconfd = \"$persist_dir\\..\\php81\\cli\\conf.d\"",
+        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        "if(!(test-path $phpconfd\\xdebug.ini)) {",
+        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
+        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
+        "} else {",
+        "    Write-Host -f Yellow \"PHP 8.1 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
+        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "}"
+    ],
+    "notes": [
+        "Xdebug is already enabled if PHP 8.1 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
+    "checkver": {
+        "url": "https://xdebug.org/download/historical",
+        "regex": "php_xdebug-([\\d.]+-8.1)-vs16-x86_64.dll"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll"
+            }
+        },
+        "hash": {
+            "url": "https://xdebug.org/download/historical",
+            "regex": "([a-fA-F0-9]{64}).+?$basename"
+        }
+    }
+}

--- a/bucket/php82-xdebug.json
+++ b/bucket/php82-xdebug.json
@@ -1,0 +1,45 @@
+{
+    "version": "3.2.0-8.2",
+    "description": "A popular general-purpose scripting language that is especially suited to web development. (version 8.2)",
+    "homepage": "https://xdebug.org/",
+    "license": {
+        "identifier": "Xdebug-1.01",
+        "url": "https://xdebug.org/license.php"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://xdebug.org/files/php_xdebug-3.2.0-8.2-vs16-x86_64.dll#/php_xdebug.dll",
+            "hash": "f7f8207db1c4c2b95497e0bec27b2354c16a8caa85490c434c67502836b17f15"
+        }
+    },
+    "post_install": [
+        "$phpconfd = \"$persist_dir\\..\\php82\\cli\\conf.d\"",
+        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        "if(!(test-path $phpconfd\\xdebug.ini)) {",
+        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
+        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
+        "} else {",
+        "    Write-Host -f Yellow \"PHP 8.2 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
+        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "}"
+    ],
+    "notes": [
+        "Xdebug is already enabled if PHP 8.2 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
+    "checkver": {
+        "url": "https://xdebug.org/download/historical",
+        "regex": "php_xdebug-([\\d.]+-8.2)-vs16-x86_64.dll"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://xdebug.org/files/php_xdebug-$version-vs16-x86_64.dll#/php_xdebug.dll"
+            }
+        },
+        "hash": {
+            "url": "https://xdebug.org/download/historical",
+            "regex": "([a-fA-F0-9]{64}).+?$basename"
+        }
+    }
+}


### PR DESCRIPTION
Add php-xdebug 3.2.0 version for PHP 8.0, 8.1, 8.2

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).