### PR TITLE
systeminformer-nightly: Fix `architecture.extract_dir`, and fixed other small errors

### DIFF
--- a/bucket/systeminformer-nightly.json
+++ b/bucket/systeminformer-nightly.json
@@ -3,18 +3,29 @@
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://systeminformer.sourceforge.io",
     "license": "MIT",
+    "url": "https://github.com/winsiderss/si-builds/releases/download/3.0.5727/systeminformer-3.0.5727-bin.zip",
+    "hash": "d06ebb4f230cfaa7e39a446f633645c354a513a7f58ecc974f5342230fc0607b",
     "architecture": {
-        "64bit": {
-            "url": "https://github.com/winsiderss/si-builds/releases/download/3.0.5727/systeminformer-3.0.5727-bin.zip",
-            "hash": "d06ebb4f230cfaa7e39a446f633645c354a513a7f58ecc974f5342230fc0607b",
-            "extract_dir": "64bit"
-        },
         "32bit": {
-            "url": "https://github.com/winsiderss/si-builds/releases/download/3.0.5727/systeminformer-3.0.5727-bin.zip",
-            "hash": "d06ebb4f230cfaa7e39a446f633645c354a513a7f58ecc974f5342230fc0607b",
-            "extract_dir": "32bit"
+            "extract_dir": "i386"
+        },
+        "64bit": {
+            "extract_dir": "amd64"
+        },
+        "arm64": {
+            "extract_dir": "arm64"
         }
     },
+    "pre_install": [
+        "ensure \"$persist_dir\" | Out-Null",
+        "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -ErrorAction 'SilentlyContinue' }"
+    ],
+    "shortcuts": [
+        [
+            "SystemInformer.exe",
+            "System Informer"
+        ]
+    ],
     "post_install": [
         "# Clear icon GUIDs",
         "$settings = Get-ChildItem \"$dir\\SystemInformer.exe.settings.xml\"",
@@ -23,16 +34,7 @@
         "($settingsXml.settings.ChildNodes | Where-Object { $_.name.Contains(\"IconGuids\") }) | ForEach-Object { [void]$_.ParentNode.RemoveChild($_) }",
         "$settingsXml.Save($settings)"
     ],
-    "shortcuts": [
-        [
-            "SystemInformer.exe",
-            "System Informer"
-        ]
-    ],
-    "persist": [
-        "SystemInformer.exe.settings.xml",
-        "usernotesdb.xml"
-    ],
+    "pre_uninstall": "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -ErrorAction 'SilentlyContinue' }",
     "checkver": {
         "url": "https://github.com/winsiderss/si-builds/releases",
         "regex": "/tag/([\\d.]+)"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Fixes this bug that I had with this app while updating it.
![(WindowsTerminal)14l2p6_12-28-2022](https://user-images.githubusercontent.com/101912712/209795217-7528f0cc-b2cf-4b94-a21c-4be31904e732.jpg)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
