### PR TITLE
RunHiddenConsole: Add version 1.0.2

### DIFF
--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -10,17 +10,21 @@
   "architecture": {
       "64bit": {
           "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x64-v1.0.2.zip",
-          "hash": "e865ff311abeb5e933a52a7265dcbc9baa8aede295494b4297fdaaa3ec7d3bd3"
+          "hash": "23e76d8d64af132bc239e778f30b0f12af7aae31e9f51a4c6338ede6175ceb95"
       },
       "32bit": {
           "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x86-v1.0.2.zip",
-          "hash": "697617948b1c82efada09df6a77b73be4bd3c8052c6e6cf2fc8281cb180feff9"
+          "hash": "b1ccd9345c3d182e2277ae4b3f6826bd624884e0d41e0b8acc8fd8b1c6741c9d"
       }
   },
   "bin": [
       "RunHiddenConsole.exe"
   ],
   "checkver": "github",
+  "checkver": {
+    "url": "https://github.com/rise-worlds/RunHiddenConsole/releases",
+    "regex": "assets/v([\\d\\.\\-]+)"
+  },
   "autoupdate": {
     "architecture": {
       "64bit": {
@@ -31,12 +35,7 @@
       }
     },
     "hash": {
-      "64bit": {
-        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x64-$version.hashes.txt"
-      },
-      "32bit": {
-        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x86-v$version.hashes.txt"
-      }
+      "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/hashes.txt"
     }
   }
 }

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -19,5 +19,6 @@
   },
   "bin": [
       "RunHiddenConsole.exe"
-  ]
+  ],
+  "checkver": "github"
 }

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -1,5 +1,5 @@
 {
-  "version": "v1.0.2",
+  "version": "1.0.2",
   "description": "Hide console window for windows programs",
   "notes": "This is a simple utility to hide the console window for windows programs. It is useful for running programs in the background without the console window showing up.",
   "homepage": "https://github.com/rise-worlds/RunHiddenConsole",
@@ -24,12 +24,18 @@
   "autoupdate": {
     "architecture": {
       "64bit": {
-        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x64-$version.zip",
-        "hash": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x64-$version.hashes.txt"
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x64-v$version.zip",
       },
       "32bit": {
-        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x86-$version.zip",
-        "hash": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x86-$version.hashes.txt"
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x86-v$version.zip",
+      }
+    },
+    "hash": {
+      "64bit": {
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x64-$version.hashes.txt"
+      },
+      "32bit": {
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v$version/RunHiddenConsole-x86-v$version.hashes.txt"
       }
     }
   }

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -9,11 +9,11 @@
   },
   "architecture": {
       "64bit": {
-          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.1/RunHiddenConsole-x64-v1.0.2.zip",
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x64-v1.0.2.zip",
           "hash": "e865ff311abeb5e933a52a7265dcbc9baa8aede295494b4297fdaaa3ec7d3bd3"
       },
       "32bit": {
-          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.1/RunHiddenConsole-x86-v1.0.2.zip",
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.2/RunHiddenConsole-x86-v1.0.2.zip",
           "hash": "697617948b1c82efada09df6a77b73be4bd3c8052c6e6cf2fc8281cb180feff9"
       }
   },

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -4,28 +4,20 @@
   "notes": "This is a simple utility to hide the console window for windows programs. It is useful for running programs in the background without the console window showing up.",
   "homepage": "https://github.com/rise-worlds/RunHiddenConsole",
   "license": "MIT",
