### PR TITLE
zls-dev@0.15.0-dev.3+fedbf31: bug fixes and other changes

### DIFF
--- a/bucket/zls-dev.json
+++ b/bucket/zls-dev.json
@@ -22,33 +22,35 @@
         "script": [
             "$zig_version_api = 'https://ziglang.org/download/index.json'",
             "$zig_version_api_response = Invoke-RestMethod -Uri $zig_version_api",
-            "$zig_version = $zig_version_api_response.master.version.replace('+','%2B')",
-            "$zls_version_api = \"https://releases.zigtools.org/v1/zls/select-version?zig_version=$zig_version&compatibility=only-runtime\"",
-            "$zls_version_api_response = Invoke-RestMethod -Uri $zls_version_api",
+            "$zig_version = $zig_version_api_response.master.version",
+            "$zls_version_api = 'https://releases.zigtools.org/v1/zls/select-version'",
+            "$zls_version_api_body = @{ zig_version=$zig_version; compatibility='only-runtime' }",
+            "$zls_version_api_response = Invoke-RestMethod -Uri $zls_version_api -Body $zls_version_api_body",
             "$zls_version_api_response.version + ',' + $zig_version"
         ],
-        "regex": "^(?<version>.*),(?<zig>.*)$"
+        "regex": "^(?<zlsver>.*),(?<zigver>.*)$",
+        "replace": "${zlsver}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://builds.zigtools.org/zls-windows-x86_64-$version.zip",
+                "url": "https://builds.zigtools.org/zls-windows-x86_64-$matchZlsver.zip",
                 "hash": {
-                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZig&compatibility=only-runtime",
+                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZigver&compatibility=only-runtime",
                     "jsonpath": "$.x86_64-windows.shasum"
                 }
             },
             "32bit": {
-                "url": "https://builds.zigtools.org/zls-windows-x86-$version.zip",
+                "url": "https://builds.zigtools.org/zls-windows-x86-$matchZlsver.zip",
                 "hash": {
-                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZig&compatibility=only-runtime",
+                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZigver&compatibility=only-runtime",
                     "jsonpath": "$.x86-windows.shasum"
                 }
             },
             "arm64": {
-                "url": "https://builds.zigtools.org/zls-windows-aarch64-$version.zip",
+                "url": "https://builds.zigtools.org/zls-windows-aarch64-$matchZlsver.zip",
                 "hash": {
-                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZig&compatibility=only-runtime",
+                    "url": "https://releases.zigtools.org/v1/zls/select-version?zig_version=$matchZigver&compatibility=only-runtime",
                     "jsonpath": "$.aarch64-windows.shasum"
                 }
             }


### PR DESCRIPTION
1) used more descriptive match variable names (zlsver and zigver instead of version and zig).

2) refactored checkver script.

4) fixed wrong autoupdate url that used version variable instead of matched
checkver version variable.

5) fixed "bug" where checkver is not explicitly defined which is needed in this case,
because we are packing both zls and zig version in checkver regex,
and checkver needs to replace it with zls version only to compare with the
manifest version,

I think the default for checkver is first matched group anyways,
but it is good to be explicit,

I think the very previous statement is also why zig-dev manifest version is
missing the commit hash in its scoop manifest version string,
I think that needs fixing too.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

cc: @niheaven thanks for help last time 🙏
