### PR TITLE
Update mingw-winlibs-llvm-ucrt, mingw-winlibs-ucrt-mcf and mingw-winlibs-ucrt

### DIFF
--- a/bucket/mingw-winlibs-llvm-ucrt.json
+++ b/bucket/mingw-winlibs-llvm-ucrt.json
@@ -1,17 +1,17 @@
 {
-    "version": "13.2.0-16.0.6-11.0.0-r1",
+    "version": "13.2.0-17.0.5-11.0.1-r3",
     "description": "GNU Compiler Collection with LLVM/Clang/LLD/LLDB (UCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-llvm-16.0.6-mingw-w64ucrt-11.0.0-r1.7z",
-            "hash": "437401d7ebda2cd56cb25c13023730ebbebd011850768f3519191da669265a27",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-llvm-17.0.5-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "2a045e3623d8e896008db0e419bdffa1933f8091de9408bc3bd7907ba18caa7d",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-i686-posix-dwarf-gcc-13.2.0-llvm-16.0.6-mingw-w64ucrt-11.0.0-r1.7z",
-            "hash": "61f859c4a64f6f4c57ef5b83d6f9fdf08480cd6e0dbc0cc61575e3496621cb31",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-i686-posix-dwarf-gcc-13.2.0-llvm-17.0.5-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "7a66c058f7ae6c8230749268b04ebee792f1a8595194439d8e32a0c6faada179",
             "extract_dir": "mingw32"
         }
     },
@@ -24,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGcc-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-llvm-$matchLlvm-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-llvm-$matchLlvm-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             },
             "32bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGcc-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-llvm-$matchLlvm-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-llvm-$matchLlvm-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             }
         },
         "hash": {

--- a/bucket/mingw-winlibs-llvm-ucrt.json
+++ b/bucket/mingw-winlibs-llvm-ucrt.json
@@ -18,7 +18,7 @@
     "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
     "env_add_path": "bin",
     "checkver": {
-        "regex": "(?<gcc>[\\d.]+)-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
+        "regex": "(?<gcc>[\\d.]+)posix-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
         "replace": "${gcc}-${llvm}-${mingw}-r${release}"
     },
     "autoupdate": {

--- a/bucket/mingw-winlibs-ucrt-mcf.json
+++ b/bucket/mingw-winlibs-ucrt-mcf.json
@@ -1,33 +1,33 @@
 {
-    "version": "13.2.0-11.0.1-r2",
+    "version": "13.2.0-11.0.1-r3",
     "description": "GNU Compiler Collection (UCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-16.0.6-11.0.1-ucrt-r2/winlibs-x86_64-mcf-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r2.7z",
-            "hash": "813b503b4d122b17642d82cdad7eac6f024ef1e62202f38f0705bfba72bc242b",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-x86_64-mcf-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "34aa4a22a2934bb8b5d0133f9913ff1e416aedd481157b24fe97c070bf0d0fc4",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-16.0.6-11.0.1-ucrt-r2/winlibs-i686-mcf-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.1-r2.7z",
-            "hash": "34033443c4190bbc81e42f2f77ea2ecfe12115330d6104f6d8e3de9c62b08ce6",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0mcf-11.0.1-ucrt-r3/winlibs-i686-mcf-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "d4d50d6f1bfaf3309007f197dbbb82e3f968f6208363c1be2a180e9c914a6511",
             "extract_dir": "mingw32"
         }
     },
     "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
     "env_add_path": "bin",
     "checkver": {
-        "regex": "(?<gcc>[\\d.]+)mcf-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
+        "regex": "(?<gcc>[\\d.]+)mcf-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
         "replace": "${gcc}-${mingw}-r${release}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccmcf-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-mcf-seh-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccmcf-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-mcf-seh-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             },
             "32bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccmcf-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-mcf-dwarf-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccmcf-$matchMingw-ucrt-r$matchRelease/winlibs-i686-mcf-dwarf-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             }
         },
         "hash": {

--- a/bucket/mingw-winlibs-ucrt.json
+++ b/bucket/mingw-winlibs-ucrt.json
@@ -1,17 +1,17 @@
 {
-    "version": "13.2.0-11.0.0-r1",
+    "version": "13.2.0-11.0.1-r3",
     "description": "GNU Compiler Collection (UCRT, WinLibs build)",
     "homepage": "https://winlibs.com",
     "license": "GPL-3.0-or-later,ZPL-2.1,BSD-2-Clause,...",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.7z",
-            "hash": "6b9663f2f183fb6b962f37e13b3ee6258836122a3dc49d4ac299117219580e32",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-x86_64-posix-seh-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "bfe1bb7020f0b32e47147610e76a08e6ebf14e1763dbda7bb9194e61f0a14a15",
             "extract_dir": "mingw64"
         },
         "32bit": {
-            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0-16.0.6-11.0.0-ucrt-r1/winlibs-i686-posix-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.0-r1.7z",
-            "hash": "3d14c4f9f2396f45bc0d59b005ec2db931429ca53b568200096f9e797cd0e10b",
+            "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/13.2.0posix-17.0.5-11.0.1-ucrt-r3/winlibs-i686-posix-dwarf-gcc-13.2.0-mingw-w64ucrt-11.0.1-r3.7z",
+            "hash": "aa3a6ea56b9a917d3fd0992ff9bbb22e0f84d16e4db453da9faa1d9fcbbdd0c0",
             "extract_dir": "mingw32"
         }
     },
@@ -24,10 +24,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGcc-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-x86_64-posix-seh-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             },
             "32bit": {
-                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGcc-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
+                "url": "https://github.com/brechtsanders/winlibs_mingw/releases/download/$matchGccposix-$matchLlvm-$matchMingw-ucrt-r$matchRelease/winlibs-i686-posix-dwarf-gcc-$matchGcc-mingw-w64ucrt-$matchMingw-r$matchRelease.7z"
             }
         },
         "hash": {

--- a/bucket/mingw-winlibs-ucrt.json
+++ b/bucket/mingw-winlibs-ucrt.json
@@ -18,7 +18,7 @@
     "post_install": "Copy-Item \"$dir\\bin\\mingw32-make.exe\" \"$dir\\bin\\make.exe\"",
     "env_add_path": "bin",
     "checkver": {
-        "regex": "(?<gcc>[\\d.]+)-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
+        "regex": "(?<gcc>[\\d.]+)posix-(?<llvm>[\\d.]+)-(?<mingw>[\\d.]+)-ucrt-r(?<release>\\d+)",
         "replace": "${gcc}-${mingw}-r${release}"
     },
     "autoupdate": {


### PR DESCRIPTION
This PR updates the three packages shown as title. I updated `mingw-winlibs-ucrt-mcf` and deleted `$matchLlvm` in its autoupdate regex, but I don't know if it'll influence the future releases when MCF Gthread supports LLVM. I also added `posix` after `$matchGcc` in the other two packages' autoupdate regex to match the latest POSIX build updates.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
