### PR TITLE
neovim-nightly: remove nvim-qt

### DIFF
--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -17,14 +17,7 @@
     },
     "extract_dir": "nvim-win64",
     "bin": [
-        "bin\\nvim.exe",
-        "bin\\nvim-qt.exe"
-    ],
-    "shortcuts": [
-        [
-            "bin\\nvim-qt.exe",
-            "Neovim"
-        ]
+        "bin\\nvim.exe"
     ],
     "checkver": {
         "url": "https://api.github.com/repos/neovim/neovim/releases",


### PR DESCRIPTION
Remove the nvim-qt shim + shortcut since upstream will not bundle nvim-qt anymore. Users who depend on nvim-qt will need to get it from a separate bucket

``` sh
❯ scoop bucket list

Name       Source                                             Updated              Manifests
----       ------                                             -------              ---------
extras     https://github.com/ScoopInstaller/Extras           3/31/2023 2:31:10 PM      1786
main       https://github.com/ScoopInstaller/Main             6/7/2023 6:27:50 PM       1202
nerd-fonts https://github.com/matthewjberger/scoop-nerd-fonts 6/5/2023 1:18:09 PM        278
Versions   git@github.com:alex-tdrn/Versions.git              6/7/2023 7:43:49 PM        424

~\scoop\buckets\Versions  7  7  0529b09  remove_neovim_nightly_nvim_qt_shims  1sec 170ms
❯ scoop update neovim-nightly
neovim-nightly: 0.10.0-dev-449-gcc4169777 -> 0.10.0-dev-480-gc0952e62f
Updating one outdated app:
Updating 'neovim-nightly' (0.10.0-dev-449-gcc4169777 -> 0.10.0-dev-480-gc0952e62f)
Downloading new version
Loading nvim-win64.zip from cache
Checking hash of nvim-win64.zip ... ok.
Uninstalling 'neovim-nightly' (0.10.0-dev-449-gcc4169777)
Removing shim 'nvim.shim'.
Removing shim 'nvim.exe'.
Unlinking ~\scoop\apps\neovim-nightly\current
Installing 'neovim-nightly' (0.10.0-dev-480-gc0952e62f) [64bit] from versions bucket
Loading nvim-win64.zip from cache
Extracting nvim-win64.zip ... done.
Linking ~\scoop\apps\neovim-nightly\current => ~\scoop\apps\neovim-nightly\0.10.0-dev-480-gc0952e62f
Creating shim for 'nvim'.
'neovim-nightly' (0.10.0-dev-480-gc0952e62f) was installed successfully!
```

Closes #1259 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
