### PR TITLE
v2rayn-pre: Fix installation scripts

### DIFF
--- a/bucket/v2rayn-pre.json
+++ b/bucket/v2rayn-pre.json
@@ -24,6 +24,7 @@
     },
     "extract_dir": "v2rayN",
     "pre_install": [
+        "if (!(Test-Path \"$dir\\bin\\Xray\")) { New-Item \"$dir\\bin\\Xray\" -ItemType Directory | Out-Null }",
         "foreach ($form in @('*.exe', '*.dat')) {",
         "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
         "        $name = $_.Name",
@@ -42,13 +43,6 @@
         ]
     ],
     "persist": "guiConfigs",
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$dir\\guiConfigs\\config.json\") {",
-            "    Copy-Item \"$dir\\guiConfigs\\config.json\" \"$persist_dir\\guiConfigs\\config.json\" | Out-Null",
-            "}"
-        ]
-    },
     "checkver": {
         "url": "https://api.github.com/repositories/199570071/releases",
         "regex": "download/([\\d.]+)/"


### PR DESCRIPTION
Closes #1936

Removing the uninstallation script like https://github.com/ScoopInstaller/Extras/pull/12503

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
