### PR TITLE
aurora-rgb: Add version 350

### DIFF
--- a/bucket/aurora-rgb.json
+++ b/bucket/aurora-rgb.json
@@ -4,10 +4,6 @@
     "homepage": "https://github.com/Aurora-RGB/Aurora",
     "license": "MIT",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v325/Aurora-v325.zip",
-            "hash": "0940176de40746727670c4733684c6a83e1c4516f749150815927723937e0756"
-        },
         "64bit": {
             "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v325/Aurora-v325.zip",
             "hash": "0940176de40746727670c4733684c6a83e1c4516f749150815927723937e0756"
@@ -22,9 +18,6 @@
     "checkver": "github",
     "autoupdate": {
         "architecture": {
-            "32bit": {
-                "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v$version/Aurora-v$version.zip"
-            },
             "64bit": {
                 "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v$version/Aurora-v$version.zip"
             }

--- a/bucket/aurora-rgb.json
+++ b/bucket/aurora-rgb.json
@@ -1,6 +1,6 @@
 {
     "version": "350",
-    "description": "Unified lighting effects across multiple brands and various games.",
+    "description": "A fork of Aurora, providing unified lighting effects across multiple brands and various games",
     "homepage": "https://www.project-aurora.com/",
     "license": "MIT",
     "architecture": {

--- a/bucket/aurora-rgb.json
+++ b/bucket/aurora-rgb.json
@@ -1,0 +1,33 @@
+{
+    "version": "325",
+    "description": "Unified lighting effects across multiple brands and various games.",
+    "homepage": "http://www.project-aurora.com/",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v325/Aurora-v325.zip",
+            "hash": "0940176de40746727670c4733684c6a83e1c4516f749150815927723937e0756"
+        },
+        "64bit": {
+            "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v325/Aurora-v325.zip",
+            "hash": "0940176de40746727670c4733684c6a83e1c4516f749150815927723937e0756"
+        }
+    },
+    "shortcuts": [
+        [
+            "AuroraRgb.exe",
+            "Aurora"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v$version/Aurora-v$version.zip"
+            },
+            "64bit": {
+                "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v$version/Aurora-v$version.zip"
+            }
+        }
+    }
+}

--- a/bucket/aurora-rgb.json
+++ b/bucket/aurora-rgb.json
@@ -1,7 +1,7 @@
 {
     "version": "325",
     "description": "Unified lighting effects across multiple brands and various games.",
-    "homepage": "http://www.project-aurora.com/",
+    "homepage": "https://github.com/Aurora-RGB/Aurora",
     "license": "MIT",
     "architecture": {
         "32bit": {

--- a/bucket/aurora-rgb.json
+++ b/bucket/aurora-rgb.json
@@ -1,12 +1,12 @@
 {
-    "version": "325",
+    "version": "350",
     "description": "Unified lighting effects across multiple brands and various games.",
-    "homepage": "https://github.com/Aurora-RGB/Aurora",
+    "homepage": "https://www.project-aurora.com/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v325/Aurora-v325.zip",
-            "hash": "0940176de40746727670c4733684c6a83e1c4516f749150815927723937e0756"
+            "url": "https://github.com/Aurora-RGB/Aurora/releases/download/v350/Aurora-v350.zip",
+            "hash": "6c8d7f5d562652cfd81ec8464253043628bd24c664771cbea8a446f362280cb8"
         }
     },
     "shortcuts": [
@@ -15,7 +15,9 @@
             "Aurora"
         ]
     ],
-    "checkver": "github",
+    "checkver": {
+        "github": "https://github.com/Aurora-RGB/Aurora"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION
Add version 350

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

- Closes https://github.com/ScoopInstaller/Extras/issues/15191

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Aurora RGB package for easy installation and updates via the package manager.
  * 64-bit support with checksum-verified downloads to ensure download integrity.
  * Automatic release detection from the upstream source for seamless autoupdates.
  * Adds a convenient launcher shortcut for quick startup.
  * Includes clear metadata (version, description, homepage) and an MIT license.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->