### PR TITLE
vlc-nightly-ucrt-llvm : Add version 20230222

### DIFF
--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,0 +1,51 @@
+{
+    "version": "20230222",
+    "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
+    "homepage": "https://www.videolan.org/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230222-0429/vlc-4.0.0-dev-win64-013a1e4a.7z",
+            "hash": "sha512:deabf07c8363ee8b145000daf05aeaac7a22beab07c96fbe0efbece5f445177a9f7fc16092323957a8cbd0928ca89d3a80a472b2e16a785d702c0a187646de1b"
+        }
+    },
+    "extract_dir": "vlc-4.0.0-dev",
+    "pre_install": [
+        "if (!(Test-Path \"$persist_dir\\portable\") -and (Test-Path \"$env:APPDATA\\vlc\")) {",
+        "    info \"Copying old '$env:APPDATA\\vlc' to '$persist_dir\\portable'\"",
+        "    ensure \"$dir\\portable\\vlc\" | Out-Null",
+        "    Copy-Item \"$env:APPDATA\\vlc\\*\" \"$dir\\portable\" -Recurse -Force",
+        "    Move-Item \"$dir\\portable\\vlc-qt-interface.ini\" \"$dir\\portable\\vlc\"",
+        "}"
+    ],
+    "bin": "vlc.exe",
+    "shortcuts": [
+        [
+            "vlc.exe",
+            "VLC media player"
+        ]
+    ],
+    "persist": "portable",
+    "checkver": {
+        "script": [
+            "$base_url = 'https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/'",
+            "$page = Invoke-WebRequest $base_url -UseBasicParsing",
+            "$full_version = $page.links | Where-Object href -match '\\d\\d\\d\\d\\d\\d\\d\\d-\\d+' | Select-Object -first 1 -expand href",
+            "$dl_page = Invoke-WebRequest ($base_url + $full_version) -UseBasicParsing",
+            "$dl = $full_version + ($dl_page.links | Where-Object href -match '.7z' | Select-Object -first 1 -expand href)",
+            "Write-Output $dl"
+        ],
+        "regex": "(?<package_sub_url>(?<version_folder>(\\d\\d\\d\\d\\d\\d\\d\\d)-\\d+)\\/(?<package_folder_name>vlc-[\\d.]+-dev).+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/$matchPackage_Sub_Url",
+                "hash": {
+                    "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/$matchVersion_Folder/SHA512SUM"
+                }
+            }
+        },
+        "extract_dir": "$matchPackage_Folder_Name"
+    }
+}

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230329",
+    "version": "20240516",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230329-0427/vlc-4.0.0-dev-win64-4c6222e6.7z",
-            "hash": "sha512:066d75265cd6778ccdd6d8c54d4c4bb41d43fe754ad7adc0e1b6c8e6b7489c7d7707939a134e1c90af2e82cd3e62bde73f2e1bc88e9251449ed284dfdfdbc9e8"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20240516-0451/vlc-4.0.0-dev-win64-7f737771.7z",
+            "hash": "sha512:cc7c2b83ed8103d51fdfe0f0a8b7205c3747f426acaa885ba44c93cd88a8379b89ee72d0b15812e6d262ef441d727dd8f8781d4c19335aa987e97543f8e27535"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",
@@ -30,22 +30,21 @@
         "script": [
             "$base_url = 'https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/'",
             "$page = Invoke-WebRequest $base_url -UseBasicParsing",
-            "$full_version = $page.links | Where-Object href -match '\\d\\d\\d\\d\\d\\d\\d\\d-\\d+' | Select-Object -first 1 -expand href",
+            "$full_version = $page.Links.href.Where({ $_ -match '\\d{8}-\\d{4}/' }, 1)",
             "$dl_page = Invoke-WebRequest ($base_url + $full_version) -UseBasicParsing",
-            "$dl = $full_version + ($dl_page.links | Where-Object href -match '.7z' | Select-Object -first 1 -expand href)",
-            "Write-Output $dl"
+            "\"$full_version$($dl_page.Links.href.Where({ $_ -match '.7z$' }, 1))\""
         ],
