### PR TITLE
chore: Replace deprecated `env` function with `(Set|Get)-EnvVar`

### DIFF
--- a/bucket/python-alpha.json
+++ b/bucket/python-alpha.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python-alpha.json
+++ b/bucket/python-alpha.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python-beta.json
+++ b/bucket/python-beta.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python-beta.json
+++ b/bucket/python-beta.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python-pre.json
+++ b/bucket/python-pre.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python-pre.json
+++ b/bucket/python-pre.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python-rc.json
+++ b/bucket/python-rc.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python-rc.json
+++ b/bucket/python-rc.json
@@ -61,8 +61,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -73,8 +73,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python310.json
+++ b/bucket/python310.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python310.json
+++ b/bucket/python310.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python311.json
+++ b/bucket/python311.json
@@ -55,8 +55,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -94,8 +94,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python311.json
+++ b/bucket/python311.json
@@ -55,8 +55,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -94,8 +94,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python312.json
+++ b/bucket/python312.json
@@ -55,8 +55,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -94,8 +94,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python312.json
+++ b/bucket/python312.json
@@ -55,8 +55,8 @@
             "}",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -94,8 +94,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python35.json
+++ b/bucket/python35.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python35.json
+++ b/bucket/python35.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python36.json
+++ b/bucket/python36.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python37.json
+++ b/bucket/python37.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python37.json
+++ b/bucket/python37.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python38.json
+++ b/bucket/python38.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python38.json
+++ b/bucket/python38.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/python39.json
+++ b/bucket/python39.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext;.PY;.PYW\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (env 'PATHEXT' $true) -replace ';.PYW?', ''",
-            "    env 'PATHEXT' $true \"$pathext\"",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
             "}"
         ]
     },

--- a/bucket/python39.json
+++ b/bucket/python39.json
@@ -57,8 +57,8 @@
             "(Get-ChildItem \"$dir\\_tmp\\AttachedContainer\\*.msi\").FullName | ForEach-Object { Expand-MsiArchive $_ \"$dir\" }",
             "Remove-Item \"$dir\\_tmp\", \"$dir\\setup.exe\" -Force -Recurse",
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext;.PY;.PYW\" -Global",
             "}"
         ]
     },
@@ -69,8 +69,8 @@
     "uninstaller": {
         "script": [
             "if ($global) {",
-            "    $pathext = (Get-EnvVar -Name PATHEXT -Global:$true) -replace ';.PYW?', ''",
-            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global:$true",
+            "    $pathext = (Get-EnvVar -Name PATHEXT -Global) -replace ';.PYW?', ''",
+            "    Set-EnvVar -Name PATHEXT -Value \"$pathext\" -Global",
             "}"
         ]
     },

--- a/bucket/tesseract3.json
+++ b/bucket/tesseract3.json
@@ -33,7 +33,7 @@
     "post_install": [
         "$langdir = versiondir tesseract3-languages current $global",
         "if (Test-Path $langdir) {",
-        "   env \"TESSDATA_PREFIX\" $global $langdir",
+        "   Set-EnvVar -Name TESSDATA_PREFIX -Value $langdir -Global:$global",
         "}"
     ]
 }

--- a/bucket/tesseract4.json
+++ b/bucket/tesseract4.json
@@ -23,7 +23,7 @@
     "post_install": [
         "$langdir = versiondir tesseract4-languages current $global",
         "if (Test-Path $langdir) {",
-        "   env \"TESSDATA_PREFIX\" $global $langdir",
+        "   Set-EnvVar -Name TESSDATA_PREFIX -Value $langdir -Global:$global",
         "}"
     ],
     "env_set": {


### PR DESCRIPTION
```
WARN  "env" will be deprecated. Please change your code/manifest to use "Set-EnvVar"
```

Relates to https://github.com/ScoopInstaller/Main/pull/5849

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).