### PR TITLE
cursor-latest: Update to version 1.5.9, fix checkver

### DIFF
--- a/bucket/cursor-latest.json
+++ b/bucket/cursor-latest.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.4",
+    "version": "1.5.9",
     "description": "The AI Code Editor",
     "homepage": "https://www.cursor.com/",
     "license": {
@@ -9,12 +9,12 @@
     "innosetup": true,
     "architecture": {
         "64bit": {
-            "url": "https://downloads.cursor.com/production/a8e95743c5268be73767c46944a71f4465d05c90/win32/x64/user-setup/CursorUserSetup-x64-1.2.4.exe",
-            "hash": "3f999fe24c51707b159201534a6886e1e169760344250979603ea0fc7b9e8506"
+            "url": "https://downloads.cursor.com/production/de327274300c6f38ec9f4240d11e82c3b0660b29/win32/x64/user-setup/CursorUserSetup-x64-1.5.9.exe",
+            "hash": "5fda5bb39f22c2c1cba54b4d8acc5e685a7ff1f08df7ba3dbb29da4c9494ad83"
         },
         "arm64": {
-            "url": "https://downloads.cursor.com/production/a8e95743c5268be73767c46944a71f4465d05c90/win32/arm64/user-setup/CursorUserSetup-arm64-1.2.4.exe",
-            "hash": "7d7082e5eea88040ca7ac4ec8058b91be8a2dfb6fb8cd409214bf0975a6de00d"
+            "url": "https://downloads.cursor.com/production/de327274300c6f38ec9f4240d11e82c3b0660b29/win32/arm64/user-setup/CursorUserSetup-arm64-1.5.9.exe",
+            "hash": "590c555602a682ccb2a50da037cc791de572cbb3c84f27752a764d8d3380d810"
         }
     },
     "extract_dir": "{code_GetDestDir}",
@@ -51,7 +51,7 @@
     "persist": "data",
     "checkver": {
         "url": "https://www.cursor.com/api/download?platform=win32-x64-user&releaseTrack=latest",
-        "regex": "version\":\"([\\d.]+).*production/(?<Code>[\\w]+)/win32"
+        "regex": "production/(?<Code>[\\w]+)/win32.*-([\\d.]+)\\.exe"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
This PR makes the following changes:
- `cursor-latest`: Update to version 1.5.9, fix checkver.

<!-- Provide a general summary of your changes in the title above -->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