-        "regex": "(?<package_sub_url>(?<version_folder>(\\d\\d\\d\\d\\d\\d\\d\\d)-\\d+)\\/(?<package_folder_name>vlc-[\\d.]+-dev).+)"
+        "regex": "(\\d{8})-(?<time>\\d{4})/(?<filename>(?<extract_dir>vlc-[\\d.]+-dev).+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/$matchPackage_Sub_Url",
+                "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/$version-$matchTime/$matchFilename",
                 "hash": {
-                    "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/$matchVersion_Folder/SHA512SUM"
+                    "url": "$baseurl/SHA512SUM"
                 }
             }
         },
-        "extract_dir": "$matchPackage_Folder_Name"
+        "extract_dir": "$matchExtract_Dir"
     }
 }

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230310",
+    "version": "20230311",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230310-0450/vlc-4.0.0-dev-win64-a4ac04bf.7z",
-            "hash": "sha512:edbf66a099c1001c6ef32593dfce1b34216b8bb8578fb6544c3cb9f3b1fc4253096888f8f2b11f00040edaaf36756a079ddeab74915cbbd6a13ab2d9403ef367"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230311-0429/vlc-4.0.0-dev-win64-36dbf29d.7z",
+            "hash": "sha512:2d873eb3c530cced3f5b489ff7b136cbebfd749d51a575971677b54868b53dca87b8c39cc7d1c82dcba185c7b8c4d5a446e7113c6d35d626e220182c88704824"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230316",
+    "version": "20230317",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230316-0442/vlc-4.0.0-dev-win64-6d90eba0.7z",
-            "hash": "sha512:7e3c1361f8d39c050903b63698ef4aab6eafaf99a891ec9108aeefa3601cf13d1774dc56570a619b97927d1e24d3ca26f26de4032a5cc8227c638450eb387942"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230317-0439/vlc-4.0.0-dev-win64-bdc6edb1.7z",
+            "hash": "sha512:9d3bcf58ccf59e7f68a13c4de399b3c29859eaeb9d5fc68d6354ebaa82ec1a804db8e6203b78af4b7c272998b422d75478b30fa51f15f4300172ee8d3b2da1a3"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230317",
+    "version": "20230318",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230317-0439/vlc-4.0.0-dev-win64-bdc6edb1.7z",
-            "hash": "sha512:9d3bcf58ccf59e7f68a13c4de399b3c29859eaeb9d5fc68d6354ebaa82ec1a804db8e6203b78af4b7c272998b422d75478b30fa51f15f4300172ee8d3b2da1a3"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230318-0439/vlc-4.0.0-dev-win64-e476328e.7z",
+            "hash": "sha512:5ccb985da04c7afa0a3dee1ec298bb83f073c5c0220fbea9b0ce311b789ae198188f4de811d090740bbfbaa962c5cb9b159dd2a2d37e5efa76cad92739f5e3b7"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230222",
+    "version": "20230303",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230222-0429/vlc-4.0.0-dev-win64-013a1e4a.7z",
-            "hash": "sha512:deabf07c8363ee8b145000daf05aeaac7a22beab07c96fbe0efbece5f445177a9f7fc16092323957a8cbd0928ca89d3a80a472b2e16a785d702c0a187646de1b"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230303-0427/vlc-4.0.0-dev-win64-11538a1e.7z",
+            "hash": "sha512:c2ffa26a3ee04469d93c1864816b0a1d4298c4b5f3b87e42f52630ecd807d5b541d7383db3a8e2b3b5a9f98181e30acd1ad78a9b4b7fdf459a46d2f744403931"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230323",
+    "version": "20230324",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230323-0447/vlc-4.0.0-dev-win64-f808bdd6.7z",
-            "hash": "sha512:d84bc265430c6c275e518bb4a9e3c965b93eb701029a9a743a92a20703a16c3383c36906237e499758943febb44ee06114c2f302a6b8e179577477b7b33de42e"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230324-0427/vlc-4.0.0-dev-win64-f7bb59d9.7z",
+            "hash": "sha512:df6e0558be192d305e07fe4406e70f42722d657f89bb6733458f9f4ff654e0bd694bbe9b8152b0af101c2f767456d3cca000583df9f4c761f7f21ef92506d49e"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230308",
+    "version": "20230309",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230308-0427/vlc-4.0.0-dev-win64-394232d6.7z",
-            "hash": "sha512:e628fdd5d0d6c0dbbe4796abafac7d31e247b550d3861d7f9a6dcd0c2dea7563be6ace530bf7e5268e1af4bad0524d28ddaf4d06d2e2a7613c5379b764f5e038"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230309-0428/vlc-4.0.0-dev-win64-0c25f466.7z",
+            "hash": "sha512:71ba6d9beb9fb04775c01f29713bb19666328f37881737e66d328dde71a52a801262a283a7e052058dc623b2c5b14ff5e45079c3cf74bec12c519996e9a7c4ce"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230311",
+    "version": "20230315",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230311-0429/vlc-4.0.0-dev-win64-36dbf29d.7z",
-            "hash": "sha512:2d873eb3c530cced3f5b489ff7b136cbebfd749d51a575971677b54868b53dca87b8c39cc7d1c82dcba185c7b8c4d5a446e7113c6d35d626e220182c88704824"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230315-0429/vlc-4.0.0-dev-win64-586e1cba.7z",
+            "hash": "sha512:aae7e262d1e669bff75cf0b911354cc6b052eac7cb58a83efd8f6fddb6192b14a99cbead7476178dd1910e3e70e8a1a8514191eaf7783eee0e5e0a6eb1e4abe8"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230309",
+    "version": "20230310",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230309-0428/vlc-4.0.0-dev-win64-0c25f466.7z",
-            "hash": "sha512:71ba6d9beb9fb04775c01f29713bb19666328f37881737e66d328dde71a52a801262a283a7e052058dc623b2c5b14ff5e45079c3cf74bec12c519996e9a7c4ce"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230310-0450/vlc-4.0.0-dev-win64-a4ac04bf.7z",
+            "hash": "sha512:edbf66a099c1001c6ef32593dfce1b34216b8bb8578fb6544c3cb9f3b1fc4253096888f8f2b11f00040edaaf36756a079ddeab74915cbbd6a13ab2d9403ef367"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230326",
+    "version": "20230327",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230326-1132/vlc-4.0.0-dev-win64-7ad79325.7z",
-            "hash": "sha512:93d4203c7a6a78a96c504f36943d17195bc1e2daefd631391cc74901f4462a441bb2ac797f8a16c23ab7823b5bbde09e9d6802a8bcfa696cb0ea170853a22247"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230327-0426/vlc-4.0.0-dev-win64-fc701dfa.7z",
+            "hash": "sha512:359e2db0fc68115ccca56fb0ebce190af2b36f49ff1b8b9864189a12275fb4265d77b5e2d7aec12e3b549201d850e351dce108d4022ace1b6bf5d09a21ff707e"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230315",
+    "version": "20230316",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230315-0429/vlc-4.0.0-dev-win64-586e1cba.7z",
-            "hash": "sha512:aae7e262d1e669bff75cf0b911354cc6b052eac7cb58a83efd8f6fddb6192b14a99cbead7476178dd1910e3e70e8a1a8514191eaf7783eee0e5e0a6eb1e4abe8"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230316-0442/vlc-4.0.0-dev-win64-6d90eba0.7z",
+            "hash": "sha512:7e3c1361f8d39c050903b63698ef4aab6eafaf99a891ec9108aeefa3601cf13d1774dc56570a619b97927d1e24d3ca26f26de4032a5cc8227c638450eb387942"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230324",
+    "version": "20230325",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230324-0427/vlc-4.0.0-dev-win64-f7bb59d9.7z",
-            "hash": "sha512:df6e0558be192d305e07fe4406e70f42722d657f89bb6733458f9f4ff654e0bd694bbe9b8152b0af101c2f767456d3cca000583df9f4c761f7f21ef92506d49e"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230325-0436/vlc-4.0.0-dev-win64-1ed24cb2.7z",
+            "hash": "sha512:82dd248752a28325b4a89d0c71fe7dadff7dcabd80f4ff739d39a709396edb3f3dc636aa5282100d69510e0ac53774b6004933d5779fdd0d826d5b4c043625ed"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230319",
+    "version": "20230320",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230319-0429/vlc-4.0.0-dev-win64-ff905bd5.7z",
-            "hash": "sha512:e7a160738f7abaea564437246bd617630154a444a02ebf5159fada5ee3a888adc4de2c2144c18eddba144655a626a812ca3e80eb5e9c66ceda2fbda2baf5f905"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230320-0453/vlc-4.0.0-dev-win64-7d70397c.7z",
+            "hash": "sha512:d78c58387e2b56cf04c81dd10a0e629faf13f99e7824becf2070c4132cce8a13fc530f710f3e784d80b969b56120a51d396a13a843fd9939d381581af2ab454c"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230320",
+    "version": "20230321",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230320-0453/vlc-4.0.0-dev-win64-7d70397c.7z",
-            "hash": "sha512:d78c58387e2b56cf04c81dd10a0e629faf13f99e7824becf2070c4132cce8a13fc530f710f3e784d80b969b56120a51d396a13a843fd9939d381581af2ab454c"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230321-0437/vlc-4.0.0-dev-win64-f5d79535.7z",
+            "hash": "sha512:0a727e5d10085f8c5d361f2d1b388340dc42e7d1a5c01e902f936c490174e26aab11ebde7d880962f4b9b36ad6b865e959501d7e439bb4c66045cb6458bb99df"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -22,7 +22,7 @@
     "shortcuts": [
         [
             "vlc.exe",
-            "VLC media player"
+            "VLC media player (UCRT LLVM Nightly)"
         ]
     ],
     "persist": "portable",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230328",
