### PR TITLE
steam@nightly: fix steam uninstall failed use `pre_uninstall`

### DIFF
--- a/bucket/steam.json
+++ b/bucket/steam.json
@@ -9,6 +9,9 @@
     "notes": "Changing Steam library folder is HIGHLY recommended.",
     "url": "https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe#/dl.7z",
     "pre_install": "Remove-Item \"$dir\\`$PLUGINSDIR\" -Force -Recurse",
+    "pre_uninstall": [
+        "if (!(is_admin)) { error 'Admin rights are required to uninstall steam'; break }"
+    ],
     "uninstaller": {
         "file": "uninstall.exe",
         "args": "/S"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
to fix #1905, add pre_uninstall for steam.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1905
<!-- or -->
Relates to #1905

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
