### PR TITLE
kde-apps: Migrate from binary-factory.kde.org

### DIFF
--- a/bucket/dolphin-nightly.json
+++ b/bucket/dolphin-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "3887",
+    "version": "3893",
     "homepage": "https://apps.kde.org/dolphin/",
     "description": "A file manager developed by KDE that lets you navigate and browse the contents of your hard drives, USB sticks, SD cards, and more.",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-3887-windows-cl-msvc2022-x86_64.7z",
-            "hash": "45616d04f6b1dda6c1b6b0f46a4941cb2ce2464523e13f0d9bebfb672162c91a"
+            "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-3893-windows-cl-msvc2022-x86_64.7z",
+            "hash": "01c633ca70281b3daac39c2addd6b5f77137f2eba21ff360bae9618890cd5c61"
         }
     },
     "bin": "bin\\dolphin.exe",

--- a/bucket/dolphin-nightly.json
+++ b/bucket/dolphin-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "3856",
+    "version": "3887",
     "homepage": "https://apps.kde.org/dolphin/",
     "description": "A file manager developed by KDE that lets you navigate and browse the contents of your hard drives, USB sticks, SD cards, and more.",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-3856-windows-cl-msvc2022-x86_64.7z",
-            "hash": "8436175f3f12f681b2ea68b7bc98dee7d386980b5e98b06767b9bbf58e7dadde"
+            "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-3887-windows-cl-msvc2022-x86_64.7z",
+            "hash": "45616d04f6b1dda6c1b6b0f46a4941cb2ce2464523e13f0d9bebfb672162c91a"
         }
     },
     "bin": "bin\\dolphin.exe",

--- a/bucket/dolphin-nightly.json
+++ b/bucket/dolphin-nightly.json
@@ -1,12 +1,12 @@
 {
+    "version": "3856",
     "homepage": "https://apps.kde.org/dolphin/",
-    "version": "1163",
     "description": "A file manager developed by KDE that lets you navigate and browse the contents of your hard drives, USB sticks, SD cards, and more.",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Dolphin_Nightly_win64/lastSuccessfulBuild/artifact/dolphin-master-1163-windows-cl-msvc2019-x86_64.7z",
-            "hash": "14b4c9b58a815262ae7bc4de924472a57ee0ddc892cb4418a35b9a7348d51ddb"
+            "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-3856-windows-cl-msvc2022-x86_64.7z",
+            "hash": "8436175f3f12f681b2ea68b7bc98dee7d386980b5e98b06767b9bbf58e7dadde"
         }
     },
     "bin": "bin\\dolphin.exe",
@@ -18,13 +18,13 @@
     ],
     "pre_install": "Stop-Process -Name 'dbus-daemon' -Force -ErrorAction 'SilentlyContinue'",
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Dolphin_Nightly_win64/",
+        "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/",
         "regex": "dolphin-master-([\\d]+)-windows-cl-msvc(?<Year>[\\d]+)-x86_64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Dolphin_Nightly_win64/lastSuccessfulBuild/artifact/dolphin-master-$version-windows-cl-msvc$matchYear-x86_64.7z",
+                "url": "https://cdn.kde.org/ci-builds/system/dolphin/master/windows/dolphin-master-$version-windows-cl-msvc$matchYear-x86_64.7z",
                 "hash": {
                     "url": "$url.sha256"
                 }

--- a/bucket/filelight-nightly.json
+++ b/bucket/filelight-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1314",
+    "version": "1188",
     "description": "Disk usage visualizer",
     "homepage": "https://apps.kde.org/filelight",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Filelight_Nightly_win64/lastSuccessfulBuild/artifact/filelight-master-1314-windows-msvc2019_64-cl.7z",
