### PR TITLE
qview-nightly: Add possible plugin persists

### DIFF
--- a/bucket/qview-nightly.json
+++ b/bucket/qview-nightly.json
@@ -17,7 +17,14 @@
     },
     "pre_install": [
         "Get-ChildItem \"$dir\\qView-nightly-*.exe\" | Rename-Item -NewName { $_.name -Replace '-nightly.+', '.exe' }",
-        "Remove-Item \"$dir\\qView-*.*-win*.exe\""
+        "Remove-Item \"$dir\\qView-*.*-win*.exe\"",
+        "'apng', 'apngd', 'avif', 'jpegxl' | ForEach-Object { $_ = \"imageformats\\q$_.dll\"; if (!(Test-Path \"$persist_dir\\$_\")) { New-Item \"$dir\\$_\" | Out-Null } }"
+    ],
+    "persist": [
+        "imageformats\\qapng.dll",
+        "imageformats\\qapngd.dll",
+        "imageformats\\qavif.dll",
+        "imageformats\\qjpegxl.dll"
     ],
     "bin": "qView.exe",
     "shortcuts": [


### PR DESCRIPTION
This allows people to add `imageformats` plugins if they so choose

These are common ones, I'm open to adding more on request, but it's better to at least support these as it's a pretty large amount of functionality.

Relates to https://github.com/ScoopInstaller/Extras/pull/10165

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).