### PR TITLE
kdeconnect-nightly: Fix autoupdate and update version

### DIFF
--- a/bucket/kdeconnect-nightly.json
+++ b/bucket/kdeconnect-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1343",
+    "version": "1388",
     "description": "Communications and data transfer between devices over local networks",
     "homepage": "https://apps.kde.org/kdeconnect",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-master-1343-windows-msvc2019_64-cl.7z",
-            "hash": "0e4aaf4f27762af6785a1d1e8b5069d01329d2a079b627c78037e0dc190fb103"
+            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/1388/artifact/kdeconnect-kde-master-1388-windows-cl-msvc2019-x86_64.7z",
+            "hash": "2e9bbcb07638116b4426613cc9e596fd7ab4782277e8cd98b94588ef94b76bec"
         }
     },
     "bin": [

--- a/bucket/kdeconnect-nightly.json
+++ b/bucket/kdeconnect-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1388",
+    "version": "1394",
     "description": "Communications and data transfer between devices over local networks",
     "homepage": "https://apps.kde.org/kdeconnect",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/1388/artifact/kdeconnect-kde-master-1388-windows-cl-msvc2019-x86_64.7z",
-            "hash": "2e9bbcb07638116b4426613cc9e596fd7ab4782277e8cd98b94588ef94b76bec"
+            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/1394/artifact/kdeconnect-kde-master-1394-windows-cl-msvc2019-x86_64.7z",
+            "hash": "8c740dbadadb50b144952145d412e120f7fcd041c0a85af56a19e5a8f6da55fa"
         }
     },
     "bin": [

--- a/bucket/kdeconnect-nightly.json
+++ b/bucket/kdeconnect-nightly.json
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/",
-        "regex": "kdeconnect-kde-master-(\\d+)-windows"
+        "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/api/json/",
+        "jsonpath": "$.number"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/artifact/kdeconnect-kde-master-$version-windows-msvc2019_64-cl.7z"
+                "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/$version/artifact/kdeconnect-kde-master-$version-windows-cl-msvc2019-x86_64.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- Fixes a change in the artifact url that caused the manifest autoupdate to fail
- Changed checkver to use the jenkins api to retrieve the build number
- Updated manifest to latest build version

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
