### PR TITLE
Persist the settings of PEView for System Informer

### DIFF
--- a/bucket/systeminformer-nightly.json
+++ b/bucket/systeminformer-nightly.json
@@ -18,7 +18,7 @@
     },
     "pre_install": [
         "ensure \"$persist_dir\" | Out-Null",
-        "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -ErrorAction 'SilentlyContinue' }"
+        "'SystemInformer.exe.settings.xml', 'peview.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$persist_dir\\$_\" \"$dir\\$_\" -ErrorAction 'SilentlyContinue' }"
     ],
     "shortcuts": [
         [
@@ -34,7 +34,7 @@
         "($settingsXml.settings.ChildNodes | Where-Object { $_.name.Contains(\"IconGuids\") }) | ForEach-Object { [void]$_.ParentNode.RemoveChild($_) }",
         "$settingsXml.Save($settings)"
     ],
-    "pre_uninstall": "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -ErrorAction 'SilentlyContinue' }",
+    "pre_uninstall": "'SystemInformer.exe.settings.xml', 'peview.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -ErrorAction 'SilentlyContinue' }",
     "checkver": {
         "url": "https://systeminformer.sourceforge.io/canary",
         "regex": "systeminformer-([\\d.]+)"


### PR DESCRIPTION
[System Informer](https://systeminformer.sourceforge.io/) has a PE file viewer called `peview.exe`, which follows the same portable mechanism as the main executable, by loading the `<executable_name>.settings.xml` file. Current manifest misses this, causing it to persist in user's `%APPDATA%` directory.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
