### PR TITLE
strawberry-nightly: Fix `checkver` and `autoupdate`

### DIFF
--- a/bucket/strawberry-nightly.json
+++ b/bucket/strawberry-nightly.json
@@ -1,10 +1,10 @@
 {
-    "version": "3116133961",
+    "version": "5846752525",
     "description": "A music player and music collection organizer",
     "homepage": "https://www.strawbs.org/",
     "license": "GPL-3.0-only",
-    "url": "https://nightly.link/strawberrymusicplayer/strawberry/workflows/ccpp/master/upload-windows.zip",
-    "hash": "469c17ff5e043aaa18bee5fc134acce1792eacc90da8267c173216ee3f666007",
+    "url": "https://nightly.link/strawberrymusicplayer/strawberry/workflows/build/master/windows-msvc.zip",
+    "hash": "cf920612b32c69fddddec026e383c917ff719428c97866a116f323ded37ddf57",
     "pre_install": [
         "Remove-Item \"$dir\\*-Debug-*.exe\"",
         "Expand-7zipArchive \"$dir\\StrawberrySetup-*-msvc-x$($architecture.Substring(0, 2)).exe\" \"$dir\"",
@@ -19,10 +19,10 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repositories/28609243/actions/workflows/ccpp.yml/runs?branch=master&status=success",
+        "url": "https://api.github.com/repositories/28609243/actions/workflows/build.yml/runs?branch=master&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {
-        "url": "https://nightly.link/strawberrymusicplayer/strawberry/workflows/ccpp/master/upload-windows.zip"
+        "url": "https://nightly.link/strawberrymusicplayer/strawberry/workflows/build/master/windows-msvc.zip"
     }
 }


### PR DESCRIPTION
They changed the workflow name/file
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).