### PR TITLE
odin@2024-12: Add extract_dir property to odin and odin-dev

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,6 +9,7 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
+    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",

--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -9,7 +9,7 @@
             "hash": "c2bb7483b319375971f4718069a3e81dd2f7d9f7c6eaeb49b8c4eecad119f445"
         }
     },
-    "extract_dir": "windows_artifacts",
+    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,6 +10,7 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
+    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",


### PR DESCRIPTION
Closes #1778

Odin releases currently have a structure of:
```
odin-windows-amd64-dev-2024-12.zip
| - dist.zip
    | - dist
        | LICENSE
        | base
        | core
        | examples
        | LLVM-C.dll
        | odin.exe
        | shared
        | vendor
```
Adding the `extract_dir` property with a value of `dist` allows Odin to be installed properly.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
