### PR TITLE
miniconda3-py3*: add version py37, py38, py39, py310, py311

### DIFF
--- a/bucket/miniconda3-py310.json
+++ b/bucket/miniconda3-py310.json
@@ -1,0 +1,63 @@
+{
+    "version": "23.11.0-2",
+    "description": "A cross-platform, Python-agnostic binary package manager",
+    "homepage": "https://conda.io/miniconda.html",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        "",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Windows-x86_64.exe#/setup.exe",
+            "hash": "f242f98378691496851f78beaf466797fb20251ba5092840c794503594d37726"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "persist": "envs",
+    "checkver": {
+        "url": "https://repo.anaconda.com/miniconda/",
+        "regex": "Miniconda3-py310_([\\d.-]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py310_$version-Windows-x86_64.exe#/setup.exe"
+            }
+        },
+        "hash": {
+            "url": "https://repo.anaconda.com/miniconda/",
+            "regex": "(?sm)$basename.*?>$sha256<"
+        }
+    }
+}

--- a/bucket/miniconda3-py311.json
+++ b/bucket/miniconda3-py311.json
@@ -1,0 +1,63 @@
+{
+    "version": "23.11.0-2",
+    "description": "A cross-platform, Python-agnostic binary package manager",
+    "homepage": "https://conda.io/miniconda.html",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        "",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py311_23.11.0-2-Windows-x86_64.exe#/setup.exe",
+            "hash": "c9b32faa9262828702334b16bcb5b53556e630d54e5127f5c36c7ba7ed43179a"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "persist": "envs",
+    "checkver": {
+        "url": "https://repo.anaconda.com/miniconda/",
+        "regex": "Miniconda3-py311_([\\d.-]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py311_$version-Windows-x86_64.exe#/setup.exe"
+            }
+        },
+        "hash": {
+            "url": "https://repo.anaconda.com/miniconda/",
+            "regex": "(?sm)$basename.*?>$sha256<"
+        }
+    }
+}

--- a/bucket/miniconda3-py37.json
+++ b/bucket/miniconda3-py37.json
@@ -1,0 +1,63 @@
+{
+    "version": "23.1.0-1",
+    "description": "A cross-platform, Python-agnostic binary package manager",
+    "homepage": "https://conda.io/miniconda.html",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        "",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py37_23.1.0-1-Windows-x86_64.exe#/setup.exe",
+            "hash": "2319e6ab37215daf08f47b0da35a53f6a648121029113ae2ba53917d777b84bd"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "persist": "envs",
+    "checkver": {
+        "url": "https://repo.anaconda.com/miniconda/",
+        "regex": "Miniconda3-py37_([\\d.-]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py37_$version-Windows-x86_64.exe#/setup.exe"
+            }
+        },
+        "hash": {
+            "url": "https://repo.anaconda.com/miniconda/",
+            "regex": "(?sm)$basename.*?>$sha256<"
+        }
+    }
+}

--- a/bucket/miniconda3-py38.json
+++ b/bucket/miniconda3-py38.json
@@ -1,0 +1,63 @@
+{
+    "version": "23.11.0-2",
+    "description": "A cross-platform, Python-agnostic binary package manager",
+    "homepage": "https://conda.io/miniconda.html",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        "",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py38_23.11.0-2-Windows-x86_64.exe#/setup.exe",
+            "hash": "74dff3c5e867dffa74a34eca1c4daac550ba42f9229547b37ae4a706c58ca775"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "persist": "envs",
+    "checkver": {
+        "url": "https://repo.anaconda.com/miniconda/",
+        "regex": "Miniconda3-py38_([\\d.-]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py38_$version-Windows-x86_64.exe#/setup.exe"
+            }
+        },
+        "hash": {
+            "url": "https://repo.anaconda.com/miniconda/",
+            "regex": "(?sm)$basename.*?>$sha256<"
+        }
+    }
+}

--- a/bucket/miniconda3-py39.json
+++ b/bucket/miniconda3-py39.json
@@ -1,0 +1,63 @@
+{
+    "version": "23.11.0-2",
+    "description": "A cross-platform, Python-agnostic binary package manager",
+    "homepage": "https://conda.io/miniconda.html",
+    "license": "BSD-3-Clause",
+    "notes": [
+        "From 4.6.0, conda has built the support for Cmd, Powershell or other shells.",
+        "Use \"conda init powershell\" or \"conda init __your_favorite_shell__\"",
+        "",
+        "Miniconda3 drops support for 32-bit CPUs from v22.9.0. If you are running a 32-bit system, please install miniconda3-4.12.0 from the Versions bucket."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_23.11.0-2-Windows-x86_64.exe#/setup.exe",
+            "hash": "3bffceaf97f2945d6ff38d51c946b5e4ad161096e7734c34e98a9b38092a0ab5"
+        }
+    },
+    "pre_install": "if ($dir -match ' ') { error 'The installation directory cannot include a space'; break}",
+    "installer": {
+        "script": [
+            "# Using Start-Process as a workaround because the installer will not work properly when args are quoted (e.g. \"`\"/S`\"\")",
+            "# Move the installer to the upper directory to avoid the error \"The installatiom directory is not empty.\"",
+            "Move-Item \"$dir\\setup.exe\" \"$dir\\..\\setup.exe\" | Out-Null",
+            "Start-Process \"$dir\\..\\setup.exe\" -ArgumentList @('/S', '/InstallationType=JustMe', '/RegisterPython=0', '/AddToPath=0', '/NoRegistry=1', \"/D=$dir\") -Wait | Out-Null"
+        ]
+    },
+    "post_install": "Remove-Item \"$dir\\..\\setup.exe\" -Force | Out-Null",
+    "uninstaller": {
+        "script": [
+            "Start-Process \"$dir\\Uninstall-Miniconda3.exe\" -ArgumentList '/S' -Wait | Out-Null",
+            "# Create a 'dummy' to avoid error because the uninstaller removes the symlink. The does not affect persist.",
+            "if (!(Test-Path \"$dir\\envs\")) { New-Item \"$dir\\envs\" -ItemType Directory | Out-Null }"
+        ]
+    },
+    "bin": [
+        "python.exe",
+        "pythonw.exe",
+        [
+            "python.exe",
+            "python3"
+        ]
+    ],
+    "env_add_path": [
+        "scripts",
+        "Library\\bin"
+    ],
+    "persist": "envs",
+    "checkver": {
+        "url": "https://repo.anaconda.com/miniconda/",
+        "regex": "Miniconda3-py39_([\\d.-]+)-Windows"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://repo.anaconda.com/miniconda/Miniconda3-py39_$version-Windows-x86_64.exe#/setup.exe"
+            }
+        },
+        "hash": {
+            "url": "https://repo.anaconda.com/miniconda/",
+            "regex": "(?sm)$basename.*?>$sha256<"
+        }
+    }
+}


### PR DESCRIPTION

https://repo.anaconda.com/miniconda/
https://docs.anaconda.com/free/miniconda/miniconda-other-installer-links/#windows-installers

miniconda3 support different python version now. 

these manifest is fork from bucket `Extras`. https://github.com/ScoopInstaller/Extras/blob/master/bucket/miniconda3.json

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