-            "hash": "f68636f5b54d08e9ba9d370b6df91d27d46431140b415870a70460bfb90457af"
+            "url": "https://cdn.kde.org/ci-builds/utilities/filelight/master/windows/filelight-master-1188-windows-cl-msvc2022-x86_64.7z",
+            "hash": "660613aa0931a12cc0a0e61f62e175213f618d48ebed508679ad5e26b3654d84"
         }
     },
     "bin": [
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Filelight_Nightly_win64/",
-        "regex": "filelight-master-(\\d+)-windows"
+        "url": "https://cdn.kde.org/ci-builds/utilities/filelight/master/windows/",
+        "regex": "filelight-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Filelight_Nightly_win64/lastSuccessfulBuild/artifact/filelight-master-$version-windows-msvc2019_64-cl.7z"
+                "url": "https://cdn.kde.org/ci-builds/utilities/filelight/master/windows/filelight-master-$version-windows-cl-$matchLib-x86_64.7z"
             }
         },
         "hash": {

--- a/bucket/kate-nightly.json
+++ b/bucket/kate-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "6891",
+    "version": "6909",
     "description": "Multi-document editor",
     "homepage": "https://apps.kde.org/kate",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-6891-windows-cl-msvc2022-x86_64.7z",
-            "hash": "b5e60e42e317cbaf92edf94a82d906ad754073ac304d92aad5a186d6bef1374c"
+            "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-6909-windows-cl-msvc2022-x86_64.7z",
+            "hash": "571d2d24ef35fe8afbbebe9bfc0465b873e18ed005392efedbb8fd4ee6b7962e"
         }
     },
     "bin": [

--- a/bucket/kate-nightly.json
+++ b/bucket/kate-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1758",
-    "description": "Communications and data transfer between devices over local networks",
-    "homepage": "https://apps.kde.org/kdeconnect",
+    "version": "6876",
+    "description": "Multi-document editor",
+    "homepage": "https://apps.kde.org/kate",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Kate_Nightly_win64/lastSuccessfulBuild/artifact/kate-master-1758-windows-msvc2019_64-cl.7z",
-            "hash": "c6368326b8a9402892c5d867ca76105afa46e8542b19ff0a3e967ee6bea9ab2d"
+            "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-6876-windows-cl-msvc2022-x86_64.7z",
+            "hash": "00ec5203aaba6c66ad4a6adba18079aa4bee9c5384cf0b195ec93c186366994f"
         }
     },
     "bin": [
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Kate_Nightly_win64/",
-        "regex": "kate-master-(\\d+)-windows"
+        "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/",
+        "regex": "kate-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Kate_Nightly_win64/lastSuccessfulBuild/artifact/kate-master-$version-windows-msvc2019_64-cl.7z"
+                "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-$version-windows-cl-$matchLib-x86_64.7z"
             }
         },
         "hash": {

--- a/bucket/kate-nightly.json
+++ b/bucket/kate-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "6876",
+    "version": "6891",
     "description": "Multi-document editor",
     "homepage": "https://apps.kde.org/kate",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-6876-windows-cl-msvc2022-x86_64.7z",
-            "hash": "00ec5203aaba6c66ad4a6adba18079aa4bee9c5384cf0b195ec93c186366994f"
+            "url": "https://cdn.kde.org/ci-builds/utilities/kate/master/windows/kate-master-6891-windows-cl-msvc2022-x86_64.7z",
+            "hash": "b5e60e42e317cbaf92edf94a82d906ad754073ac304d92aad5a186d6bef1374c"
         }
     },
     "bin": [

--- a/bucket/kdeconnect-nightly.json
+++ b/bucket/kdeconnect-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1712",
+    "version": "3761",
     "description": "Communications and data transfer between devices over local networks",
     "homepage": "https://apps.kde.org/kdeconnect",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/1712/artifact/kdeconnect-kde-master-1712-windows-cl-msvc2019-x86_64.7z",
-            "hash": "b0590d7042ad8016a80b31470c70fbf61fc683f966f1f8e7e871ec26aef8c4fa"
+            "url": "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/windows/kdeconnect-kde-master-3761-windows-cl-msvc2022-x86_64.7z",
+            "hash": "3e5fd24a518ffff95e7c407eaa9ca52c3cba889e4a83512c3cc2be7244e24d3d"
         }
     },
     "bin": [
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/lastSuccessfulBuild/api/json/",
-        "jsonpath": "$.number"
+        "url": "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/windows/",
+        "regex": "kdeconnect-kde-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/kdeconnect-kde_Nightly_win64/$version/artifact/kdeconnect-kde-master-$version-windows-cl-msvc2019-x86_64.7z"
+                "url": "https://cdn.kde.org/ci-builds/network/kdeconnect-kde/master/windows/kdeconnect-kde-master-$version-windows-cl-$matchLib-x86_64.7z"
             }
         },
         "hash": {

--- a/bucket/kdenlive-nightly.json
+++ b/bucket/kdenlive-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1308",
+    "version": "7813",
     "description": "Video editing software based on the MLT Framework, KDE and Qt",
     "homepage": "https://kdenlive.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/lastSuccessfulBuild/artifact/kdenlive-master-1308-windows-mingw_64-gcc.7z",
-            "hash": "719c22cc28ccca880fccb6ada06d3911a533e2b3487c440ef860f9957c7d36ef"
+            "url": "https://cdn.kde.org/ci-builds/multimedia/kdenlive/master/windows/kdenlive-master-7813-windows-gcc-x86_64.7z",
+            "hash": "55a62fbbbc3059480bb62c2917f6003e5480265427e1379b697200e1081af9af"
         }
     },
     "bin": "bin\\kdenlive.exe",
