### PR TITLE
fmedia16@1.6: Fix download urls

### DIFF
--- a/bucket/fmedia16.json
+++ b/bucket/fmedia16.json
@@ -1,15 +1,15 @@
 {
-    "homepage": "http://fmedia.firmdev.com/",
-    "description": "A fast media player/recorder/converter",
-    "license": "GPL-3.0-only",
     "version": "1.6",
+    "description": "A fast media player/recorder/converter",
+    "homepage": "https://web.archive.org/web/20190820034904/http://fmedia.firmdev.com/",
+    "license": "GPL-3.0-only",
     "architecture": {
         "64bit": {
-            "url": "http://fmedia.firmdev.com/fmedia-1.6-win-x64.zip",
+            "url": "https://www.videohelp.com/download/fmedia-1.6-win-x64.zip",
             "hash": "ce7d7e74b091e3aa111615b473d85b1137301979a6cb4ec500942da3ac3e5dbb"
         },
         "32bit": {
-            "url": "http://fmedia.firmdev.com/fmedia-1.6-win-x86.zip",
+            "url": "https://www.videohelp.com/download/fmedia-1.6-win-x86.zip",
             "hash": "bf7f0d7c9a9c38c1ebf2c4a49c36656e80cb5b433de5b36d12692c985b62bf42"
         }
     },


### PR DESCRIPTION
The [original site](http://fmedia.firmdev.com/) with downloads seems unavailable for a long time (latest archived version is [dated 2019](https://web.archive.org/web/20190820034904/http://fmedia.firmdev.com/)).

Since the original repo has been removed as well (ScoopInstaller/Extras#16007) the only place [I could find] with `fmedia` mirrored binaries is [VideoHelp forum](https://www.videohelp.com/software/fmedia/old-versions) archive.

Both binaries seem to be ok - same hashes as originals, virustotal check passed:
https://www.virustotal.com/gui/url/0431301e49759700b98ffc19152b5f9271ece4f1d28081c85e750e9258fd5f6d
https://www.virustotal.com/gui/url/fe4768884a0cd80e432d10c144feeb17b3b8912344b7ebee2072b46a6958574b
so I wonder if they could be used as a new source.

By the way, the latest version with both 64bit/32bit options is 1.15 ([fmedia-1.15-win-x64.zip](https://www.videohelp.com/download/fmedia-1.15-win-x64.zip), [fmedia-1.15-win-x86.zip](https://www.videohelp.com/download/fmedia-1.15-win-x86.zip)).

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
