### PR TITLE
Thorium-AVX2: add version 117.0.5938.157

### DIFF
--- a/bucket/thorium-avx2.json
+++ b/bucket/thorium-avx2.json
@@ -1,0 +1,44 @@
+{
+    "version": "117.0.5938.157",
+    "description": "Chromium fork for Linux, Windows, MacOS, Android, and Raspberry Pi named after radioactive element No. 90. Compiled with AVX2 support. If your CPU does not support AVX2 DO NOT INSTALL. Use CPU-Z to determine if your CPU supports AVX2.",
+    "homepage": "https://thorium.rocks/",
+    "license": {
+        "identifier": "BSD 3-Clause",
+        "url": "https://github.com/Alex313031/Thorium-Win-AVX2/blob/main/LICENSE"
+    },
+    "url": "https://github.com/Alex313031/Thorium-Win-AVX2/releases/download/M117.0.5938.157/Thorium_AVX2_117.0.5938.157.zip",
+    "hash": "c9fde8a85e050ef62afe1238dbd215aea01fa0fcc330b0006ccfa855c3ac2fad",
+    "extract_dir":"BIN",
+    "bin": [
+        [
+            "thorium.exe",
+            "thorium",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "shortcuts": [
+        [
+            "thorium.exe",
+            "Thorium",
+            "--user-data-dir=\"$dir\\User Data\""
+        ]
+    ],
+    "post_install": [
+        "if (!(Test-Path \"$dir\\User Data\\*\") -and (Test-Path \"$env:LocalAppData\\Thorium\\User Data\")) {",
+        "    info '[Portable Mode]: Copying user data...'",
+        "    Copy-Item \"$env:LocalAppData\\Thorium\\User Data\\*\" \"$dir\\User Data\" -Recurse",
+        "}"
+    ],
+    "env_set": {
+        "CHROME_EXECUTABLE": "$dir\\thorium.exe"
+    },
+    "persist": "User Data",
+    "checkver": {
+        "github": "https://github.com/Alex313031/Thorium-Win-AVX2",
+        "regex": "/releases/tag/M(?:v|V)?([\\d.]+)"
+    },
+    "autoupdate":{
+        "url": "https://github.com/Alex313031/Thorium-Win-AVX2/releases/download/M$version/Thorium_AVX2_$version.zip",
+        "extract_dir": "Thorium_$version"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
A version of the package I have submitted for Scoop/Extras, this version of thorium is compiled for CPUs that have AVX2 support

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
