### PR TITLE
taiga-beta: Make `persist` explicit

### DIFF
--- a/bucket/taiga-beta.json
+++ b/bucket/taiga-beta.json
@@ -5,7 +5,11 @@
     "license": "GPL-3.0-only",
     "url": "https://github.com/erengy/taiga/releases/download/v1.4.0/TaigaSetup_1.4.0.exe#/dl.7z",
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
-    "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
+    "pre_install": [
+        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
+        "'user', 'feed' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
+    ],
     "bin": "Taiga.exe",
     "shortcuts": [
         [
@@ -13,7 +17,12 @@
             "Taiga"
         ]
     ],
-    "persist": "data",
+    "persist": [
+        "data\\user",
+        "data\\feed",
+        "data\\settings.xml",
+        "data\\db\\anime.xml"
+    ],
     "checkver": {
         "url": "https://api.github.com/repositories/14477437/releases",
         "jsonpath": "$.[0].tag_name",

--- a/bucket/taiga-beta.json
+++ b/bucket/taiga-beta.json
@@ -7,7 +7,7 @@
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
     "pre_install": [
         "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
-        "'user', 'feed' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'user', 'feed', 'db\\image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
         "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
     ],
     "bin": "Taiga.exe",
@@ -21,6 +21,7 @@
         "data\\user",
         "data\\feed",
         "data\\settings.xml",
+        "data\\db\\image",
         "data\\db\\anime.xml"
     ],
     "checkver": {

--- a/bucket/taiga-beta.json
+++ b/bucket/taiga-beta.json
@@ -6,9 +6,9 @@
     "url": "https://github.com/erengy/taiga/releases/download/v1.4.0/TaigaSetup_1.4.0.exe#/dl.7z",
     "hash": "22556aff39f20a88bde4f0b944d886dd729810477b6b97dab39a0c9a60ad43e0",
     "pre_install": [
-        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir\\$_\" -Recurse }",
-        "'user', 'feed', 'db\\image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
-        "'settings', 'db\\anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"\\data\\$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
+        "'$PLUGINSDIR', 'Uninstall.exe' | ForEach-Object { Remove-Item \"$dir/$_\" -Recurse }",
+        "'user', 'feed', 'db/image' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"/data/$_\")\")) { New-Item -ItemType 'Directory' \"$dir$_\" | Out-Null } }",
+        "'settings', 'db/anime' | ForEach-Object { if (!(Test-Path \"$persist_dir$($_ = \"/data/$_.xml\")\" )) { New-Item \"$dir$_\" | Out-Null } }"
     ],
     "bin": "Taiga.exe",
     "shortcuts": [
@@ -18,11 +18,11 @@
         ]
     ],
     "persist": [
-        "data\\user",
-        "data\\feed",
-        "data\\settings.xml",
-        "data\\db\\image",
-        "data\\db\\anime.xml"
+        "data/user",
+        "data/feed",
+        "data/settings.xml",
+        "data/db/image",
+        "data/db/anime.xml"
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/14477437/releases",


### PR DESCRIPTION
The reason for this is because inside the `data` dir, `db\anime-relations.txt` (https://github.com/erengy/anime-relations) and `theme` can receive updates relatively often, and `theme` is not very user customizable.

Relates to https://github.com/ScoopInstaller/Extras/pull/11833

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).