### PR TITLE
ffmpeg-nightly: Fix `checkver`

### DIFF
--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -1,13 +1,13 @@
 {
-    "version": "1679923274",
+    "version": "2023-03-27-13-21",
     "description": "A complete, cross-platform solution to record, convert and stream audio and video.",
     "homepage": "https://ffmpeg.org",
     "license": "GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
-            "hash": "445ec058cb8d1e373e61c6f74d02e9202cc9a69b37643b00331ff7bbd1c01b6a",
-            "extract_dir": "ffmpeg-master-latest-win64-gpl"
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2023-03-27-13-21/ffmpeg-N-110099-gf7abe92bd7-win64-gpl.zip",
+            "hash": "2a0d6fd830375513d59d7c2acec7af8e6f949a0887b8cbba1557f3dc76f0c384",
+            "extract_dir": "ffmpeg-N-110099-gf7abe92bd7-win64-gpl"
         }
     },
     "bin": [
@@ -16,13 +16,23 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "script": "try { Get-Date (Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest).published_at -UFormat %s } catch { '' }",
-        "regex": "\\A(\\d+)\\Z"
+        "script": [
+            "try {",
+            "    $api = Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest",
+            "    foreach ($name in $api.assets.name) { if ($name -match 'win64-gpl\\.zip\\Z') { $asset = $name; break } }",
+            "    $api.tag_name, $asset -join ' '",
+            "}",
+            "catch {",
+            "    ''",
+            "}"
+        ],
+        "regex": "\\Aautobuild-([\\d-]+) ffmpeg-N-(?<build>\\d+)-g(?<commit>[a-f\\d]+)-win64-gpl\\.zip\\Z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-$version/ffmpeg-N-$matchBuild-g$matchCommit-win64-gpl.zip",
+                "extract_dir": "ffmpeg-N-$matchBuild-g$matchCommit-win64-gpl"
             }
         }
     }

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -19,7 +19,7 @@
         "script": [
             "try {",
             "    $api = Invoke-RestMethod https://api.github.com/repositories/292087234/releases/latest",
-            "    foreach ($name in $api.assets.name) { if ($name -match 'win64-gpl\\.zip\\Z') { $asset = $name; break } }",
+            "    foreach ($name in $api.assets.name) { if ($name -clike '*-win64-gpl.zip') { $asset = $name; break } }",
             "    $api.tag_name, $asset -join ' '",
             "}",
             "catch {",


### PR DESCRIPTION
The actions were adjusted which broke the manifest
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).