@@ -17,13 +17,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/",
-        "regex": "kdenlive-master-(\\d+)-windows"
+        "url": "https://cdn.kde.org/ci-builds/multimedia/kdenlive/master/windows/",
+        "regex": "kdenlive-master-(\\d+)-windows-gcc-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Kdenlive_Nightly_mingw64/lastSuccessfulBuild/artifact/kdenlive-master-$version-windows-mingw_64-gcc.7z"
+                "url": "https://cdn.kde.org/ci-builds/multimedia/kdenlive/master/windows/kdenlive-master-$version-windows-gcc-x86_64.7z"
             }
         },
         "hash": {

--- a/bucket/kdenlive-nightly.json
+++ b/bucket/kdenlive-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "7813",
+    "version": "7843",
     "description": "Video editing software based on the MLT Framework, KDE and Qt",
     "homepage": "https://kdenlive.org",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/multimedia/kdenlive/master/windows/kdenlive-master-7813-windows-gcc-x86_64.7z",
-            "hash": "55a62fbbbc3059480bb62c2917f6003e5480265427e1379b697200e1081af9af"
+            "url": "https://cdn.kde.org/ci-builds/multimedia/kdenlive/master/windows/kdenlive-master-7843-windows-gcc-x86_64.7z",
+            "hash": "07551064939e9c7a7531916d2f6f0b549b80ff0753546b28712a0113d9b995c9"
         }
     },
     "bin": "bin\\kdenlive.exe",

--- a/bucket/labplot-nightly.json
+++ b/bucket/labplot-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "6374",
+    "version": "6390",
     "homepage": "https://labplot.kde.org/",
     "description": "A free, open source, and cross-platform Data Visualization and Analysis software accessible to everyone.",
     "license": "Apache-2.0,BSD-3-Clause,CC0-1.0,CC-BY-3.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0-only,GPL-3.0-or-later,LGPL-3.0-or-later,MIT",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-6374-windows-cl-msvc2019-x86_64.7z",
