### PR TITLE
python: updating autoupdate regex

### DIFF
--- a/bucket/python310.json
+++ b/bucket/python310.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "python-(3\\.10\\.[\\d.]+)-"
+        "regex": "Python (3\\.10\\.[\\d.]+) - "
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "Python (3\\.6\\.[\\d.]+) - "
+        "regex": "python-(3\\.6\\.[\\d.]+)-"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "python-(3\\.6\\.[\\d.]+)-"
+        "regex": "Python (3\\.6\\.[\\d.]+) - "
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python37.json
+++ b/bucket/python37.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "python-(3\\.7\\.[\\d.]+)-"
+        "regex": "Python (3\\.7\\.[\\d.]+) - "
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python38.json
+++ b/bucket/python38.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "python-(3\\.8\\.[\\d.]+)-"
+        "regex": "Python (3\\.8\\.[\\d.]+) - "
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/python39.json
+++ b/bucket/python39.json
@@ -103,7 +103,7 @@
     ],
     "checkver": {
         "url": "https://www.python.org/downloads/windows/",
-        "regex": "python-(3\\.9\\.[\\d.]+)-"
+        "regex": "Python (3\\.9\\.[\\d.]+) - "
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Updated the regex to check for new version of python versions.

Checked with `checkver.ps1`:
![image](https://github.com/ScoopInstaller/Versions/assets/14291370/c54bd7be-612e-4ae4-b3f0-a2fbfa1ad312)


<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
