### PR TITLE
fix: godot url #955

### DIFF
--- a/bucket/godot-alpha.json
+++ b/bucket/godot-alpha.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/news",
+        "url": "https://godotengine.org/blog/pre-release/",
         "regex": "Dev snapshot: Godot (?<ver>[\\d.]+) alpha (?<alpha>[\\d.]+)",
         "replace": "${1}-alpha${2}"
     },

--- a/bucket/godot-beta.json
+++ b/bucket/godot-beta.json
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/news",
+        "url": "https://godotengine.org/blog/pre-release/",
         "regex": "Dev snapshot: Godot (?<ver>[\\d.]+) beta (?<beta>[\\d.]+)",
         "replace": "${1}-beta${2}"
     },

--- a/bucket/godot-mono-beta.json
+++ b/bucket/godot-mono-beta.json
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/news",
+        "url": "https://godotengine.org/blog/pre-release/",
         "regex": "Dev snapshot: Godot (?<ver>[\\d.]+) beta (?<beta>[\\d.]+)",
         "replace": "${1}-beta${2}"
     },

--- a/bucket/godot-mono-rc.json
+++ b/bucket/godot-mono-rc.json
@@ -1,18 +1,18 @@
 {
-    "version": "4.0-rc3",
+    "version": "4.0-rc4",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc3/mono/Godot_v4.0-rc3_mono_win64.zip",
-            "hash": "sha512:bb5747dbac735d9f29177b4c497c982d8bd00f112fb707b8f0947acf1e27685e390ad07627a777619e090533226ab526e629c58cb6e63c5e5f31c29f8567ef65",
-            "extract_dir": "Godot_v4.0-rc3_mono_win64"
+            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc4/mono/Godot_v4.0-rc4_mono_win64.zip",
+            "hash": "sha512:fc30f67abbbb546b356f372afd99175ac83bb04947bf0b2c40d76a5ae7d18dcce84c24eed9519037a1a7422d7537cf70422aa9f91552447cee22a70adef34caf",
+            "extract_dir": "Godot_v4.0-rc4_mono_win64"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc3/mono/Godot_v4.0-rc3_mono_win32.zip",
-            "hash": "sha512:823a3aed8a7ac8fc81da8c6c7d6e394fdaca45c2b734deae48c1c92fe0f4977e9a8ace10bcbb03f192a2cef1142d742452a20ca5258c6184fb7bbb03dc942398",
-            "extract_dir": "Godot_v4.0-rc3_mono_win32"
+            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc4/mono/Godot_v4.0-rc4_mono_win32.zip",
+            "hash": "sha512:9de9cb998ab2530103b890bf6c5386c6683af0f2ea4c7c175b1e0e3e836f7345bca3f82c6120e77f9f31274f576c25d0fa9af89d93ddd029692099ceb1fdbc74",
+            "extract_dir": "Godot_v4.0-rc4_mono_win32"
         }
     },
     "pre_install": [
@@ -27,7 +27,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/blog",
+        "url": "https://godotengine.org/blog/pre-release/",
         "regex": "Release candidate: Godot (?<ver>[\\d.]+) RC (?<rc>[\\d.]+)",
         "replace": "${1}-rc${2}"
     },

--- a/bucket/godot-rc.json
+++ b/bucket/godot-rc.json
@@ -1,16 +1,16 @@
 {
-    "version": "4.0-rc3",
+    "version": "4.0-rc4",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc3/Godot_v4.0-rc3_win64.exe.zip",
-            "hash": "sha512:de5ed8043aa00329ed03cdef97726fc7899d36fc408f6aa0384cc54513f0f30b110f270b19255b42971d9bf89db86703d205fefcafee75207c7b9c078ba0b8a1"
+            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc4/Godot_v4.0-rc4_win64.exe.zip",
+            "hash": "sha512:2094fc7f4e4907f11d75eefa27131daa93be6cba1817cb79fe079fa74f23be1456c1380ede4125c7a993925c2403aa52910dadc9efd50623674f72fc8a39b38f"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc3/Godot_v4.0-rc3_win32.exe.zip",
-            "hash": "sha512:6fef227ae9d8aa18d5fb1747f47591077af647723aa2ff14046a7234f44ee1e3fe417c0dced49eaca1133beee995397da18a44b2431293541d5e99882d1aa498"
+            "url": "https://downloads.tuxfamily.org/godotengine/4.0/rc4/Godot_v4.0-rc4_win32.exe.zip",
+            "hash": "sha512:473093d2aaf908ba2752c53a21c8b9e2e5e5be6b4eb891571be261624af22a91ba871973e5a0c83355e09e524aa87d48cd71b399fa3592a3d3584dbd51127412"
         }
     },
     "pre_install": [
@@ -25,7 +25,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/news",
+        "url": "https://godotengine.org/blog/pre-release/",
         "regex": "Release candidate: Godot (?<ver>[\\d.]+) RC (?<rc>[\\d.]+)",
         "replace": "${1}-rc${2}"
     },


### PR DESCRIPTION
Fix Godot autoupdate url

Relates to #955

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
