### PR TITLE
greenshot-unstable: Update to version 1.3.277

### DIFF
--- a/bucket/greenshot-unstable.json
+++ b/bucket/greenshot-unstable.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.3.270",
+    "version": "1.3.277",
     "description": "Light-weight screenshot software.",
     "homepage": "https://getgreenshot.org",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.270/Greenshot-INSTALLER-1.3.270-UNSTABLE.exe",
-    "hash": "51a2eadde551927a8d86bbd6100d9304e7f505f70f8b8499b2b7059f757ebbe4",
+    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.277/Greenshot-INSTALLER-1.3.277-UNSTABLE.exe",
+    "hash": "b1a6982940802c911ab2969c41c19808adc1e7a8c0d444507c868d5f55a0adf5",
     "innosetup": true,
     "pre_install": "if (!(Test-Path \"$persist_dir\\greenshot.ini\")) { New-Item -ItemType File \"$dir\\greenshot.ini\" | Out-Null }",
     "bin": "Greenshot.exe",
@@ -16,7 +16,7 @@
     ],
     "persist": "greenshot.ini",
     "checkver": {
-        "url": "https://github.com/greenshot/greenshot/releases",
+        "url": "https://api.github.com/repositories/36756917/releases",
         "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE"
     },
     "autoupdate": {


### PR DESCRIPTION
- Update to the latest version.
- Fix `checkver`.

Closes #1590
Closes #1286 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
