### PR TITLE
bun-canary: Add version 1.0.18-canary.33+61f92d9e5

### DIFF
--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.9-canary.10+e954bce30",
+    "version": "1.0.9-canary.5+c3a7b574c",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "b71ee27668bef409c08665120751e7e7df7bf55d3fde533b092b550247c625b0"
+            "hash": "c14edb52a9316fe8c22907cbb12a58a190f3fe8fa308120898ff512b0ddd34dd"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.11-canary.6+84414f8fe",
+    "version": "1.0.11-canary.14+c49a5a7d7",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "6474729a9cabe188dd3f1e8ef33e4113df092748698129396e70518ff8bff4d2"
+            "hash": "396834b6b2b64cfa918e9c4b95f103e2047bfc447b51b158bb72d9b6c6428c3b"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.8-canary.97+ab97bf0f1",
+    "version": "1.0.9-canary.7+39101d16c",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "36be6a198abb43b465265bac295500ad76868693476e772d4294992474a02589"
+            "hash": "cbb79d6d093ca8dd5505ad7d88f02a09be04244ece924a2b36e50f637ca3e153"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.11-canary.16+b7587b76e",
+    "version": "1.0.11-canary.6+84414f8fe",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "85de93befef7ca957ab849269b47c8aba1514940b1f9c421786041a6c27c7d2c"
+            "hash": "6474729a9cabe188dd3f1e8ef33e4113df092748698129396e70518ff8bff4d2"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -40,9 +40,6 @@
             "64bit": {
                 "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip"
             }
-        },
-        "hash": {
-            "url": "$baseurl/SHASUMS256.txt"
         }
     }
 }

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.9-canary.7+39101d16c",
+    "version": "1.0.9-canary.10+e954bce30",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "cbb79d6d093ca8dd5505ad7d88f02a09be04244ece924a2b36e50f637ca3e153"
+            "hash": "b71ee27668bef409c08665120751e7e7df7bf55d3fde533b092b550247c625b0"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,0 +1,41 @@
+{
+    "version": "1.0.8-canary.97+ab97bf0f1",
+    "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
+    "homepage": "https://bun.sh/",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
+            "hash": "36be6a198abb43b465265bac295500ad76868693476e772d4294992474a02589"
+        }
+    },
+    "extract_dir": "bun-windows-x64",
+    "bin": "bun.exe",
+    "checkver": {
+        "script": [
+            "$dl_url = 'https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip'",
+            "$dl = cache_path 'bun-canary' 'unknown' $dl_url",
+            "$dl_dir = strip_ext $dl",
+            "Invoke-WebRequest $dl_url -OutFile $dl",
+            "Expand-Archive $dl $dl_dir",
+            "$ver = & \"$dl_dir\\bun-windows-x64\\bun.exe\" --revision",
+            "Move-Item -Force $dl (cache_path 'bun-canary' $ver $dl_url)",
+            "Remove-Item $dl_dir -Recurse",
+            "$ver"
+        ],
+        "regex": "(\\S+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHASUMS256.txt"
+        }
+    }
+}

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -13,7 +13,14 @@
         }
     },
     "extract_dir": "bun-windows-x64",
-    "bin": "bun.exe",
+    "bin": [
+        "bun.exe",
+        [
+            "bun.exe",
+            "bunx",
+            "x"
+        ]
+    ],
     "checkver": {
         "script": [
             "$dl_url = 'https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip'",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.9-canary.5+c3a7b574c",
+    "version": "1.0.11-canary.16+b7587b76e",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "c14edb52a9316fe8c22907cbb12a58a190f3fe8fa308120898ff512b0ddd34dd"
+            "hash": "85de93befef7ca957ab849269b47c8aba1514940b1f9c421786041a6c27c7d2c"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.18-canary.27+1a2643520",
+    "version": "1.0.18-canary.33+61f92d9e5",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "18687c783a525bf8666c42ccf498dc5b7a6ea6f838f0c74a7efcf7916c19e65c"
+            "hash": "38f5919c2dbbb003c6bed2d92ed3e1da3850433ce147c37a98f29f47a4d6bce9"
         }
     },
     "extract_dir": "bun-windows-x64",

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.11-canary.14+c49a5a7d7",
+    "version": "1.0.18-canary.27+1a2643520",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -9,7 +9,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "396834b6b2b64cfa918e9c4b95f103e2047bfc447b51b158bb72d9b6c6428c3b"
+            "hash": "18687c783a525bf8666c42ccf498dc5b7a6ea6f838f0c74a7efcf7916c19e65c"
         }
     },
     "extract_dir": "bun-windows-x64",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

JavaScript runtime, similar to Node and Deno, designed as a drop-in replacement for Node

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
