### PR TITLE
Revert "systeminformer-nightly: Update to version 3.0.7429"

### DIFF
--- a/bucket/systeminformer-nightly.json
+++ b/bucket/systeminformer-nightly.json
@@ -1,10 +1,10 @@
 {
-    "version": "3.0.7429",
+    "version": "3.0.7422",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://systeminformer.sourceforge.io",
     "license": "MIT",
-    "url": "https://github.com/winsiderss/si-builds/releases/download/3.0.7429/systeminformer-3.0.7429-bin.zip",
-    "hash": "011645dce70fbc5d2f06659b97db1ab32527fbdae522b50b838d28cd2e96ded2",
+    "url": "https://github.com/winsiderss/si-builds/releases/download/3.0.7422/systeminformer-3.0.7422-bin.zip",
+    "hash": "f6a8c347847c97294a3141a0115ca1e883109e639663c6f716dc90f03e2dc78d",
     "architecture": {
         "32bit": {
             "extract_dir": "i386"

--- a/bucket/systeminformer-nightly.json
+++ b/bucket/systeminformer-nightly.json
@@ -36,8 +36,8 @@
     ],
     "pre_uninstall": "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -ErrorAction 'SilentlyContinue' }",
     "checkver": {
-        "url": "https://github.com/winsiderss/si-builds/releases",
-        "regex": "/tag/([\\d.]+)"
+        "url": "https://api.github.com/repositories/550621342/releases",
+        "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {
         "url": "https://github.com/winsiderss/si-builds/releases/download/$version/systeminformer-$version-bin.zip"


### PR DESCRIPTION
Fixes `ERROR Download failed! (Error 3) Resource was not found`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).