### PR TITLE
postman-canary: Update to version 10.19.15-canary231101-0730

### DIFF
--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.13.6-canary230502-1507",
+    "version": "10.13.9-canary230531-0714",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.13.6-canary230502-1507/PostmanCanary-win64-10.13.6-canary230502-1507-full.nupkg",
-            "hash": "sha1:edd6e5b718ff23bbff8f189b33ec6aa08cc3a2a2"
+            "url": "https://dl.pstmn.io/download/10.13.9-canary230531-0714/PostmanCanary-win64-10.13.9-canary230531-0714-full.nupkg",
+            "hash": "sha1:86db7726c227a7340147d62be6ca6b3b04b58a61"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.13.9-canary230531-0714",
+    "version": "10.15.6-canary230706-1055",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.13.9-canary230531-0714/PostmanCanary-win64-10.13.9-canary230531-0714-full.nupkg",
-            "hash": "sha1:86db7726c227a7340147d62be6ca6b3b04b58a61"
+            "url": "https://dl.pstmn.io/download/10.15.6-canary230706-1055/PostmanCanary-win64-10.15.6-canary230706-1055-full.nupkg",
+            "hash": "sha1:2ee7c832860274bf9a25f128c488184e5cdb6060"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.16.5-canary230801-0730",
+    "version": "10.19.15-canary231101-0730",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.16.5-canary230801-0730/PostmanCanary-win64-10.16.5-canary230801-0730-full.nupkg",
-            "hash": "sha1:103afccdeef29ff596722f2f2f25c9fe3e29e249"
+            "url": "https://dl.pstmn.io/download/10.19.15-canary231101-0730/PostmanCanary-win64-10.19.15-canary231101-0730-full.nupkg",
+            "hash": "sha1:affff7b54cdd3f2c50135f34f530ecc56cc4aaa7"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.15.6-canary230706-1055",
+    "version": "10.16.5-canary230801-0730",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.15.6-canary230706-1055/PostmanCanary-win64-10.15.6-canary230706-1055-full.nupkg",
-            "hash": "sha1:2ee7c832860274bf9a25f128c488184e5cdb6060"
+            "url": "https://dl.pstmn.io/download/10.16.5-canary230801-0730/PostmanCanary-win64-10.16.5-canary230801-0730-full.nupkg",
+            "hash": "sha1:103afccdeef29ff596722f2f2f25c9fe3e29e249"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,19 +1,15 @@
 {
-    "version": "9.3.0-canary01",
-    "description": "Complete API development environment.",
-    "homepage": "https://www.getpostman.com/",
+    "version": "10.7.1-canary230110-0834",
+    "description": "Complete API development environment (canary version)",
+    "homepage": "https://www.postman.com/",
     "license": {
         "identifier": "Freeware",
-        "url": "https://www.getpostman.com/licenses/postman_eula"
+        "url": "https://www.postman.com/legal/terms/"
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/9.3.0-canary01/PostmanCanary-win64-9.3.0-canary01-full.nupkg#/dl.7z",
-            "hash": "sha1:e75eba44e07d47468eb5216ba9841145e40e67e1"
-        },
-        "32bit": {
-            "url": "https://dl.pstmn.io/download/9.3.0-canary01/PostmanCanary-win32-9.3.0-canary01-full.nupkg#/dl.7z",
-            "hash": "sha1:82c8b0398e5a881a95e597bfbda11f2241c1885c"
+            "url": "https://dl.pstmn.io/download/10.7.1-canary230110-0834/PostmanCanary-win64-10.7.1-canary230110-0834-full.nupkg",
+            "hash": "sha1:69d59d362233a4dffca8c454fcc6904a34896fce"
         }
     },
     "extract_dir": "lib\\net45",
@@ -31,16 +27,9 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.pstmn.io/download/$version/PostmanCanary-win64-$version-full.nupkg#/dl.7z",
+                "url": "https://dl.pstmn.io/download/$version/PostmanCanary-win64-$version-full.nupkg",
                 "hash": {
-                    "url": "https://dl.pstmn.io/RELEASES?platform=win64&channel=canary",
-                    "jsonpath": "$.releases[*].files[?(@.name=='$basename')].hash"
-                }
-            },
-            "32bit": {
-                "url": "https://dl.pstmn.io/download/$version/PostmanCanary-win32-$version-full.nupkg#/dl.7z",
-                "hash": {
-                    "url": "https://dl.pstmn.io/RELEASES?platform=win32&channel=canary",
+                    "url": "https://dl.pstmn.io/RELEASES?platform=win64&channel=canary&from=$version",
                     "jsonpath": "$.releases[*].files[?(@.name=='$basename')].hash"
                 }
             }

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.7.1-canary230110-0834",
+    "version": "10.10.4-canary230217-1037",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.7.1-canary230110-0834/PostmanCanary-win64-10.7.1-canary230110-0834-full.nupkg",
-            "hash": "sha1:69d59d362233a4dffca8c454fcc6904a34896fce"
+            "url": "https://dl.pstmn.io/download/10.10.4-canary230217-1037/PostmanCanary-win64-10.10.4-canary230217-1037-full.nupkg",
+            "hash": "sha1:bdf4e385df689c35a1d54ffbb82e9d7371192d0d"
         }
     },
     "extract_dir": "lib\\net45",

--- a/bucket/postman-canary.json
+++ b/bucket/postman-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "10.10.4-canary230217-1037",
+    "version": "10.13.6-canary230502-1507",
     "description": "Complete API development environment (canary version)",
     "homepage": "https://www.postman.com/",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dl.pstmn.io/download/10.10.4-canary230217-1037/PostmanCanary-win64-10.10.4-canary230217-1037-full.nupkg",
-            "hash": "sha1:bdf4e385df689c35a1d54ffbb82e9d7371192d0d"
+            "url": "https://dl.pstmn.io/download/10.13.6-canary230502-1507/PostmanCanary-win64-10.13.6-canary230502-1507-full.nupkg",
+            "hash": "sha1:edd6e5b718ff23bbff8f189b33ec6aa08cc3a2a2"
         }
     },
     "extract_dir": "lib\\net45",


### PR DESCRIPTION
- Update to last version from canary channel: 10.x instead of 9.x (since last stable 9.x is available here as per #665).
- Remove 32bit version (not available more).
- Update links.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
