### PR TITLE
zip-beta: Fix link

### DIFF
--- a/bucket/zip-beta.json
+++ b/bucket/zip-beta.json
@@ -9,8 +9,8 @@
         "zipnote.exe",
         "zipsplit.exe"
     ],
-    "url": "http://r.windows.random.supplies/zip3.1d26.zip",
-    "hash": "822b1a808636e28d0c67e76572a21dc2bc1b2a1c092cc01c762c883e2c2cbd63",
+    "url": "http://www.paehl.com/downloads/Zip3.1d26.7z",
+    "hash": "c042416f8e78dcbf5dc37091667baf772efe41b399db19a6a1f1aee22d59abda",
     "architecture": {
         "64bit": {
             "extract_dir": "x64"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The current link's domain has an expired certificate which breaks installation. After ignoring the cert error in the browser to download the archive, the `info.txt` inside indicates it was someone else who compiled the binaries so the current link is actually just a repack. Anyways, I have changed the link to the original source where the binaries came from (http://www.paehl.com/?Old_programs___ZIP_UNZIP)
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
