### PR TITLE
zed-opengl-nightly: add 03-11-2025

### DIFF
--- a/bucket/zed-opengl-nightly.json
+++ b/bucket/zed-opengl-nightly.json
@@ -1,0 +1,26 @@
+{
+    "version": "03-11-2025",
+    "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
+    "homepage": "https://zed.dev/",
+    "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/03-11-2025/zed-opengl.exe",
+            "hash": "bfea9bcce7b6479bd884416223868a7a016f6e478327e8a1eaebbfb7c404a9a6"
+        }
+    },
+    "bin": "zed.exe",
+    "shortcuts": [
+        [
+            "zed.exe",
+            "Zed"
+        ]
+    ],
+    "checkver": {
+        "url": "https://github.com/deevus/zed-windows-builds/releases",
+        "regex": "(\\d{2}-\\d{2}-\\d{4})"
+    },
+    "autoupdate": {
+        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed-opengl.exe"
+    }
+}


### PR DESCRIPTION
Adds `zed-opengl-nightly`

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
