### PR TITLE
sqlitebrowser-nightly: Use github releases and update to 20250118 (#2145)

### DIFF
--- a/bucket/sqlitebrowser-nightly.json
+++ b/bucket/sqlitebrowser-nightly.json
@@ -1,16 +1,16 @@
 {
-    "version": "2024-12-23",
+    "version": "20250118",
     "description": "DB Browser for SQLite (DB4S) project (nightly build)",
     "homepage": "https://github.com/sqlitebrowser/sqlitebrowser",
     "license": "MPL-2.0|GPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://nightlies.sqlitebrowser.org/win64/DB.Browser.for.SQLite-2024-12-23-win64.zip",
-            "hash": "5d943e856b137c699e1f8b8bad923dec50413d9755b37feab1a078fd97396303"
+            "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/nightly/DB.Browser.for.SQLite-20250118-x64.zip",
+            "hash": "88e8c628d415e5ea06aa5a4f2f16bb83bbff93aa2b49f2f7c711bfb7660bd93f"
         },
         "32bit": {
-            "url": "https://nightlies.sqlitebrowser.org/win32/DB.Browser.for.SQLite-2024-12-23-win32.zip",
-            "hash": "c1848c4dba7d569df6170017cb36a2c75c7508093a0dfcb0315122482bbcf11c"
+            "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/nightly/DB.Browser.for.SQLite-20250118-x86.zip",
+            "hash": "faa5b0ee742de23affc20aa80af4ed5a8cf33295d943394b836ebc8ce3c1cdcb"
         }
     },
     "bin": [
@@ -29,17 +29,18 @@
     ],
     "persist": "Data",
     "checkver": {
-        "url": "https://nightlies.sqlitebrowser.org/win64/",
-        "regex": "SQLite-(\\d{4}-\\d{2}-\\d{2})-win64\\.",
+        "url": "https://api.github.com/repos/sqlitebrowser/sqlitebrowser/releases/tags/nightly",
+        "jsonpath": "$.assets..browser_download_url",
+        "regex": "SQLite-(?<version>\\d{8})-x64\\.",
         "reverse": true
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://nightlies.sqlitebrowser.org/win64/DB.Browser.for.SQLite-$version-win64.zip"
+                "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/nightly/DB.Browser.for.SQLite-$matchVersion-x64.zip"
             },
             "32bit": {
-                "url": "https://nightlies.sqlitebrowser.org/win32/DB.Browser.for.SQLite-$version-win32.zip"
+                "url": "https://github.com/sqlitebrowser/sqlitebrowser/releases/download/nightly/DB.Browser.for.SQLite-$matchVersion-x86.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2145

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Use nightly tag instead of the nightly server, which now includes a partial date version as a segment in the url. Also, the server's stable [latest link](https://nightlies.sqlitebrowser.org/latest/DB.Browser.for.SQLite-win64.zip) hasn't been updated since last December (2023-12-23).

Nightly server old format:
```
version: $year-$month-$day
url: https://nightlies.sqlitebrowser.org/win64/DB.Browser.for.SQLite-$year-$month-$day-win64.zip
```

Nightly server new format:
```
version: $year-$month-$day
url: https://nightlies.sqlitebrowser.org/win64/$year-$month/DB.Browser.for.SQLite-$year-$month-$day-win64.zip
```