### PR TITLE
windows-terminal-preview: Switch to portable distribution

### DIFF
--- a/bucket/windows-terminal-preview.json
+++ b/bucket/windows-terminal-preview.json
@@ -1,24 +1,24 @@
 {
-    "version": "1.18.1421.0",
+    "version": "1.18.1462.0",
     "description": "The new Windows Terminal, and the original Windows console host - all in the same place! (Preview version)",
     "homepage": "https://github.com/microsoft/terminal",
     "license": "MIT",
     "notes": "Add Windows Terminal Preview as a context menu option by running `reg import \"$dir\\install-context.reg\"`",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_x64.zip",
-            "hash": "a216681cdc0f1b9709201193862d49e54b8047604a342350a2fc98656172f67f"
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_x64.zip",
+            "hash": "c63e631edbc8211e48ea299a33a5e0acf713f3115258e8594edcc402d2f7a093"
         },
         "32bit": {
-            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_x86.zip",
-            "hash": "043c24ae080c71871958643d1f71976921e6c4cc553ba118846ccca5d93278d2"
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_x86.zip",
+            "hash": "b7d47efa7862800d5cac6cf75d7efe2014ed1d0faac6b381deb85f6f186de915"
         },
         "arm64": {
-            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_arm64.zip",
-            "hash": "5cc4413ac36ac3c3b3c63c4a57239723fd16df3a1fc25f620ca54bcf0b7f3ff1"
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1462.0/Microsoft.WindowsTerminalPreview_1.18.1462.0_arm64.zip",
+            "hash": "62fd69046caf504c456beb3004cf4e83207d25fd7a03b75d8b2d2a8175630d1d"
         }
     },
-    "extract_dir": "terminal-1.18.1421.0",
+    "extract_dir": "terminal-1.18.1462.0",
     "pre_install": [
         "# Remove this hint in 2023-12-01",
         "$settings_path = \"$env:LOCALAPPDATA\\Packages\\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\\LocalState\"",

--- a/bucket/windows-terminal-preview.json
+++ b/bucket/windows-terminal-preview.json
@@ -19,6 +19,16 @@
         }
     },
     "extract_dir": "terminal-1.18.1421.0",
+    "pre_install": [
+        "# Remove this hint in 2023-12-01",
+        "$settings_path = \"$env:LOCALAPPDATA\\Packages\\Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe\\LocalState\"",
+        "if (!(Test-Path \"$persist_dir\\settings\") -and (Test-Path $settings_path)) {",
+        "  $current_settings = $dir.Replace($version, 'current') + \"\\settings\"",
+        "  warn \"Portable mode is enabled from version 1.18.1421.0, please migrate the settings manually:\"",
+        "  warn \"Original settings dir: `'$settings_path`'\"",
+        "  warn \"Portable settings dir: `'$current_settings`'\"",
+        "}"
+    ],
     "installer": {
         "script": [
             "$winVer = [Environment]::OSVersion.Version",

--- a/bucket/windows-terminal-preview.json
+++ b/bucket/windows-terminal-preview.json
@@ -1,28 +1,29 @@
 {
-    "version": "1.17.1023",
+    "version": "1.18.1421.0",
     "description": "The new Windows Terminal, and the original Windows console host - all in the same place! (Preview version)",
     "homepage": "https://github.com/microsoft/terminal",
     "license": "MIT",
     "notes": "Add Windows Terminal Preview as a context menu option by running `reg import \"$dir\\install-context.reg\"`",
-    "suggest": {
-        "vcredist": "extras/vcredist2022"
-    },
-    "url": "https://github.com/microsoft/terminal/releases/download/v1.17.1023/Microsoft.WindowsTerminalPreview_Win10_1.17.10234.0_8wekyb3d8bbwe.msixbundle#/dl.7z",
-    "hash": "8829bf4a1ecffa384f2dbed1496c39dd291db44d0d0fb3f81845ae76eb174484",
     "architecture": {
         "64bit": {
-            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x64.msix' | Remove-Item -Force -Recurse"
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_x64.zip",
+            "hash": "a216681cdc0f1b9709201193862d49e54b8047604a342350a2fc98656172f67f"
         },
         "32bit": {
-            "pre_install": "Get-ChildItem \"$dir\" -Exclude '*x86.msix' | Remove-Item -Force -Recurse"
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_x86.zip",
+            "hash": "043c24ae080c71871958643d1f71976921e6c4cc553ba118846ccca5d93278d2"
+        },
+        "arm64": {
+            "url": "https://github.com/microsoft/terminal/releases/download/v1.18.1421.0/Microsoft.WindowsTerminalPreview_1.18.1421.0_arm64.zip",
+            "hash": "5cc4413ac36ac3c3b3c63c4a57239723fd16df3a1fc25f620ca54bcf0b7f3ff1"
         }
     },
+    "extract_dir": "terminal-1.18.1421.0",
     "installer": {
         "script": [
             "$winVer = [Environment]::OSVersion.Version",
-            "if (($winver.Major -lt '10') -or ($winVer.Build -lt 18362)) { error 'At least Windows 10 19H1 (build 18362) is required.'; break }",
-            "Get-ChildItem \"$dir\" '*.msix' | Select-Object -ExpandProperty Fullname | Expand-7zipArchive -DestinationPath \"$dir\" -Removal",
-            "Get-ChildItem \"$dir\\ProfileIcons\" '*.png' | Rename-Item -NewName { $_.Name.Replace('%7B', '{').Replace('%7D', '}') }"
+            "if (($winver.Major -lt '10') -or ($winVer.Build -lt 19041)) { error 'At least Windows 10 20H1 (build 19041) is required.'; break }",
+            "if (!(Test-Path \"$persist_dir\\.portable\")) { Add-Content \"$dir\\.portable\" '' -Encoding Ascii }"
         ]
     },
     "post_install": [
@@ -35,7 +36,6 @@
         "    }",
         "}"
     ],
-    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "bin": [
         [
             "WindowsTerminal.exe",
@@ -52,12 +52,32 @@
             "Windows Terminal Preview"
         ]
     ],
+    "persist": [
+        ".portable",
+        "settings"
+    ],
+    "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "checkver": {
         "url": "https://api.github.com/repos/microsoft/terminal/releases",
-        "jsonpath": "$.[?(@.prerelease == true)]",
-        "regex": "\"tag_name\": \"v([\\d.]+)\"[\\s\\S]+?Win10_(?<version>[\\d.]+)_8wekyb3d8bbwe"
+        "jsonpath": "$[?(@.prerelease == true)].tag_name",
+        "regex": "v([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminalPreview_Win10_$matchVersion_8wekyb3d8bbwe.msixbundle#/dl.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminalPreview_$version_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminalPreview_$version_x86.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/microsoft/terminal/releases/download/v$version/Microsoft.WindowsTerminalPreview_$version_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/microsoft/terminal/releases/tag/v$version",
+            "regex": "(?s)$basename.*?$sha256"
+        },
+        "extract_dir": "terminal-$version"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
>Note Well, the change from [v1.17.1073](https://github.com/microsoft/terminal/releases/v1.17.10230) where we would munge our version number didn't live much longer than a single release.

The split versioning change from the previous preview was dropped, so checkver is fixed.
>In 1.18 and above: We've removed any runtime dependency on the "desktop" C++ Runtime Library

Removed vcredist suggestion

Converted to portable mode following the stable manifest
https://github.com/microsoft/terminal/releases/tag/v1.18.1421.0

Edit: added settings migration note from extras manifest
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/pull/11335

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
