### PR TITLE
marknote-nightly: Add version 506

### DIFF
--- a/bucket/marknote-nightly.json
+++ b/bucket/marknote-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "503",
+    "version": "506",
     "description": "A simple markdown note-taking app developed by KDE",
     "homepage": "https://apps.kde.org/marknote/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-503-windows-cl-msvc2022-x86_64.7z",
-            "hash": "2bb1ecfcbf575bde1141bc1efdfaba88878e141e4c00174cde8b5defbf7327c4"
+            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-506-windows-cl-msvc2022-x86_64.7z",
+            "hash": "0c7e352649e9cdd09b43e41576442027af751f2aa78bbe781c6fd6a0aa1c4407"
         }
     },
     "bin": "bin\\marknote.exe",

--- a/bucket/marknote-nightly.json
+++ b/bucket/marknote-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "495",
+    "version": "503",
     "description": "A simple markdown note-taking app developed by KDE",
     "homepage": "https://apps.kde.org/marknote/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-495-windows-cl-msvc2022-x86_64.7z",
-            "hash": "25b755456d85041a10f11f55d827a83b0f64783a1cfff7be94cb774a20d1d798"
+            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-503-windows-cl-msvc2022-x86_64.7z",
+            "hash": "2bb1ecfcbf575bde1141bc1efdfaba88878e141e4c00174cde8b5defbf7327c4"
         }
     },
     "bin": "bin\\marknote.exe",

--- a/bucket/marknote-nightly.json
+++ b/bucket/marknote-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "489",
+    "version": "495",
     "description": "A simple markdown note-taking app developed by KDE",
     "homepage": "https://apps.kde.org/marknote/",
     "license": "GPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-489-windows-cl-msvc2022-x86_64.7z",
-            "hash": "a232d93da576995d8f157d6330658712c3c6ff9286ea77016d705e46589cf30b"
+            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-495-windows-cl-msvc2022-x86_64.7z",
+            "hash": "25b755456d85041a10f11f55d827a83b0f64783a1cfff7be94cb774a20d1d798"
         }
     },
     "bin": "bin\\marknote.exe",

--- a/bucket/marknote-nightly.json
+++ b/bucket/marknote-nightly.json
@@ -1,0 +1,33 @@
+{
+    "version": "489",
+    "description": "A simple markdown note-taking app developed by KDE",
+    "homepage": "https://apps.kde.org/marknote/",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-489-windows-cl-msvc2022-x86_64.7z",
+            "hash": "a232d93da576995d8f157d6330658712c3c6ff9286ea77016d705e46589cf30b"
+        }
+    },
+    "bin": "bin\\marknote.exe",
+    "shortcuts": [
+        [
+            "bin\\marknote.exe",
+            "Marknote Nightly"
+        ]
+    ],
+    "checkver": {
+        "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/",
+        "regex": "marknote-master-(\\d+)-windows-cl-(?<lib>\\w+)-x86_64\\.7z"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://cdn.kde.org/ci-builds/office/marknote/master/windows/marknote-master-$version-windows-cl-$matchLib-x86_64.7z"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION
Add manifest for nightly builds of Marknote - new WYSIWYG note-taking application from KDE.

Closes #1757

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
