### PR TITLE
odin-dev: Remove `extract_dir` to solve `bin` error

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,7 +9,6 @@
             "hash": "17fe50d8980637c3be9e4880bd6eaf9fe7a025d6600cf386af99144caf3a2ce9"
         }
     },
-    "extract_dir": "windows_artifacts",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",


### PR DESCRIPTION
Odin seems to have changed their folder structure again, like pre #742. I'll suggest that the Odin project keeps their folder structure the same in the near future, but this just fixes the latest version.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to #742 
Relates to #740 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
