### PR TITLE
vlc-nightly: remove win32 build

### DIFF
--- a/bucket/vlc-nightly.json
+++ b/bucket/vlc-nightly.json
@@ -1,19 +1,19 @@
 {
-    "version": "20240927",
+    "version": "20250309",
     "description": "A free and open source multimedia player and framework that plays most multimedia files as well as DVDs, Audio CDs, VCDs, and various streaming protocols.",
     "homepage": "https://www.videolan.org/",
     "license": "GPL-2.0-only",
     "architecture": {
         "64bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64/20240927-0425/vlc-4.0.0-dev-win64-78ae78c0.7z",
-            "hash": "sha512:61d4b09da5caa1798448761c8da0d65a4fcb60b0f6bae60ea6fcf9638ca606c261a2fc916245e33d6fec76ab1d288e1eb28703702528930d0dbf4640ad0070fc"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64/20250309-0427/vlc-4.0.0-dev-win64-dd4bc208.7z",
+            "hash": "sha512:d2f5d55a852022a1c3471a371f18ca8f35696bf7fe2f7de9ef87e0ce1d00e6a028c910a0ea4eafb72d8e68d700ed76648bfe82bc1794c021671be983ae8d7220"
         },
         "arm64": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win64-arm-llvm/20240927-0426/vlc-4.0.0-dev-win64-78ae78c0.7z",
-            "hash": "sha512:5b23b3ed11a0096767bac5796467007e3d01677ba774876254e81fc2234edf3afc7ca1fd179be90cd7d57f823b57c5e9515c646859b1047f74e1f0f33509568d"
+            "url": "https://artifacts.videolan.org/vlc/nightly-win64-arm-llvm/20250309-0429/vlc-4.0.0-dev-win64-dd4bc208.7z",
+            "hash": "sha512:6ebcb19359eaddd77ac38a0c2203bced4eed8905299eacefb77fe245f9d334b970c146e745ffd40076bec428387cfd7b968c59af9a892603bb8bbd3bcff80012"
         }
     },
-    "extract_dir": "vlc-4.0.0-dev",
+    "extract_dir": "$matchFolderversion",
     "pre_install": [
         "if (!(Test-Path \"$persist_dir\\portable\") -and (Test-Path \"$env:APPDATA\\vlc\")) {",
         "    info \"Copying old '$env:APPDATA\\vlc' to '$persist_dir\\portable'\"",

--- a/bucket/vlc-nightly.json
+++ b/bucket/vlc-nightly.json
@@ -8,10 +8,6 @@
             "url": "https://artifacts.videolan.org/vlc/nightly-win64/20240927-0425/vlc-4.0.0-dev-win64-78ae78c0.7z",
             "hash": "sha512:61d4b09da5caa1798448761c8da0d65a4fcb60b0f6bae60ea6fcf9638ca606c261a2fc916245e33d6fec76ab1d288e1eb28703702528930d0dbf4640ad0070fc"
         },
-        "32bit": {
-            "url": "https://artifacts.videolan.org/vlc/nightly-win32/20240202-0423/vlc-4.0.0-dev-win32-82f3c433.7z",
-            "hash": "sha512:785af62fd28a9de212735087f75d834a95ad081899b0af7fa567ba164c89f2fa8a2cd7855693f82859eec2d32d945b9cbd9963012799b174679e88579ed620ea"
-        },
         "arm64": {
             "url": "https://artifacts.videolan.org/vlc/nightly-win64-arm-llvm/20240927-0426/vlc-4.0.0-dev-win64-78ae78c0.7z",
             "hash": "sha512:5b23b3ed11a0096767bac5796467007e3d01677ba774876254e81fc2234edf3afc7ca1fd179be90cd7d57f823b57c5e9515c646859b1047f74e1f0f33509568d"
@@ -36,7 +32,7 @@
     "persist": "portable",
     "checkver": {
         "script": [
-            "$builds = 'win32', 'win64', 'win64-arm-llvm'",
+            "$builds = 'win64', 'win64-arm-llvm'",
             "$scriptver = ''",
             "$urls =  @()",
             "foreach ($build in $builds) {",
@@ -50,7 +46,7 @@
             "}",
             "Write-Output ('version:\"' + $scriptver + '\"') ('urls:\"' + $urls + '\"')"
         ],
-        "regex": "version:\"(?<version>\\d+)\"\\surls:\"(?<win32bitver>.+\\/)(?<win32bitfile>(?<folderversion>vlc-[\\d.]+-dev).+)\\s(?<win64bitver>.+\\/)(?<win64bitfile>.+)\\s(?<winarm64ver>.+\\/)(?<winarm64file>.+)\""
+        "regex": "version:\"(?<version>\\d+)\"\\surls:\"(?<win64bitver>.+\\/)(?<win64bitfile>.+)\\s(?<winarm64ver>.+\\/)(?<winarm64file>.+)\""
     },
     "autoupdate": {
         "architecture": {
@@ -58,12 +54,6 @@
                 "url": "https://artifacts.videolan.org/vlc/nightly-win64/$matchWin64bitver$matchWin64bitfile",
                 "hash": {
                     "url": "https://artifacts.videolan.org/vlc/nightly-win64/$matchWin64bitverSHA512SUM"
-                }
-            },
-            "32bit": {
-                "url": "https://artifacts.videolan.org/vlc/nightly-win32/$matchWin32bitver$matchWin32bitfile",
-                "hash": {
-                    "url": "https://artifacts.videolan.org/vlc/nightly-win32/$matchWin32bitverSHA512SUM"
                 }
             },
             "arm64": {


### PR DESCRIPTION
win32 builds have been deprecated since 2024-02-05 https://github.com/videolan/vlc/commit/8c8f3159718a5d79c9157b574618172cb54e4037

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2065

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).