### PR TITLE
Remove extract_dir from odin, odin-dev, and odin-nightly

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -9,7 +9,6 @@
             "hash": "4df923dd90a5f2ef45ff586b038503e9d2a0fa0abe6d292674158c5a3153eab1"
         }
     },
-    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",

--- a/bucket/odin-nightly.json
+++ b/bucket/odin-nightly.json
@@ -9,7 +9,6 @@
             "hash": "f1fd009ec73eb9c878a0e282a9a59f0f15945642e424783544d2fcd56a61322a"
         }
     },
-    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://odinbinaries.thisdrunkdane.io/file/odin-binaries/nightly.json",

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,7 +10,6 @@
             "hash": "4df923dd90a5f2ef45ff586b038503e9d2a0fa0abe6d292674158c5a3153eab1"
         }
     },
-    "extract_dir": "dist",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",


### PR DESCRIPTION
Latest release no longer nests its contents inside the `dist` directory. Can remove the `extract_dir` until the next time they change the release structure.

Closes #2107

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
