### PR TITLE
syncplay-beta: Update to version 1.7.1-RC1

### DIFF
--- a/bucket/syncplay-beta.json
+++ b/bucket/syncplay-beta.json
@@ -19,14 +19,14 @@
     "checkver": {
         "script": [
             "try {",
-            "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq ($char = 'v')) { $ver = $ver.Substring(1) } else { $char = '' }",
-            "    $char, $ver, ($ver -replace '-', '_') -join ' '",
+            "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq ($prefix = 'v')) { $ver = $ver.Substring(1) } else { $prefix = '' }",
+            "    $prefix, $ver, ($ver -replace '-', '_') -join ' '",
             "}",
             "catch { '' }"
         ],
-        "regex": "\\A(?<tag>v)? (\\S+) (?<underscore>\\S+)\\Z"
+        "regex": "\\A(?<prefix>v)? (\\S+) (?<underscore>\\S+)\\Z"
     },
     "autoupdate": {
-        "url": "https://github.com/Syncplay/syncplay/releases/download/$matchTag$version/Syncplay_$matchUnderscore_Portable.zip"
+        "url": "https://github.com/Syncplay/syncplay/releases/download/$matchPrefix$version/Syncplay_$matchUnderscore_Portable.zip"
     }
 }

--- a/bucket/syncplay-beta.json
+++ b/bucket/syncplay-beta.json
@@ -20,7 +20,7 @@
         "script": [
             "try {",
             "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq ($prefix = 'v')) { $ver = $ver.Substring(1) } else { $prefix = '' }",
-            "    $prefix, $ver, ($ver -replace '-', '_') -join ' '",
+            "    $prefix, $ver, $ver.Replace('-', '_') -join ' '",
             "}",
             "catch { '' }"
         ],

--- a/bucket/syncplay-beta.json
+++ b/bucket/syncplay-beta.json
@@ -1,13 +1,13 @@
 {
-    "version": "1.7.0-RC1",
+    "version": "1.7.1-RC1",
     "description": "Solution to synchronize video playback across multiple instances of mpv, VLC, MPC-HC, MPC-BE and mplayer2 over the Internet.",
     "homepage": "https://syncplay.pl/",
     "license": "Apache-2.0",
     "suggest": {
         "vcredist": "extras/vcredist2022"
     },
-    "url": "https://github.com/Syncplay/syncplay/releases/download/1.7.0-RC1/Syncplay_1.7.0_RC1_Portable.zip",
-    "hash": "e04314a2b89b08b2f1f1aa809c388eae33ae6aa7191be51e3b23e288c3460969",
+    "url": "https://github.com/Syncplay/syncplay/releases/download/v1.7.1-RC1/Syncplay_1.7.1_RC1_Portable.zip",
+    "hash": "d861e85bbb98c5ad6499b582c76ec5d5db0655ab421acd59a494c937ddd7e03d",
     "bin": "Syncplay.exe",
     "shortcuts": [
         [
@@ -18,12 +18,15 @@
     "persist": "syncplay.ini",
     "checkver": {
         "script": [
-            "$ver = ((Invoke-WebRequest 'https://api.github.com/repositories/4732425/releases').Content | ConvertFrom-Json)[0].tag_name",
-            "$ver, ($ver -replace '-', '_') -join ' '"
+            "try {",
+            "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq 'v') { $ver = $ver.Substring(1) }",
+            "    $ver, ($ver -replace '-', '_') -join ' '",
+            "}",
+            "catch {}"
         ],
         "regex": "^(\\S+) (?<underscore>\\S+)$"
     },
     "autoupdate": {
-        "url": "https://github.com/Syncplay/syncplay/releases/download/$version/Syncplay_$matchUnderscore_Portable.zip"
+        "url": "https://github.com/Syncplay/syncplay/releases/download/v$version/Syncplay_$matchUnderscore_Portable.zip"
     }
 }

--- a/bucket/syncplay-beta.json
+++ b/bucket/syncplay-beta.json
@@ -19,14 +19,14 @@
     "checkver": {
         "script": [
             "try {",
-            "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq 'v') { $ver = $ver.Substring(1) }",
-            "    $ver, ($ver -replace '-', '_') -join ' '",
+            "    if (($ver = (Invoke-RestMethod https://api.github.com/repositories/4732425/releases)[0].tag_name)[0] -eq ($char = 'v')) { $ver = $ver.Substring(1) } else { $char = '' }",
+            "    $char, $ver, ($ver -replace '-', '_') -join ' '",
             "}",
-            "catch {}"
+            "catch { '' }"
         ],
-        "regex": "^(\\S+) (?<underscore>\\S+)$"
+        "regex": "\\A(?<tag>v)? (\\S+) (?<underscore>\\S+)\\Z"
     },
     "autoupdate": {
-        "url": "https://github.com/Syncplay/syncplay/releases/download/v$version/Syncplay_$matchUnderscore_Portable.zip"
+        "url": "https://github.com/Syncplay/syncplay/releases/download/$matchTag$version/Syncplay_$matchUnderscore_Portable.zip"
     }
 }


### PR DESCRIPTION
Fixes `checkver.script` and `autoupdate.url`
The repo's inconsistent with using `v` in tags, so a case was added for stripping it
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).