### PR TITLE
beyondcompare4: Add manifest, version 4.4.7.28397

### DIFF
--- a/bucket/beyondcompare4.json
+++ b/bucket/beyondcompare4.json
@@ -1,0 +1,67 @@
+{
+    "version": "4.4.7.28397",
+    "description": "Directory and file compare functions in one package",
+    "homepage": "https://www.scootersoftware.com",
+    "license": {
+        "identifier": "Shareware",
+        "url": "https://www.scootersoftware.com/index.php?zz=kb_licensev4"
+    },
+    "notes": [
+        "Add Beyond Compare as a context menu option by running: '$dir\\install-context.reg'",
+        "When migrated from 'extras/beyondcompare', persistence data required a manual migration:",
+        "i.e. Rename '~\\persist\\beyondcompare' to '~\\persist\\beyondcompare4', then (re)install the manifest."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://www.scootersoftware.com/files/BCompare-4.4.7.28397_x64.msi",
+            "hash": "089b8acbe228e876f4847132ec71fe256b134703e2e6205619b28905cb69f881"
+        },
+        "32bit": {
+            "url": "https://www.scootersoftware.com/files/BCompare-4.4.7.28397_x86.msi",
+            "hash": "7d722749e18309212f7d483b80e992b1c0f35dc437b93be6133cfe6b03574307"
+        }
+    },
+    "extract_dir": "Beyond Compare 4",
+    "bin": [
+        "Bcomp.exe",
+        "BCompare.exe"
+    ],
+    "shortcuts": [
+        [
+            "BCompare.exe",
+            "Beyond Compare 4"
+        ],
+        [
+            "BCClipboard.exe",
+            "Clipboard Compare"
+        ]
+    ],
+    "post_install": [
+        "$dir_escaped = \"$dir\".Replace('\\', '\\\\')",
+        "\"install-context-$architecture\", \"uninstall-context\" | ForEach-Object {",
+        "  if (Test-Path \"$bucketsdir\\$bucket\\scripts\\beyondcompare4\\$_.reg\") {",
+        "    $content = Get-Content \"$bucketsdir\\$bucket\\scripts\\beyondcompare4\\$_.reg\"",
+        "    $content = $content.Replace('$install_dir', $dir_escaped)",
+        "    if ($global) {",
+        "      $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    $outfile_no_arch = $_.Replace(\"-$architecture\", \"\")",
+        "    $content | Set-Content -Path \"$dir\\$outfile_no_arch.reg\"",
+        "  }",
+        "}"
+    ],
+    "checkver": {
+        "url": "https://www.scootersoftware.com/kb/dl4_winalternate",
+        "regex": "BCompare-([\\d.]+)_x64\\.msi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.scootersoftware.com/files/BCompare-$version_x64.msi"
+            },
+            "32bit": {
+                "url": "https://www.scootersoftware.com/files/BCompare-$version_x86.msi"
+            }
+        }
+    }
+}

--- a/scripts/beyondcompare4/install-context-32bit.reg
+++ b/scripts/beyondcompare4/install-context-32bit.reg
@@ -1,0 +1,23 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare4/install-context-64bit.reg
+++ b/scripts/beyondcompare4/install-context-64bit.reg
@@ -1,0 +1,30 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx64.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+@="CirrusShellEx"
+
+[HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}\InProcServer32]
+@="$install_dir\\BCShellEx.dll"
+"ThreadingModel"="Apartment"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+@="{57FA2D12-D22D-490A-805A-5CB48E84F12A}"
+
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"="Beyond Compare 4 Shell Extension"

--- a/scripts/beyondcompare4/uninstall-context.reg
+++ b/scripts/beyondcompare4/uninstall-context.reg
@@ -1,0 +1,12 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+[-HKEY_CURRENT_USER\Software\Wow6432Node\Classes\CLSID\{57FA2D12-D22D-490A-805A-5CB48E84F12A}]
+
+[-HKEY_CURRENT_USER\Software\Classes\*\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Directory\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\Folder\shellex\ContextMenuHandlers\CirrusShellEx]
+[-HKEY_CURRENT_USER\Software\Classes\lnkfile\shellex\ContextMenuHandlers\CirrusShellEx]
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Shell Extensions\Approved]
+"{57FA2D12-D22D-490A-805A-5CB48E84F12A}"=-


### PR DESCRIPTION
-'move' beyondcompare v4 manifest from bucket 'extras' to bucket 'version'

  - give leeway for Beyond Compare v5 in 'extras'
  - see discussion https://github.com/ScoopInstaller/Extras/pull/14026#issuecomment-2575140902
  - see discussion https://github.com/ScoopInstaller/Extras/pull/14026#issuecomment-2575237952
  - see discussion https://github.com/ScoopInstaller/Extras/pull/14026#issuecomment-2576357032

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Relates to https://github.com/ScoopInstaller/Extras/issues/13663

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

FYI @HUMORCE