### PR TITLE
nodejs-nightly: Deprecate 32bit & Update to version 24.0.0-nightly202410199f5000e0f2

### DIFF
--- a/bucket/nodejs-nightly.json
+++ b/bucket/nodejs-nightly.json
@@ -1,23 +1,18 @@
 {
-    "version": "23.0.0-nightly20240529c0c598d753",
+    "version": "24.0.0-nightly202410199f5000e0f2",
     "description": "An asynchronous event driven JavaScript runtime designed to build scalable network applications. (nightly verison)",
     "homepage": "https://nodejs.org",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nodejs.org/download/nightly/v23.0.0-nightly20240529c0c598d753/node-v23.0.0-nightly20240529c0c598d753-win-x64.7z",
-            "hash": "41ff011765e0d20fe70c6240e9715b09d5439954dc19f73ba4fd9cd5924c865f",
-            "extract_dir": "node-v23.0.0-nightly20240529c0c598d753-win-x64"
-        },
-        "32bit": {
-            "url": "https://nodejs.org/download/nightly/v23.0.0-nightly20240529c0c598d753/node-v23.0.0-nightly20240529c0c598d753-win-x86.7z",
-            "hash": "9b8440d721a98533cbdbbf5fc92c2bc184bbd316ca54076d22834d694734615c",
-            "extract_dir": "node-v23.0.0-nightly20240529c0c598d753-win-x86"
+            "url": "https://nodejs.org/download/nightly/v24.0.0-nightly202410199f5000e0f2/node-v24.0.0-nightly202410199f5000e0f2-win-x64.7z",
+            "hash": "9c6bbb7bec8e2c5bfaf27eb7477ea3f1b11f11bc41fef61662b1acf2cf624572",
+            "extract_dir": "node-v24.0.0-nightly202410199f5000e0f2-win-x64"
         },
         "arm64": {
-            "url": "https://nodejs.org/download/nightly/v23.0.0-nightly20240529c0c598d753/node-v23.0.0-nightly20240529c0c598d753-win-arm64.7z",
-            "hash": "4758608c52d3a7d93c07913c95109b5e8c657d378f249c59d58d0b5b9b60993d",
-            "extract_dir": "node-v23.0.0-nightly20240529c0c598d753-win-arm64"
+            "url": "https://nodejs.org/download/nightly/v24.0.0-nightly202410199f5000e0f2/node-v24.0.0-nightly202410199f5000e0f2-win-arm64.7z",
+            "hash": "7b589be1f4436fe8e883e68f594ef5a44d38a98275781497fb4fbbc4ffb472c7",
+            "extract_dir": "node-v24.0.0-nightly202410199f5000e0f2-win-arm64"
         }
     },
     "persist": [
@@ -42,10 +37,6 @@
             "64bit": {
                 "url": "https://nodejs.org/download/nightly/v$version/node-v$version-win-x64.7z",
                 "extract_dir": "node-v$version-win-x64"
-            },
-            "32bit": {
-                "url": "https://nodejs.org/download/nightly/v$version/node-v$version-win-x86.7z",
-                "extract_dir": "node-v$version-win-x86"
             },
             "arm64": {
                 "url": "https://nodejs.org/download/nightly/v$version/node-v$version-win-arm64.7z",


### PR DESCRIPTION
Relates to https://github.com/ScoopInstaller/Main/pull/6264

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).