### PR TITLE
bun-canary: Download from unique artifact url

### DIFF
--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -9,10 +9,10 @@
     "architecture": {
         "64bit": {
             "url": "https://nightly.link/oven-sh/bun/suites/8506344388/artifacts/1374029880#/dl.zip",
-            "hash": "1e07c1e0bd8ffe4880dad29d9174419edf2f0070eb1ef1f0529f1a9121c41c82"
+            "hash": "1e07c1e0bd8ffe4880dad29d9174419edf2f0070eb1ef1f0529f1a9121c41c82",
+            "pre_install": "Expand-7zipArchive \"$dir\\bun-windows-x64.zip\" -ExtractDir 'bun-windows-x64' -Removal"
         }
     },
-    "extract_dir": "bun-windows-x64",
     "bin": [
         "bun.exe",
         [

--- a/bucket/bun-canary.json
+++ b/bucket/bun-canary.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0-canary.47+7531bfbfe",
+    "version": "1.1.0-canary.51+9e6e8b023",
     "description": "Incredibly fast JavaScript runtime, bundler, transpiler and package manager - all in one.",
     "homepage": "https://bun.sh/",
     "license": "MIT",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip",
-            "hash": "9b5430cd95cd253a4acfcf6d7de7b172e84554fa467db61e0e6371aa5c063354"
+            "url": "https://nightly.link/oven-sh/bun/suites/8506344388/artifacts/1374029880#/dl.zip",
+            "hash": "1e07c1e0bd8ffe4880dad29d9174419edf2f0070eb1ef1f0529f1a9121c41c82"
         }
     },
     "extract_dir": "bun-windows-x64",
@@ -23,22 +23,28 @@
     ],
     "checkver": {
         "script": [
-            "$dl_url = 'https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip'",
-            "$dl = cache_path 'bun-canary' 'unknown' $dl_url",
+            "$runs = (irm 'https://api.github.com/repos/oven-sh/bun/actions/workflows/bun-windows.yml/runs?status=success&per_page=1')",
+            "$buildId = $runs.workflow_runs[0].id",
+            "$artifacts = (irm \"https://api.github.com/repos/oven-sh/bun/actions/runs/$buildId/artifacts\")",
+            "$artifactId = $artifacts.artifacts | Where-Object { $_.name -eq 'bun-windows-x64' } | Select-Object -ExpandProperty 'id'",
+            "$dl_url = \"https://nightly.link/oven-sh/bun/suites/$buildId/artifacts/$artifactId\"",
+            "$dl = cache_path 'bun-canary' 'unknown' \"$dl_url#/dl.zip\"",
             "$dl_dir = strip_ext $dl",
-            "Invoke-WebRequest $dl_url -OutFile $dl",
-            "Expand-Archive $dl $dl_dir",
+            "Invoke-RestMethod $dl_url -OutFile $dl",
+            "Expand-Archive $dl $dl_dir -Force",
+            "Expand-Archive \"$dl_dir\\bun-windows-x64.zip\" $dl_dir -Force",
             "$ver = & \"$dl_dir\\bun-windows-x64\\bun.exe\" --revision",
-            "Move-Item -Force $dl (cache_path 'bun-canary' $ver $dl_url)",
-            "Remove-Item $dl_dir -Recurse",
-            "$ver"
+            "Move-Item $dl $dl_dir -Force",
+            "Remove-Item $dl_dir -Recurse -Force",
+            "$ret = \"$ver#$buildId#$artifactId\"",
+            "$ret"
         ],
-        "regex": "(\\S+)"
+        "regex": "(?<version>\\S+)#(?<buildid>\\d+)#(?<artifactid>\\d+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/oven-sh/bun/releases/download/canary/bun-windows-x64.zip"
+                "url": "https://nightly.link/oven-sh/bun/suites/$matchBuildid/artifacts/$matchArtifactid#/dl.zip"
             }
         }
     }


### PR DESCRIPTION
Prevent https://github.com/ScoopInstaller/Versions/issues?q=bun-canary from occuring

NOTE: It is impossible to download GHA artifacts without using GH auth token or the https://nightly.link/ service.


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
