### PR TITLE
vidcoder-beta: Add version 12.9-beta

### DIFF
--- a/bucket/vidcoder-beta.json
+++ b/bucket/vidcoder-beta.json
@@ -1,13 +1,13 @@
 {
-    "version": "11.7-beta",
+    "version": "12.9-beta",
     "description": "DVD/Blu-ray ripping and video transcoding tool that uses HandBrake as its encoding engine.",
     "homepage": "https://vidcoder.net",
     "license": "GPL-2.0-only",
     "notes": "VidCoder Settings are stored in \"%APPDATA%\\VidCoder\\VidCoder.sqlite\"",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/RandomEngy/VidCoder/releases/download/v11.7-beta/VidCoder-11.7-beta-Portable.exe#/dl.7z",
-            "hash": "bde27286287846bd5a27a50e40371217ef18d4fe5f3f2e7b3ea13ba87bb5f4fb"
+            "url": "https://github.com/RandomEngy/VidCoder/releases/download/v12.9-beta/VidCoder-12.9-beta-Portable.exe#/dl.7z",
+            "hash": "31334e4ec3a799d7d671b3e8b21bc09f156e0d49f2a94ec6251a4ee78102f4a3"
         }
     },
     "bin": [

--- a/bucket/vidcoder-beta.json
+++ b/bucket/vidcoder-beta.json
@@ -1,0 +1,37 @@
+{
+    "version": "11.7-beta",
+    "description": "DVD/Blu-ray ripping and video transcoding tool that uses HandBrake as its encoding engine.",
+    "homepage": "https://vidcoder.net",
+    "license": "GPL-2.0-only",
+    "notes": "VidCoder Settings are stored in \"%APPDATA%\\VidCoder\\VidCoder.sqlite\"",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/RandomEngy/VidCoder/releases/download/v11.7-beta/VidCoder-11.7-beta-Portable.exe#/dl.7z",
+            "hash": "bde27286287846bd5a27a50e40371217ef18d4fe5f3f2e7b3ea13ba87bb5f4fb"
+        }
+    },
+    "bin": [
+        [
+            "VidCoderCLI.exe",
+            "VidCoderCLI-Beta"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "VidCoder.exe",
+            "VidCoder Beta"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/RandomEngy/VidCoder/releases",
+        "jsonpath": "$[?(@.target_commitish == 'beta')].tag_name",
+        "regex": "v([\\d.]+-beta)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/RandomEngy/VidCoder/releases/download/v$version/VidCoder-$version-Portable.exe#/dl.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #1283


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added VidCoder Beta package (v12.9-beta) to the bucket.
  * Provides 64-bit portable build with verified download and hash.
  * Includes CLI mapping for easy command-line use and a desktop/start menu shortcut labeled “VidCoder Beta.”
  * Supports automatic version checks and updates for future beta releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->