### PR TITLE
ols-nightly: Add version 20250928-g4a2a71e

### DIFF
--- a/bucket/ols-nightly.json
+++ b/bucket/ols-nightly.json
@@ -1,0 +1,25 @@
+{
+    "version": "d12ee2ef83989d0fcf71b20a0305111344a69b7d",
+    "description": "Language server for Odin.",
+    "homepage": "https://github.com/DanielGavin/ols",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/DanielGavin/ols/releases/download/nightly/ols-x86_64-pc-windows-msvc.zip",
+            "hash": "e1c0e13797bc71146033928fe4702a3a33f8ecbde1d1354289b1d867c0331926"
+        }
+    },
+    "bin": "ols.exe",
+    "checkver": {
+        "url": "https://github.com/DanielGavin/ols/releases/tag/nightly",
+        "regex": "commit/(?<sha>[0-9a-f]{40})",
+        "replace": "${sha}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/DanielGavin/ols/releases/download/nightly/ols-x86_64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}

--- a/bucket/ols-nightly.json
+++ b/bucket/ols-nightly.json
@@ -1,19 +1,24 @@
 {
-    "version": "d12ee2ef83989d0fcf71b20a0305111344a69b7d",
+    "version": "20250928-g4a2a71e",
     "description": "Language server for Odin.",
     "homepage": "https://github.com/DanielGavin/ols",
     "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/DanielGavin/ols/releases/download/nightly/ols-x86_64-pc-windows-msvc.zip",
-            "hash": "e1c0e13797bc71146033928fe4702a3a33f8ecbde1d1354289b1d867c0331926"
+            "hash": "3c4a3e05a8af493d52a968fecc113bd99d7d445c42f21949231ee0b2387db8d5"
         }
     },
-    "bin": "ols.exe",
+    "bin": [
+        [
+            "ols-x86_64-pc-windows-msvc.exe",
+            "ols"
+        ]
+    ],
     "checkver": {
         "url": "https://github.com/DanielGavin/ols/releases/tag/nightly",
-        "regex": "commit/(?<sha>[0-9a-f]{40})",
-        "replace": "${sha}"
+        "regex": "datetime=\"(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})(.*\\n)*?.*/commit/(?<commit>[0-9a-f]{7})",
+        "replace": "${year}${month}${day}-g${commit}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
> Added `ols-nightly` package to provide Odin Language Server

Title is self explanatory.

Added an `ols-nightly` package which access to nightly builds for the [DanielGavin/ols](https://github.com/DanielGavin/ols) tool.

I would have provided a `ols-dev` and `ols` package but the main releases do not appear to have artifacts attached. I am looking into adding those into the aforementioned repository via a pull request.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
