### PR TITLE
Fix influxdb1 download url

### DIFF
--- a/bucket/influxdb1.json
+++ b/bucket/influxdb1.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://dl.influxdata.com/influxdb/releases/influxdb-1.11.8_windows_amd64.zip",
+            "url": "https://dl.influxdata.com/influxdb/releases/influxdb-1.11.8-windows-amd64.zip",
             "hash": "8cc0d67a92a72da19f408e432208ee3ec76cc618a8ae2fb235578e985db45909",
             "extract_dir": "influxdb-1.11.8-1"
         }


### PR DESCRIPTION
The influxdb1 download url isn't working. 

Following the checkver url you could see that it should be dash instead of underscores
[portal.influxdata.com](https://portal.influxdata.com/versions.json)

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
