### PR TITLE
cherry-studio-pre: add version 1.1.4

### DIFF
--- a/bucket/cherry-studio-pre.json
+++ b/bucket/cherry-studio-pre.json
@@ -1,0 +1,50 @@
+{
+    "version": "1.1.4",
+    "description": "A desktop client that supports for multiple LLM providers (Pre-release).",
+    "homepage": "https://cherry-ai.com",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.1.4/Cherry-Studio-1.1.4-setup.exe#/dl.7z",
+            "hash": "sha512:bb794fb1e678de1a53a799ebb5e7de879ade73b44d8b6be1598ea2c0abf83d30545575d9840d085b7ff0ec935b0e196c5b5e7c74693a9ddc8d0dc7b716e5561b",
+            "pre_install": [
+                "Expand-7zipArchive \"$dir\\`$PLUGINSDIR\\app-64.7z\" \"$dir\"",
+                "Remove-Item \"$dir\\`$*\", \"$dir\\Unintall*\" -Recurse"
+            ]
+        }
+    },
+    "shortcuts": [
+        [
+            "Cherry Studio.exe",
+            "Cherry Studio"
+        ]
+    ],
+    "post_install": [
+        "if (Test-Path \"$persist_dir\\data\\*\") {",
+        "    New-Item \"$Env:AppData\\CherryStudio\" -ItemType Directory -Force | Out-Null",
+        "    Copy-Item \"$persist_dir\\data\\*\" \"$Env:AppData\\CherryStudio\" -Recurse",
+        "}"
+    ],
+    "pre_uninstall": [
+        "if (Test-Path \"$Env:AppData\\CherryStudio\\*\") {",
+        "    Remove-Item \"$persist_dir\\data\" -Recurse -Force",
+        "    Move-Item \"$Env:AppData\\CherryStudio\" \"$persist_dir\\data\" -Force",
+        "}"
+    ],
+    "persist": "data",
+    "checkver": {
+        "url": "https://api.github.com/repos/CherryHQ/cherry-studio/releases",
+        "regex": "download/v([\\d.]+)/"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-setup.exe#/dl.7z",
+                "hash": {
+                    "url": "$baseurl/latest.yml",
+                    "regex": "sha512: $base64"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #2197 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

Simply clone the Extras/cherry-studio manifest and modify the checkver part.