### PR TITLE
iperf3.5: Add version 3.5

### DIFF
--- a/bucket/iperf3.5.json
+++ b/bucket/iperf3.5.json
@@ -1,0 +1,19 @@
+{
+    "version": "3.5",
+    "description": "Tool for measuring the maximum achievable bandwidth on IP networks (last 32bit version)",
+    "homepage": "https://iperf.fr/",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://files.budman.pw/iperf3.5_64.zip",
+            "hash": "94a0ec4e486904a6a8ebe390eca37871f47a097599908c3647d6ad1d0bbdff59",
+            "extract_dir": "iperf3.5_64"
+        },
+        "32bit": {
+            "url": "https://files.budman.pw/iperf3.5_32.zip",
+            "hash": "bf4b95a58e54ceda101e33b0b908c581df1ce4a217f233e1092dc3278572de43",
+            "extract_dir": "iperf3.5_32"
+        }
+    },
+    "bin": "iperf3.exe"
+}


### PR DESCRIPTION
Last version of iPerf 3 that has a 32bit release.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
