### PR TITLE
Persiste the `portable` sub-folder to make the installation portable

### DIFF
--- a/bucket/arduino18.json
+++ b/bucket/arduino18.json
@@ -21,6 +21,9 @@
             "Arduino Debug 1.8"
         ]
     ],
+    "persist": [
+        "portable"
+    ],
     "checkver": {
         "url": "https://www.arduino.cc/wiki/page-data/en/software/page-data.json",
         "regex": "arduino-(1.8.\\d+)"


### PR DESCRIPTION
Persiste the `portable` sub-folder to make the installation portable.
All user data will be automatically stored inside the new folder.

- [ x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
