### PR TITLE
Fix shim for dbeaver-cli

### DIFF
--- a/bucket/dbeaver-ea.json
+++ b/bucket/dbeaver-ea.json
@@ -19,12 +19,8 @@
     "extract_dir": "dbeaver",
     "bin": [
         [
-            "dbeaver.exe",
-            "dbeaver-cli.exe"
-        ],
-        [
-            "dbeaver-ea.exe",
-            "dbeaver-cli.exe"
+            "dbeaver-cli.exe",
+            "dbeaver-ea-cli"
         ]
     ],
     "shortcuts": [


### PR DESCRIPTION
Installation script was failing because the shim to `dbeaver-cli.exe` wasn't configured correctly. I also changed its alias to `dbeaver-ea-cli` to avoid conflict with `dbeaver-cli` shim from the non-EA version in the `extras` repo.

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
