### PR TITLE
Fix odin

### DIFF
--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -10,7 +10,7 @@
             "hash": "4df923dd90a5f2ef45ff586b038503e9d2a0fa0abe6d292674158c5a3153eab1"
         }
     },
-    "extract_dir": "dist",
+    "extract_dir": "",
     "bin": "odin.exe",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",


### PR DESCRIPTION
The odin release package structure seems to have changed; `odin.exe` is now in the root instead of `dist`, at least on windows. I've updated this to reflect that.