### PR TITLE
cuda12.9: Add version 12.9.1

### DIFF
--- a/bucket/cuda12.9.json
+++ b/bucket/cuda12.9.json
@@ -1,0 +1,30 @@
+{
+    "version": "12.9.1",
+    "description": "A parallel computing platform and programming model invented by NVIDIA (version 12.9)",
+    "homepage": "https://developer.nvidia.com/cuda-toolkit",
+    "license": {
+        "identifier": "Freeware",
+        "url": "https://docs.nvidia.com/cuda/eula/index.html"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "http://developer.download.nvidia.com/compute/cuda/12.9.1/local_installers/cuda_12.9.1_576.57_windows.exe#/dl.7z",
+            "hash": "md5:9475f337896805cbe66935cbb8504d6f"
+        }
+    },
+    "installer": {
+        "script": [
+            "$names = @('bin', 'extras', 'include', 'lib', 'libnvvp', 'nvml', 'nvvm', 'compute-sanitizer')",
+            "foreach ($name in $names) {",
+            "    Copy-Item \"$dir\\cuda_*\\*\\$name\" \"$dir\" -Recurse -Force",
+            "    Copy-Item \"$dir\\lib*\\*\\$name\" \"$dir\" -Recurse -Force",
+            "}",
+            "Get-ChildItem \"$dir\" -Exclude $names | Remove-Item -Recurse -Force"
+        ]
+    },
+    "env_add_path": "bin",
+    "env_set": {
+        "CUDA_PATH": "$dir",
+        "CUDA_PATH_V12_9": "$dir"
+    }
+}


### PR DESCRIPTION
As the CUDA version in `Main` has been updated to `13.x`, I'm adding the latest `12.x` version to be able to compile programs requiring it.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added CUDA 12.9.1 as a new installable package.
  - Supports 64-bit download with checksum verification.
  - Installer organizes core CUDA components for a tidy install and removes extraneous files.
  - Automatically adds the CUDA bin directory to PATH.
  - Sets CUDA_PATH and CUDA_PATH_V12_9 environment variables for tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->