### PR TITLE
Add Gradle 7

### DIFF
--- a/bucket/gradle7.json
+++ b/bucket/gradle7.json
@@ -1,0 +1,16 @@
+{
+    "version": "7.6.1",
+    "description": "An open-source build automation tool focused on flexibility and performance. (Source code and documentation boundled)",
+    "homepage": "https://gradle.org",
+    "license": "Apache-2.0",
+    "hash": "518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2",
+    "url": "https://gradle.org/next-steps/?version=7.6.1&format=all",
+    "extract_dir": "gradle-7.6.1",
+    "bin": "bin\\gradle.bat",
+    "suggest": {
+        "JDK": [
+            "java/oraclejdk",
+            "java/openjdk"
+        ]
+    }
+}

--- a/bucket/gradle7.json
+++ b/bucket/gradle7.json
@@ -4,7 +4,7 @@
     "homepage": "https://gradle.org",
     "license": "Apache-2.0",
     "hash": "518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2",
-    "url": "https://gradle.org/next-steps/?version=7.6.1&format=all",
+    "url": "https://services.gradle.org/distributions/gradle-7.6.1-all.zip",
     "extract_dir": "gradle-7.6.1",
     "bin": "bin\\gradle.bat",
     "suggest": {


### PR DESCRIPTION
Add Gradle 7 to versions bucket, seeing that Gradle 8 got released.


Closes [1084](https://github.com/ScoopInstaller/Versions/issues/1084)

- [X ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
