### PR TITLE
Odin@2024-12: Fix installation failing

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,7 +9,8 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
-    "bin": "dist/odin.exe",
+    "extract_dir": "dist",
+    "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
         "regex": "/releases/tag/dev-([\\d-]+)"

--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,7 +9,7 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
-    "bin": "odin.exe",
+    "bin": "dist/odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
         "regex": "/releases/tag/dev-([\\d-]+)"

--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -9,7 +9,8 @@
             "hash": "141a3d47b0d5b763586372001b25e4c79542c4c01083b5391da40d88dca4c5ca"
         }
     },
-    "extract_dir": "windows_artifacts",
+    "extract_dir": "dist",
+    "bin": "odin.exe",
     "bin": "dist/odin.exe",
     "checkver": {
         "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",

--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -10,7 +10,7 @@
         }
     },
     "extract_dir": "windows_artifacts",
-    "bin": "odin.exe",
+    "bin": "dist/odin.exe",
     "checkver": {
         "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",
         "regex": "nightly%2B([\\d\\-]+).zip",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,7 +10,8 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
-    "bin": "dist/odin.exe",
+    "extract_dir": "dist",
+    "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
         "regex": "/releases/tag/dev-([\\d-]+)"

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,7 +10,7 @@
             "hash": "86130c73faaaad3838fef68988e54ea8fc6cdd0f7927261011b14eee9fb9d85a"
         }
     },
-    "bin": "odin.exe",
+    "bin": "dist/odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
         "regex": "/releases/tag/dev-([\\d-]+)"


### PR DESCRIPTION
# Odin installation fails

```console
PS D:\git\Versions> scoop install odin
Installing 'odin' (2024-12) [64bit] from 'versions' bucket
Loading odin-windows-amd64-dev-2024-12.zip from cache
Checking hash of odin-windows-amd64-dev-2024-12.zip ... ok.
Extracting odin-windows-amd64-dev-2024-12.zip ... done.
Linking D:\Programs\scoop\apps\odin\current => D:\Programs\scoop\apps\odin\2024-12
Creating shim for 'odin'.
Get-Command : The term 'odin.exe' is not recognized as the name of a cmdlet,
function, script file, or operable program. Check the spelling of the name,
or if a path was included, verify that the path is correct and try again.
At D:\Programs\scoop\apps\scoop\current\lib\install.ps1:757 char:21
+             $bin = (Get-Command $target).Source
+                     ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (odin.exe:String) [Get-Command
   ], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException,Microsoft.PowerShell.
   Commands.GetCommandCommand

Can't shim 'odin.exe': File doesn't exist.
```

I updated `bin` path in manifest to include extra `dist` directory, since it was not matching with the directory structure inside package zip. which causes above error.

Same issue was occuring for `odin-dev 2024-12` and `odin-nightly 2024-12` updated them as well!

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
