### PR TITLE
hadoop-winutils33: Add version 3.3.5

### DIFF
--- a/bucket/hadoop-winutils33.json
+++ b/bucket/hadoop-winutils33.json
@@ -1,0 +1,27 @@
+{
+    "version": "3.3.5",
+    "description": "Windows binaries for Hadoop versions.",
+    "homepage": "https://github.com/cdarlint/winutils/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://codeload.github.com/cdarlint/winutils/zip/refs/heads/master#hadoop.zip",
+    "hash": "0116950bfb5bb03bfe9bd6fb842515a1c88fe197eeb4b7005a0a7db102f07688",
+    "extract_dir": "winutils-master/hadoop-3.3.5",
+    "env_add_path": "bin",
+    "bin": "bin\\winutils.exe",
+    "env_set": {
+        "HADOOP_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://github.com/cdarlint/winutils/",
+        "regex": "hadoop-(3.3.\\d)",
+        "reverse": true
+    },
+    "autoupdate": {
+        "url": "https://codeload.github.com/cdarlint/winutils/zip/refs/heads/master#hadoop.zip",
+        "extract_dir": "winutils-master/hadoop-$version"
+    }
+}

--- a/bucket/hadoop-winutils33.json
+++ b/bucket/hadoop-winutils33.json
@@ -6,22 +6,64 @@
     "suggest": {
         "JDK": "java/openjdk"
     },
-    "url": "https://codeload.github.com/cdarlint/winutils/zip/refs/heads/master#hadoop.zip",
-    "hash": "0116950bfb5bb03bfe9bd6fb842515a1c88fe197eeb4b7005a0a7db102f07688",
-    "extract_dir": "winutils-master/hadoop-3.3.5",
-    "env_add_path": "bin",
-    "bin": "bin\\winutils.exe",
-    "env_set": {
-        "HADOOP_HOME": "$dir"
-    },
-    "persist": "conf",
+    "url": [
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop.cmd",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop.dll",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop.exp",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop.lib",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hadoop.pdb",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hdfs",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/hdfs.cmd",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/libwinutils.lib",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/mapred",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/mapred.cmd",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/winutils.exe",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/winutils.pdb",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/yarn",
+        "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-3.3.5/bin/yarn.cmd"
+    ],
+    "hash": [
+        "e8a1f032a56beceb1989c8467b58109d2bff47f8c7bc5de3dde76cf2c6452abf",
+        "2d7f5d9b5ea01189cb0e0dfcea9e06eb58a6427a35e67afe72a80da30f9fd324",
+        "d3dd64afdc85f2a7eb5345abf2ecaa744b0a157de40859313337d47f81ee1c7b",
+        "03d8a1ed662ee4fcb7393e83386c1c086897a4b2f5a5df20eee84bc215ac5311",
+        "2923e73622a1b6ecc5785692f9fb0f32361862ea369adf931a186a079dbec220",
+        "6b8ac1bf6985f73f59f5633a7f02c1e945fde23080a8056c11ed760fbb54dd9a",
+        "db79a2c81efa42a1255232f1239b67da920130f6df04807212ab1ea59edfa0ff",
+        "ddc96e03b6ff62bd551ff5b9ec54a8b5d228aaf4836a7a4156f6a2e1b1c23741",
+        "5c35b97e49b639112135deaf94afc5753333d6f9fc815adbe3ef6a3843a36ae5",
+        "11c9502db17e000b838664ae76ace002f7bd6607a61e73a010022b5ee6bd6566",
+        "d743c658af11eebc5350768e9f29d0a1dca42bbfad6b60b1ebf023bbf9de24fc",
+        "a0ca6e358357c41ef56ebdb02c38e4a4d55da7ca7a13001678bb2ef7d644adea",
+        "ba630ced9e7d587e17bbf78b17df7e1c83f07b32a0eef3b16cb3bf442454e627",
+        "56ac42988d7fe5758667c5ca6be0c4455cb0bf073fa14dbdb6a105e3b3d6f234",
+        "ad3544310c6687376d8d6b5f796c4b0d9fe64edec3907e63dd517f82a861d0bf"
+    ],
+    "bin": "winutils.exe",
     "checkver": {
-        "url": "https://github.com/cdarlint/winutils/",
-        "regex": "hadoop-(3.3.\\d)",
-        "reverse": true
+        "url": "https://api.github.com/repos/cdarlint/winutils/contents/",
+        "jsonpath": "$..name",
+        "reverse": true,
+        "regex": "hadoop-(3.3\\.\\d+)"
     },
     "autoupdate": {
-        "url": "https://codeload.github.com/cdarlint/winutils/zip/refs/heads/master#hadoop.zip",
-        "extract_dir": "winutils-master/hadoop-$version"
+        "url": [
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop.cmd",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop.dll",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop.exp",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop.lib",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hadoop.pdb",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hdfs",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/hdfs.cmd",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/libwinutils.lib",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/mapred",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/mapred.cmd",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/winutils.exe",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/winutils.pdb",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/yarn",
+            "https://raw.githubusercontent.com/cdarlint/winutils/master/hadoop-$version/bin/yarn.cmd"
+        ]
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The author of the original `hadoop-winutils` is too busy to continue working on it, but there is a [recommended fork](https://github.com/steveloughran/winutils?tab=readme-ov-file#status-go-to-cdarlintwinutils-for-current-artifacts) that provides newer versions at [cdarlint/winutils](https://github.com/cdarlint/winutils).
This PR adds version 3.3 from @cdarlint's fork.

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Resolves https://github.com/ScoopInstaller/Extras/issues/3009

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
