### PR TITLE
vscode-insiders: use nightly version for autoupdate

### DIFF
--- a/bucket/vscode-insiders.json
+++ b/bucket/vscode-insiders.json
@@ -49,7 +49,21 @@
     "persist": "data",
     "checkver": {
         "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
-        "jsonpath": "$.productVersion"
+        "jsonpath": "$['productVersion','timestamp']",
+        "script": [
+            "# Simulate scoop's JsonPath behavior to work around a bug in Newtonsoft.Json's",
+            "# support for JsonPath's multiple property union",
+            "Add-Type -Path \"$script:PSScriptRoot\\..\\supporting\\validator\\bin\\Newtonsoft.Json.dll\"",
+            "$obj = [Newtonsoft.Json.JsonConvert]::DeserializeObject($page)",
+            "# This is the only change: change errorWhenNoMatch argument from $true to $false",
+            "# to work around the bug",
+            "$result = $obj.SelectTokens($jsonpath, $false)",
+            "# remove $jsonpath variable from parent scope to prevent Scoop's logic from running",
+            "$script:jsonpath = $null",
+            "$([String]::Join('\\n', $result))"
+        ],
+        "regex": "^(?<productVersion>.+)\\\\n(?<timestamp>.*)$",
+        "replace": "${productVersion}+${timestamp}"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/vscode-insiders.json
+++ b/bucket/vscode-insiders.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.76.0-insider",
+    "version": "1.76.0-insider+1676956801324",
     "description": "Visual Studio Code is a lightweight but powerful source code editor (Insiders, Portable Edition).",
     "homepage": "https://code.visualstudio.com/",
     "license": {
@@ -16,11 +16,11 @@
     "architecture": {
         "64bit": {
             "url": "https://update.code.visualstudio.com/latest/win32-x64-archive/insider#/dl.7z",
-            "hash": "18ec73147d7d2f5a633182ae5944509773140345b52e7a41581ee0cf6bf129d9"
+            "hash": "d79a2a8ce38b416afaa20bbfcf89c768b41b47a7b576eaee0243a088b0ae072b"
         },
         "32bit": {
             "url": "https://update.code.visualstudio.com/latest/win32-archive/insider#/dl.7z",
-            "hash": "6e1771e688ba45c57cb218ca04809cbd7d4ec1e5ad962d0e4ee10a729df04477"
+            "hash": "5444f94bff645ec857be8c08792712cf5ca9355607d3b94708b495c8d0835d1e"
         }
     },
     "post_install": [


### PR DESCRIPTION
VSCode Insider's `productVersion` doesn't change regularly since it tracks the next version of VSCode, but its `timestamp` changes nightly. Its `version` also changes nightly, though `version` is a commit hash so isn't comparable by `checkver`, which is why I chose `timestamp`. 

This includes a workaround for [a bug in Newtonsoft.Json's FieldMultipleFilter](
https://github.com/JamesNK/Newtonsoft.Json/blob/13.0.1/Src/Newtonsoft.Json/Linq/JsonPath/FieldMultipleFilter.cs#L33-L36) (missing `else`), where it always throws an exception when passing `true` to `errorWhenNoMatch` of `JToken.SelectTokens(path, errorWhenNoMatch)` when using the JsonPath multiple property union syntax (e.g. `$['Prop1','Prop2']`). Scoop always passes `true` in its JsonPath code. This workaround can be removed once the bug is resolved (I'll be working on a PR for that repo tomorrow).

**Question for reviewer**: While I find it helpful to see the "Product Version" in the version string when running updates, I'm not sure it's really necessary. We could always do something similar to [`ipfilter-nightly`](https://github.com/ScoopInstaller/Versions/blob/master/bucket/ipfilter-nightly.json), and _just_ use the timestamp as the version, which would make for a cleaner `checkver` section. Thoughts?

Closes #1004

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).