### PR TITLE
strawberry-nightly: Fix `pre_install`

### DIFF
--- a/bucket/strawberry-nightly.json
+++ b/bucket/strawberry-nightly.json
@@ -14,10 +14,9 @@
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\*-Debug-*.exe\"",
-        "Expand-7zipArchive \"$dir\\StrawberrySetup-*-msvc-x$($architecture.Substring(0, 2)).exe\" \"$dir\"",
-        "Remove-Item \"$dir\\`$PLUGINSDIR\" -Recurse",
-        "'StrawberrySetup-*', 'Uninstall' | ForEach-Object { Remove-Item \"$dir\\$_.exe\" }"
+        "Remove-Item \"$dir/*-Debug-*.exe\"",
+        "Expand-7zipArchive \"$dir/StrawberrySetup-*-msvc-x$($architecture.Substring(0, 2)).exe\" \"$dir\" -Removal",
+        "Remove-Item \"$dir/`$PLUGINSDIR\" -Recurse"
     ],
     "bin": "strawberry.exe",
     "shortcuts": [


### PR DESCRIPTION
```pwsh
Running pre_install script...
Remove-Item:
Line |
   4 |  … ySetup-*', 'Uninstall' | ForEach-Object { Remove-Item "$dir\$_.exe" }
     |                                              ~~~~~~~~~~~~~~~~~~~~~~~~~
     | Cannot find path '~\scoop\apps\strawberry-nightly\8820060660\Uninstall.exe' because it does not exist.
```

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).