### PR TITLE
zen-browser-avx2: add version 1.0.0-a.39

### DIFF
--- a/bucket/zen-browser-avx2.json
+++ b/bucket/zen-browser-avx2.json
@@ -1,0 +1,58 @@
+{
+    "version": "1.0.0-a.39",
+    "description": "An open-source, privacy-focused web browser with a focus on speed and user experience.",
+    "homepage": "https://zen-browser.app",
+    "license": "MPL-2.0",
+    "notes": [
+        "To set profile 'Scoop' as *DEFAULT*, or profiles/settings was lost after update:",
+        "  - Run 'Zen Profile Manager', choose 'Scoop' then click 'Start Zen Browser'.",
+        "  - Visit 'about:profiles' page in Zen Browser to check *DEFAULT* profile.",
+        "For details: https://support.mozilla.org/en-US/kb/profile-manager-create-remove-switch-firefox-profiles"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zen-browser/desktop/releases/download/1.0.0-a.39/zen.win-specific.zip",
+            "hash": "0DC5AF0371DAE27EBA5C0E0C6DDF7B465F11F2640B64CF10449B5807CAB60BDF"
+        }
+    },
+    "extract_dir": "zen",
+    "post_install": [
+        "zen -CreateProfile \"Scoop $persist_dir\\profile\"",
+        "$Addition = \"$persist_dir\\addition\"",
+        "if (Test-Path $Addition) {",
+        "  info 'Copying additional items...'",
+        "  Copy-Item -Path $Addition\\* -Destination $dir -Force -Recurse -ErrorAction SilentlyContinue",
+        "}"
+    ],
+    "bin": "zen.exe",
+    "shortcuts": [
+        [
+            "zen.exe",
+            "Zen Browser"
+        ],
+        [
+            "zen.exe",
+            "Zen Browser Profile Manager",
+            "-P"
+        ],
+        [
+            "private_browsing.exe",
+            "Zen Browser Private Browsing"
+        ]
+    ],
+    "persist": [
+        "distribution",
+        "profile"
+    ],
+    "checkver": {
+        "github": "https://github.com/zen-browser/desktop",
+        "regex": "/releases/tag/(?:v|V)?([\\d.]+(-a[\\d.]+)?)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zen-browser/desktop/releases/download/$version/zen.win-specific.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the Zen Browser version optimized for x86_64-v3 cpus.
[Zen Browser](https://zen-browser.app/) is an open-source, privacy-focused web browser with a focus on speed and user experience.

There are two Zen windows builds: [a generic one and one optimized for x86-64-v3](https://docs.zen-browser.app/guides/generic-optimized). 
The optimized version leverages AVX2 and should provide a nice speedup for compatibile cpus.

This is based on [this PR on the Extras bucket](https://github.com/ScoopInstaller/Extras/pull/13941), which only provides the generic build.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).