-            "hash": "f1e84174d0fc83e64bc35901f5af699560890f5cb6fc070e358b98ff4e440f14"
+            "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-6390-windows-cl-msvc2019-x86_64.7z",
+            "hash": "2b934adc2bf67ef03cac1b9c9d42f69da04d34be1f6261b8eadd6a4ecc8d7287"
         }
     },
     "shortcuts": [

--- a/bucket/labplot-nightly.json
+++ b/bucket/labplot-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "6355",
+    "version": "6374",
     "homepage": "https://labplot.kde.org/",
     "description": "A free, open source, and cross-platform Data Visualization and Analysis software accessible to everyone.",
     "license": "Apache-2.0,BSD-3-Clause,CC0-1.0,CC-BY-3.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0-only,GPL-3.0-or-later,LGPL-3.0-or-later,MIT",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-6355-windows-cl-msvc2019-x86_64.7z",
-            "hash": "94178cab3c082bd66aa543449143d4a554e020248968495565a0e1c55c464979"
+            "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-6374-windows-cl-msvc2019-x86_64.7z",
+            "hash": "f1e84174d0fc83e64bc35901f5af699560890f5cb6fc070e358b98ff4e440f14"
         }
     },
     "shortcuts": [

--- a/bucket/labplot-nightly.json
+++ b/bucket/labplot-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1771",
+    "version": "6355",
     "homepage": "https://labplot.kde.org/",
     "description": "A free, open source, and cross-platform Data Visualization and Analysis software accessible to everyone.",
     "license": "Apache-2.0,BSD-3-Clause,CC0-1.0,CC-BY-3.0,GPL-2.0-only,GPL-2.0-or-later,GPL-3.0-only,GPL-3.0-or-later,LGPL-3.0-or-later,MIT",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Labplot_Nightly_win64/lastSuccessfulBuild/artifact/labplot-master-1771-windows-cl-msvc2019-x86_64.7z",
-            "hash": "088ac6b168565fd9f9224513f25909785814f9cc61ca548d343dcbdbc7764003"
+            "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-6355-windows-cl-msvc2019-x86_64.7z",
+            "hash": "94178cab3c082bd66aa543449143d4a554e020248968495565a0e1c55c464979"
         }
     },
     "shortcuts": [
@@ -16,13 +16,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Labplot_Nightly_win64/",
-        "regex": "labplot-master-([\\d]+)"
+        "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/",
+        "regex": "labplot-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Labplot_Nightly_win64/lastSuccessfulBuild/artifact/labplot-master-$version-windows-cl-msvc2019-x86_64.7z",
+                "url": "https://cdn.kde.org/ci-builds/education/labplot/master/windows/labplot-master-$version-windows-cl-$matchLib-x86_64.7z",
                 "hash": {
                     "url": "$url.sha256"
                 }

--- a/bucket/neochat-nightly.json
+++ b/bucket/neochat-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "692",
+    "version": "8007",
     "description": "A client for Matrix, the decentralized communication protocol",
     "homepage": "https://apps.kde.org/neochat/",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/NeoChat_Nightly_win64/lastSuccessfulBuild/artifact/neochat-master-692-windows-msvc2019_64-cl.7z",
-            "hash": "022968934065732c125af70a527c415d6d24a9061dc6612d43e0f0bc280eccd7"
+            "url": "https://cdn.kde.org/ci-builds/network/neochat/master/windows/neochat-master-8007-windows-cl-msvc2022-x86_64.7z",
+            "hash": "b85d133e1f29bcd36218e2b5fcc4d28f166776a67f0b85bc1e9127bcee09a037"
         }
     },
     "bin": [
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/NeoChat_Nightly_win64/",
-        "regex": "neochat-master-(\\d+)-windows"
+        "url": "https://cdn.kde.org/ci-builds/network/neochat/master/windows/",
+        "regex": "neochat-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/NeoChat_Nightly_win64/lastSuccessfulBuild/artifact/neochat-master-$version-windows-msvc2019_64-cl.7z"
+                "url": "https://cdn.kde.org/ci-builds/network/neochat/master/windows/neochat-master-$version-windows-cl-$matchLib-x86_64.7z"
             }
         },
         "hash": {

--- a/bucket/neochat-nightly.json
+++ b/bucket/neochat-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "8007",
+    "version": "8014",
     "description": "A client for Matrix, the decentralized communication protocol",
     "homepage": "https://apps.kde.org/neochat/",
     "license": "GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/network/neochat/master/windows/neochat-master-8007-windows-cl-msvc2022-x86_64.7z",
-            "hash": "b85d133e1f29bcd36218e2b5fcc4d28f166776a67f0b85bc1e9127bcee09a037"
+            "url": "https://cdn.kde.org/ci-builds/network/neochat/master/windows/neochat-master-8014-windows-cl-msvc2022-x86_64.7z",
+            "hash": "80f42d30730d79b2232385699b34612fe0fe9b5d39e7fe9cd3faeb56fbc1b3b3"
         }
     },
     "bin": [


### PR DESCRIPTION
Since [migration KDE applications CI from Binary Factory to KDE's GitLab](https://blogs.kde.org/2024/01/30/farewell-binary-factory-add-craft-jobs-your-apps-kdes-gitlab-now/) the following broken manifests updated:

- dolphin-nightly
- filelight-nightly
- kate-nightly
- kdeconnect-nightly
- kdenlive-nightly
- labplot-nightly
- neochat-nightly

TODO (windows builds are not available yet):

- konversation
- okular-nightly

Relates to ScoopInstaller/Extras#12897

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).