### PR TITLE
chromium-nosync@125.0.6422.61-r1287751: fix checkver regex not working + remove redundant 32bit version

### DIFF
--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -34,7 +34,7 @@
     "persist": "User Data",
     "checkver": {
         "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-        "regex": ">v([.*-r]+)</h1>"
+        "regex": ">v([\\d.]+-r\\d+)</h1>"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -5,7 +5,7 @@
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
-    "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f"
+    "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f",
     "extract_dir": "Chrome-bin",
     "bin": [
         [

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -4,8 +4,12 @@
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
-    "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
-    "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
+            "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f"
+        }
+    },
     "extract_dir": "Chrome-bin",
     "bin": [
         [
@@ -33,10 +37,14 @@
         "regex": ">v([.*-r]+)</h1>"
     },
     "autoupdate": {
-        "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.nosync.7z",
-        "hash": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-            "regex": "$sha1  ../out/x64/chrome.nosync.7z"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.nosync.7z",
+                "hash": {
+                    "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
+                    "regex": "$sha1  ../out/x64/chrome.nosync.7z"
+                }
+            }
         }
     }
 }

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -42,7 +42,7 @@
                 "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.nosync.7z",
                 "hash": {
                     "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-                    "regex": "$sha1 \\.\\./out/x64/chrome.nosync.7z"
+                    "regex": "$sha1  ../out/x64/chrome.nosync.7z"
                 }
             }
         }

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -4,12 +4,8 @@
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
-            "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f"
-        }
-    },
+    "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
+    "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f"
     "extract_dir": "Chrome-bin",
     "bin": [
         [
@@ -37,14 +33,10 @@
         "regex": ">v([.*-r]+)</h1>"
     },
     "autoupdate": {
-        "architecture": {
-            "64bit": {
-                "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.nosync.7z",
-                "hash": {
-                    "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-                    "regex": "$sha1  ../out/x64/chrome.nosync.7z"
-                }
-            }
+        "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v$version/chrome.nosync.7z",
+        "hash": {
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
+            "regex": "$sha1  ../out/x64/chrome.nosync.7z"
         }
     }
 }

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -1,17 +1,13 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "124.0.6367.61-r1274542",
+    "version": "125.0.6422.61-r1287751",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v124.0.6367.61-r1274542/chrome.nosync.7z",
-            "hash": "sha1:bf1334be0e27356cd4b30b18435bbf51bd5c96d0"
-        },
-        "32bit": {
-            "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v124.0.6367.61-r1274542/chrome.nosync.7z",
-            "hash": "sha1:6a75a09124733ebc9bf9bb50c9d480c15ddb3967"
+            "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v125.0.6422.61-r1287751/chrome.nosync.7z",
+            "hash": "sha1:c878d23d4744ff55b1238940385a6d424a7f621f"
         }
     },
     "extract_dir": "Chrome-bin",
@@ -38,7 +34,7 @@
     "persist": "User Data",
     "checkver": {
         "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-        "regex": ">v([\\d.\\-r]+)</h1>"
+        "regex": ">v([.*-r]+)</h1>"
     },
     "autoupdate": {
         "architecture": {
@@ -47,13 +43,6 @@
                 "hash": {
                     "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
                     "regex": "$sha1 \\.\\./out/x64/chrome.nosync.7z"
-                }
-            },
-            "32bit": {
-                "url": "https://github.com/Hibbiki/chromium-win32/releases/download/v$version/chrome.nosync.7z",
-                "hash": {
-                    "url": "https://github.com/Hibbiki/chromium-win32/releases/latest",
-                    "regex": "$sha1 \\.\\./out/x86/chrome.nosync.7z"
                 }
             }
         }


### PR DESCRIPTION
Closes #1749 

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
