### PR TITLE
Update wox-beta to version 2.0.0-beta.2 with new installer script

### DIFF
--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -7,8 +7,12 @@
         "Python3": "python",
         "Everything": "extras/everything"
     },
-    "url": "https://github.com/Wox-launcher/Wox/releases/download/v2.0.0-beta.2/wox-windows-amd64.exe",
-    "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Wox-launcher/Wox/releases/download/v2.0.0-beta.2/wox-windows-amd64.exe",
+            "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043",
+        }
+    },
     "installer": {
         "script": "Rename-Item \"$dir\\wox-windows-amd64.exe\" 'Wox.exe'"
     },
@@ -23,6 +27,10 @@
         "regex": "tree/v([\\d.]+-beta\\.\\d+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/wox-windows-amd64.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/wox-windows-amd64.exe"
+            }
+        }
     }
 }

--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -23,6 +23,6 @@
         "regex": "tree/v([\\d.]+-beta\\.\\d+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/wox-windows-amd64.exe",
+        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/wox-windows-amd64.exe"
     }
 }

--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -10,7 +10,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Wox-launcher/Wox/releases/download/v2.0.0-beta.2/wox-windows-amd64.exe",
-            "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043",
+            "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043"
         }
     },
     "installer": {

--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.4.1196",
+    "version": "2.0.0-beta.2",
     "description": "A full-featured launcher, access programs and web contents as you type.",
     "homepage": "http://www.wox.one",
     "license": "MIT",
@@ -7,10 +7,11 @@
         "Python3": "python",
         "Everything": "extras/everything"
     },
-    "url": "https://github.com/Wox-launcher/Wox/releases/download/v1.4.1196/Wox-1.4.1196-full.nupkg",
-    "hash": "sha1:69fcc97e4b7b2702885463793ad617ed2d0c94b6",
-    "extract_dir": "lib\\net462",
-    "bin": "Wox.exe",
+    "url": "https://github.com/Wox-launcher/Wox/releases/download/v2.0.0-beta.2/wox-windows-amd64.exe",
+    "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043",
+    "installer": {
+	    "script": "Rename-Item \"$dir\\wox-windows-amd64.exe\" 'Wox.exe'"
+	},
     "shortcuts": [
         [
             "Wox.exe",
@@ -19,12 +20,9 @@
     ],
     "checkver": {
         "url": "https://github.com/Wox-launcher/Wox/releases",
-        "regex": "tree/v([\\d.]+)"
+        "regex": "tree/v([\\d.]+-beta\\.\\d+)"
     },
     "autoupdate": {
-        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/Wox-$version-full.nupkg",
-        "hash": {
-            "url": "$baseurl/RELEASES"
-        }
+        "url": "https://github.com/Wox-launcher/Wox/releases/download/v$version/wox-windows-amd64.exe",
     }
 }

--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -10,8 +10,8 @@
     "url": "https://github.com/Wox-launcher/Wox/releases/download/v2.0.0-beta.2/wox-windows-amd64.exe",
     "hash": "2a99e5bca335e96f9361c162db2e6d8beb3ec876e5596c13e2b3112bd79ce043",
     "installer": {
-	    "script": "Rename-Item \"$dir\\wox-windows-amd64.exe\" 'Wox.exe'"
-	},
+        "script": "Rename-Item \"$dir\\wox-windows-amd64.exe\" 'Wox.exe'"
+    },
     "shortcuts": [
         [
             "Wox.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The goal of this PR is to update the Wox package to the [v2.0.0-beta.2](https://github.com/Wox-launcher/Wox/releases/tag/v2.0.0-beta.2) beta.
It seems that the versioning scheme has changed (no idea if it's permanent or temporary for this dev cycle).
Package has been installed successfully via local testing.

If this repo intends to stick to the currently available [v1.4.1196](https://github.com/Wox-launcher/Wox/releases/tag/v1.4.1196) pre-release feel free to close the PR.

Closes NONE
<!-- or -->
Relates to NONE

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