+    "version": "20230329",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230328-0429/vlc-4.0.0-dev-win64-8ef1866a.7z",
-            "hash": "sha512:eec2a48d1b83702cfa9a4e13472a5b15bc82aec7168bedfed67108006c50c0d3ebd86714102c38f5eca87ec48bbbd4fb81b7eb6d74ff266d8f47ddb4fc2823e4"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230329-0427/vlc-4.0.0-dev-win64-4c6222e6.7z",
+            "hash": "sha512:066d75265cd6778ccdd6d8c54d4c4bb41d43fe754ad7adc0e1b6c8e6b7489c7d7707939a134e1c90af2e82cd3e62bde73f2e1bc88e9251449ed284dfdfdbc9e8"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230306",
+    "version": "20230307",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230306-0427/vlc-4.0.0-dev-win64-3cb6645b.7z",
-            "hash": "sha512:5cebda4afc0b632f63d002cefc924906129b33204c343395e33f1585ea0c9b1df8ee4719207b952f809671d317bfa5f986c7f13a8a89aaeff1d905960a31cc1a"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230307-0453/vlc-4.0.0-dev-win64-3cb6645b.7z",
+            "hash": "sha512:e4731de82389fec7f1e91b9769c59666ca168db263a5d96c065776803b02e5624095c093417000c151b57e9bc195eea08fc8518fe7d98bfcffc9a47b0fc21d86"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230327",
+    "version": "20230328",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230327-0426/vlc-4.0.0-dev-win64-fc701dfa.7z",
-            "hash": "sha512:359e2db0fc68115ccca56fb0ebce190af2b36f49ff1b8b9864189a12275fb4265d77b5e2d7aec12e3b549201d850e351dce108d4022ace1b6bf5d09a21ff707e"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230328-0429/vlc-4.0.0-dev-win64-8ef1866a.7z",
+            "hash": "sha512:eec2a48d1b83702cfa9a4e13472a5b15bc82aec7168bedfed67108006c50c0d3ebd86714102c38f5eca87ec48bbbd4fb81b7eb6d74ff266d8f47ddb4fc2823e4"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230303",
+    "version": "20230306",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230303-0427/vlc-4.0.0-dev-win64-11538a1e.7z",
-            "hash": "sha512:c2ffa26a3ee04469d93c1864816b0a1d4298c4b5f3b87e42f52630ecd807d5b541d7383db3a8e2b3b5a9f98181e30acd1ad78a9b4b7fdf459a46d2f744403931"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230306-0427/vlc-4.0.0-dev-win64-3cb6645b.7z",
+            "hash": "sha512:5cebda4afc0b632f63d002cefc924906129b33204c343395e33f1585ea0c9b1df8ee4719207b952f809671d317bfa5f986c7f13a8a89aaeff1d905960a31cc1a"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230318",
+    "version": "20230319",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230318-0439/vlc-4.0.0-dev-win64-e476328e.7z",
-            "hash": "sha512:5ccb985da04c7afa0a3dee1ec298bb83f073c5c0220fbea9b0ce311b789ae198188f4de811d090740bbfbaa962c5cb9b159dd2a2d37e5efa76cad92739f5e3b7"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230319-0429/vlc-4.0.0-dev-win64-ff905bd5.7z",
+            "hash": "sha512:e7a160738f7abaea564437246bd617630154a444a02ebf5159fada5ee3a888adc4de2c2144c18eddba144655a626a812ca3e80eb5e9c66ceda2fbda2baf5f905"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230307",
+    "version": "20230308",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230307-0453/vlc-4.0.0-dev-win64-3cb6645b.7z",
-            "hash": "sha512:e4731de82389fec7f1e91b9769c59666ca168db263a5d96c065776803b02e5624095c093417000c151b57e9bc195eea08fc8518fe7d98bfcffc9a47b0fc21d86"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230308-0427/vlc-4.0.0-dev-win64-394232d6.7z",
+            "hash": "sha512:e628fdd5d0d6c0dbbe4796abafac7d31e247b550d3861d7f9a6dcd0c2dea7563be6ace530bf7e5268e1af4bad0524d28ddaf4d06d2e2a7613c5379b764f5e038"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230325",
+    "version": "20230326",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230325-0436/vlc-4.0.0-dev-win64-1ed24cb2.7z",
-            "hash": "sha512:82dd248752a28325b4a89d0c71fe7dadff7dcabd80f4ff739d39a709396edb3f3dc636aa5282100d69510e0ac53774b6004933d5779fdd0d826d5b4c043625ed"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230326-1132/vlc-4.0.0-dev-win64-7ad79325.7z",
+            "hash": "sha512:93d4203c7a6a78a96c504f36943d17195bc1e2daefd631391cc74901f4462a441bb2ac797f8a16c23ab7823b5bbde09e9d6802a8bcfa696cb0ea170853a22247"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",

--- a/bucket/vlc-nightly-ucrt-llvm.json
+++ b/bucket/vlc-nightly-ucrt-llvm.json
@@ -1,12 +1,12 @@
 {
-    "version": "20230321",
+    "version": "20230323",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230321-0437/vlc-4.0.0-dev-win64-f5d79535.7z",
-            "hash": "sha512:0a727e5d10085f8c5d361f2d1b388340dc42e7d1a5c01e902f936c490174e26aab11ebde7d880962f4b9b36ad6b865e959501d7e439bb4c66045cb6458bb99df"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-ucrt-llvm/20230323-0447/vlc-4.0.0-dev-win64-f808bdd6.7z",
+            "hash": "sha512:d84bc265430c6c275e518bb4a9e3c965b93eb701029a9a743a92a20703a16c3383c36906237e499758943febb44ee06114c2f302a6b8e179577477b7b33de42e"
         }
     },
     "extract_dir": "vlc-4.0.0-dev",


### PR DESCRIPTION
**VLC tests LLVM builds for win64.**
For more details : [VLC 4.0 Nightly LLVM vs non-LLVM](https://www.reddit.com/r/VLC/comments/w2i0mr/vlc_40_nightly_llvm_vs_nonllvm/)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).