### PR TITLE
everything-alpha: Fix typo in context menu item

### DIFF
--- a/scripts/everything/install-context.reg
+++ b/scripts/everything/install-context.reg
@@ -1,14 +1,14 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
-@="Search with Everything"
+@="Search with &Everything"
 "Icon"="$app_path"
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
 @="$app_path -path \"%1\""
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
-@="Search with Everything"
+@="Search with &Everything"
 "Icon"="$app_path"
 
 ; %v – For verbs that are none implies all. If there is no parameter passed this is the working directory.
@@ -16,7 +16,7 @@ Windows Registry Editor Version 5.00
 @="$app_path -path \"%V\""
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
-@="Search with Everything"
+@="Search with &Everything"
 "Icon"="$app_path"
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]

--- a/scripts/everything/install-context.reg
+++ b/scripts/everything/install-context.reg
@@ -1,14 +1,14 @@
 Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything]
-@="search with &Everything"
+@="Search with Everything"
 "Icon"="$app_path"
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\shell\Everything\command]
 @="$app_path -path \"%1\""
 
 [HKEY_CURRENT_USER\Software\Classes\Directory\Background\shell\Everything]
-@="search with &Everything"
+@="Search with Everything"
 "Icon"="$app_path"
 
 ; %v – For verbs that are none implies all. If there is no parameter passed this is the working directory.
@@ -16,7 +16,7 @@ Windows Registry Editor Version 5.00
 @="$app_path -path \"%V\""
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything]
-@="search with &Everything"
+@="Search with Everything"
 "Icon"="$app_path"
 
 [HKEY_CURRENT_USER\Software\Classes\Drive\shell\Everything\command]


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Changes the context menu from 'search with Everything' to 'Search with Everything'. This issue also affects the regular `everything` version in the extras bucket. PR for that: https://github.com/ScoopInstaller/Extras/pull/10243

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