+  "suggest": {
+      "vcredist": "extras/vcredist2022"
+  },
   "architecture": {
       "64bit": {
-          "url": [
-              "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x64-v1.0.zip"
-          ],
-          "hash": [
-              "9e8f50fb6de48600b30bead92cbd048e8df5496dea242e3856e5ec442deb1dbe"
-          ]
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x64-v1.0.zip",
+          "hash": "9e8f50fb6de48600b30bead92cbd048e8df5496dea242e3856e5ec442deb1dbe"
       },
       "32bit": {
-          "url": [
-              "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x86-v1.0.zip"
-          ],
-          "hash": [
-              "7de627baf15043e64fd91ca7aa4b8bb221089edbe153d0019eda56e1ab68a43b"
-          ]
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x86-v1.0.zip",
+          "hash": "7de627baf15043e64fd91ca7aa4b8bb221089edbe153d0019eda56e1ab68a43b"
       }
   },
   "bin": [
-      [
-          "RunHiddenConsole.exe",
-          "RunHiddenConsole"
-      ]
+      "RunHiddenConsole.exe"
   ]
 }

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -20,7 +20,6 @@
   "bin": [
       "RunHiddenConsole.exe"
   ],
-  "checkver": "github",
   "checkver": {
     "url": "https://github.com/rise-worlds/RunHiddenConsole/releases",
     "regex": "assets/v([\\d\\.\\-]+)"

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "v1.0.2",
   "description": "Hide console window for windows programs",
   "notes": "This is a simple utility to hide the console window for windows programs. It is useful for running programs in the background without the console window showing up.",
   "homepage": "https://github.com/rise-worlds/RunHiddenConsole",
@@ -9,16 +9,28 @@
   },
   "architecture": {
       "64bit": {
-          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x64-v1.0.zip",
-          "hash": "9e8f50fb6de48600b30bead92cbd048e8df5496dea242e3856e5ec442deb1dbe"
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.1/RunHiddenConsole-x64-v1.0.2.zip",
+          "hash": "e865ff311abeb5e933a52a7265dcbc9baa8aede295494b4297fdaaa3ec7d3bd3"
       },
       "32bit": {
-          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x86-v1.0.zip",
-          "hash": "7de627baf15043e64fd91ca7aa4b8bb221089edbe153d0019eda56e1ab68a43b"
+          "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0.1/RunHiddenConsole-x86-v1.0.2.zip",
+          "hash": "697617948b1c82efada09df6a77b73be4bd3c8052c6e6cf2fc8281cb180feff9"
       }
   },
   "bin": [
       "RunHiddenConsole.exe"
   ],
-  "checkver": "github"
+  "checkver": "github",
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x64-$version.zip",
+        "hash": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x64-$version.hashes.txt"
+      },
+      "32bit": {
+        "url": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x86-$version.zip",
+        "hash": "https://github.com/rise-worlds/RunHiddenConsole/releases/download/$version/RunHiddenConsole-x86-$version.hashes.txt"
+      }
+    }
+  }
 }

--- a/bucket/run-hidden-console.json
+++ b/bucket/run-hidden-console.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.0",
+  "description": "Hide console window for windows programs",
+  "notes": "This is a simple utility to hide the console window for windows programs. It is useful for running programs in the background without the console window showing up.",
+  "homepage": "https://github.com/rise-worlds/RunHiddenConsole",
+  "license": "MIT",
+  "architecture": {
+      "64bit": {
+          "url": [
+              "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x64-v1.0.zip"
+          ],
+          "hash": [
+              "9e8f50fb6de48600b30bead92cbd048e8df5496dea242e3856e5ec442deb1dbe"
+          ]
+      },
+      "32bit": {
+          "url": [
+              "https://github.com/rise-worlds/RunHiddenConsole/releases/download/v1.0/RunHiddenConsole-x86-v1.0.zip"
+          ],
+          "hash": [
+              "7de627baf15043e64fd91ca7aa4b8bb221089edbe153d0019eda56e1ab68a43b"
+          ]
+      }
+  },
+  "bin": [
+      [
+          "RunHiddenConsole.exe",
+          "RunHiddenConsole"
+      ]
+  ]
+}


### PR DESCRIPTION
add RunHiddenConsole tool, version 1.0.2

`RunHiddenConsole` is a lite program for hiding console window, it running on windows, like a linux command line end with '&', Let the program run behind without bloking console.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
