### PR TITLE
spark33: Add version 3.3.4

### DIFF
--- a/bucket/spark33.json
+++ b/bucket/spark33.json
@@ -16,15 +16,13 @@
     "persist": "conf",
     "checkver": {
         "url": "https://archive.apache.org/dist/spark/",
-        "regex": "spark-3.3.([\\d])",
-        "reverse": true,
-        "replace": "3.3.${1}"
+        "regex": "spark-(3.3.\\d)",
+        "reverse": true
     },
     "autoupdate": {
         "url": "https://archive.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop3.tgz",
         "hash": {
-            "url": "$url.sha512",
-            "regex": "$basename: ([A-F0-9\\s]+)$"
+            "url": "$url.sha512"
         },
         "extract_dir": "spark-$version-bin-hadoop3"
     }

--- a/bucket/spark33.json
+++ b/bucket/spark33.json
@@ -1,0 +1,31 @@
+{
+    "version": "3.3.4",
+    "description": "A unified analytics engine for large-scale data processing.",
+    "homepage": "https://spark.apache.org/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://archive.apache.org/dist/spark/spark-3.3.4/spark-3.3.4-bin-hadoop3.tgz",
+    "hash": "sha512:a3874e340a113e95898edfa145518648700f799ffe2d1ce5dde7743e88fdf5559d79d9bcb1698fdfa5296a63c1d0fc4c8e32a93529ed58cd5dcf0721502a1fc7",
+    "extract_dir": "spark-3.3.4-bin-hadoop3",
+    "env_add_path": "bin",
+    "env_set": {
+        "SPARK_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://archive.apache.org/dist/spark/",
+        "regex": "spark-3.3.([\\d])",
+        "reverse": true,
+        "replace": "3.3.${1}"
+    },
+    "autoupdate": {
+        "url": "https://archive.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop3.tgz",
+        "hash": {
+            "url": "$url.sha512",
+            "regex": "$basename: ([A-F0-9\\s]+)$"
+        },
+        "extract_dir": "spark-$version-bin-hadoop3"
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
This PR adds the Spark 3.3.x series which is the most recent version available in Cloudera.
If this is desired, it would be easy to add other Spark versions as well.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
