### PR TITLE
okular-nightly: Update to version 4709

### DIFF
--- a/bucket/okular-nightly.json
+++ b/bucket/okular-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1725",
+    "version": "4709",
     "description": "Universal document viewer",
     "homepage": "https://okular.kde.org",
     "license": "LGPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://binary-factory.kde.org/job/Okular_Nightly_win64/lastSuccessfulBuild/artifact/okular-master-1725-windows-cl-msvc2019-x86_64.7z",
-            "hash": "47b725854608a3ada9fce52429d845335895dc6fe521e340c34706740b51c3d3"
+            "url": "https://cdn.kde.org/ci-builds/graphics/okular/master/windows/okular-master-4709-windows-cl-msvc2022-x86_64.7z",
+            "hash": "fe959b2979afb04feed85528f49fd901033689d7d96eaeef543058ec7ca3639e"
         }
     },
     "bin": [
@@ -22,13 +22,13 @@
         ]
     ],
     "checkver": {
-        "url": "https://binary-factory.kde.org/job/Okular_Nightly_win64/",
-        "regex": "okular-master-(\\d+)-windows"
+        "url": "https://cdn.kde.org/ci-builds/graphics/okular/master/windows/",
+        "regex": "okular-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://binary-factory.kde.org/job/Okular_Nightly_win64/lastSuccessfulBuild/artifact/okular-master-$version-windows-cl-msvc2019-x86_64.7z"
+                "url": "https://cdn.kde.org/ci-builds/graphics/okular/master/windows/okular-master-$version-windows-cl-$matchLib-x86_64.7z"
             }
         },
         "hash": {


### PR DESCRIPTION
- Migrate from binary-factory.kde.org.
- Update to the latest version.

Relates to #1662

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
