### PR TITLE
neovim-nightly: Fix checkver

### DIFF
--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.10.0-dev-1055-gb7734c4ec",
+    "version": "0.10.0-dev-1f551e0",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {
@@ -19,8 +19,7 @@
     "bin": "bin\\nvim.exe",
     "checkver": {
         "url": "https://api.github.com/repos/neovim/neovim/releases",
-        "regex": "NVIM v([\\w.-]+)\\+([\\w.-]+)",
-        "replace": "${1}-${2}"
+        "regex": "NVIM v([\\w.-]+)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.10.0-dev-1f551e0",
+    "version": "0.10.0-dev-35f475d",
     "description": "Vim fork focused on extensibility and usability",
     "homepage": "https://neovim.io",
     "license": {


### PR DESCRIPTION
Fix checkver to get new version format.

PS. The Scoop repository has the latest version `v0.10.0-dev-1055-gb7734c4ec`,
while the Neovim repository has the latest version of `v0.10.0-dev-1f551e0` (2023-09-13):

![image](https://github.com/ScoopInstaller/Versions/assets/16042676/7701638a-e115-46b4-8d76-38da69fea4bc)

Relates to [these issues](https://github.com/ScoopInstaller/Versions/issues?q=is%3Aissue+is%3Aclosed+neovim-nightly%400.10.0-dev-1055-gb7734c4ec), such as #1361, #1362, #1363, #1365, etc.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
