### PR TITLE
llama.cpp-cu124: Fix the autoupdate url

### DIFF
--- a/bucket/llama.cpp-cu124.json
+++ b/bucket/llama.cpp-cu124.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b5449/llama-b5449-bin-win-cuda12.4-x64.zip",
-            "hash": "8def3d4e0fe745812335a597b2d79ac12d8609f8cb682b289d82ddf3d6bb5853"
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b5995/llama-b5995-bin-win-cuda-12.4-x64.zip",
+            "hash": "77ce6c1eba3c28c103517f6a9603228be108dd5b10552b48f6e03df3ab83ecfd"
         }
     },
     "bin": [

--- a/bucket/llama.cpp-cu124.json
+++ b/bucket/llama.cpp-cu124.json
@@ -35,7 +35,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ggml-org/llama.cpp/releases/download/$version/llama-$version-bin-win-cuda12.4-x64.zip"
+                "url": "https://github.com/ggml-org/llama.cpp/releases/download/$version/llama-$version-bin-win-cuda-12.4-x64.zip"
             }
         }
     }


### PR DESCRIPTION
Fix the autoupdate url.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
