### PR TITLE
7zip-zstd@v24.09-v1.5.7-R1: add `7zFM.exe` to  `bin`

### DIFF
--- a/bucket/7zip-zstd.json
+++ b/bucket/7zip-zstd.json
@@ -19,6 +19,7 @@
     },
     "bin": [
         "7z.exe",
+        "7zFM.exe",
         "7zG.exe"
     ],
     "shortcuts": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Added missing 7zFM.exe shim for 7z-zstd

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2391

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
