### PR TITLE
winget1.4: Add version 1.4.10173, winget 1.5: Add version 1.5.101

### DIFF
--- a/bucket/winget1.4.json
+++ b/bucket/winget1.4.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.4.10173",
+    "description": "Windows Package Manager CLI (aka winget) (latest 1.4.x release)",
+    "homepage": "https://github.com/microsoft/winget-cli",
+    "license": "MIT",
+    "notes": [
+        "At least Windows 10 build 17763 is required to use winget.",
+        "For documentation on settings, see: https://aka.ms/winget-settings."
+    ],
+    "suggest": {
+        "vcredist": "extras/vcredist"
+    },
+    "url": "https://github.com/microsoft/winget-cli/releases/download/v1.4.10173/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+    "hash": "091899dff6a9b4d7ff364e03e408cfc1efac382ddfd945e69e952bb364e2b208",
+    "architecture": {
+        "64bit": {
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"
+        },
+        "32bit": {
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x86.msix' | Remove-Item -Force -Recurse"
+        }
+    },
+    "installer": {
+        "script": "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
+    },
+    "bin": "winget.exe",
+    "checkver": {
+        "url": "https://github.com/microsoft/winget-cli/releases.atom",
+        "regex": "tag/v(1\\.4\\.[\\d.]+)(?<preview>(-preview)?)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPreview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+        "hash": {
+            "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPreview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt"
+        }
+    }
+}

--- a/bucket/winget1.5.json
+++ b/bucket/winget1.5.json
@@ -1,0 +1,37 @@
+{
+    "version": "1.5.101",
+    "description": "Windows Package Manager CLI (aka winget) (latest 1.5.x release)",
+    "homepage": "https://github.com/microsoft/winget-cli",
+    "license": "MIT",
+    "notes": [
+        "At least Windows 10 build 17763 is required to use winget.",
+        "For documentation on settings, see: https://aka.ms/winget-settings."
+    ],
+    "suggest": {
+        "vcredist": "extras/vcredist"
+    },
+    "url": "https://github.com/microsoft/winget-cli/releases/download/v1.5.101-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+    "hash": "a52728407282ed1e5b83f8116f7d4b771b8f3208a7953a06df57e6ad983c8d01",
+    "architecture": {
+        "64bit": {
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"
+        },
+        "32bit": {
+            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x86.msix' | Remove-Item -Force -Recurse"
+        }
+    },
+    "installer": {
+        "script": "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal"
+    },
+    "bin": "winget.exe",
+    "checkver": {
+        "url": "https://github.com/microsoft/winget-cli/releases.atom",
+        "regex": "tag/v(1\\.5\\.[\\d.]+)(?<preview>(-preview)?)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPreview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle#/dl.7z",
+        "hash": {
+            "url": "https://github.com/microsoft/winget-cli/releases/download/v$version$matchPreview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.txt"
+        }
+    }
+}


### PR DESCRIPTION
[winget-preview](https://github.com/ScoopInstaller/Versions/blob/master/bucket/winget-preview.json) is seeing the 1.5 version, so the 1.4 version was not available.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
