### PR TITLE
zed-nightly: add 20240721

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -2,7 +2,7 @@
   "version": "20240721",
   "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
   "homepage": "https://zed.dev/",
-  "license": ["AGPL-3.0", "Apache-2.0", "GPL-3.0"],
+  "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
   "architecture": {
     "64bit": {
       "url": "https://github.com/deevus/zed-windows-builds/releases/download/20240721/zed-windows.zip",

--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -1,0 +1,21 @@
+{
+  "version": "20240721",
+  "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
+  "homepage": "https://zed.dev/",
+  "license": ["AGPL-3.0", "Apache-2.0", "GPL-3.0"],
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/deevus/zed-windows-builds/releases/download/20240721/zed-windows.zip",
+      "hash": "3a7e699a93c964d6caafb50220f1a310ccbbb00746fe50c97651e9b3b80a2beb"
+    }
+  },
+  "extract_dir": "zed-release",
+  "bin": "zed.exe",
+  "shortcuts": [["zed.exe", "Zed"]],
+  "checkver": {
+    "github": "https://github.com/deevus/zed-windows-builds"
+  },
+  "autoupdate": {
+    "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed-windows.zip"
+  }
+}


### PR DESCRIPTION
Adds [Zed](https://zed.dev/) nightly build for Windows. 

There is no official Windows build yet, but it is very usable. So I created a nightly build here: https://github.com/deevus/zed-windows-builds