### PR TITLE
curl-32bit: Add version 8.15.0_5

### DIFF
--- a/bucket/curl-32bit.json
+++ b/bucket/curl-32bit.json
@@ -1,0 +1,26 @@
+{
+    "version": "8.15.0_5",
+    "description": "Command line tool and library for transferring data with URLs",
+    "homepage": "https://curl.se/",
+    "license": "MIT",
+    "architecture": {
+        "32bit": {
+            "url": "https://curl.se/windows/dl-8.15.0_5/curl-8.15.0_5-win32-mingw.tar.xz",
+            "hash": "30799b6ec93c416d068581533e523d86968f75b73a8c2f82d5cd55f62e028e0d",
+            "extract_dir": "curl-8.15.0_5-win32-mingw"
+        }
+    },
+    "bin": "bin\\curl.exe",
+    "autoupdate": {
+        "architecture": {
+            "32bit": {
+                "url": "https://curl.se/windows/dl-$version/curl-$version-win32-mingw.tar.xz",
+                "extract_dir": "curl-$version-win32-mingw",
+                "hash": {
+                    "url": "$baseurl/hashes.txt",
+                    "regex": "SHA2-256\\($basename\\)=\\s+$sha256"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the following changes:
- `curl-32bit`: Add version 8.15.0_5.

Relates to:
- https://github.com/ScoopInstaller/Main/pull/7143

<!-- notes -->
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new 32-bit Windows (MinGW) curl package at version 8.15.0_5, enabling installation on legacy 32-bit systems.
  * Provides seamless auto-update to future versions for hassle-free maintenance.
  * Installs with the standard curl.exe command available on PATH for immediate use.
  * Includes verified downloads to ensure integrity and a consistent extraction layout for reliable setup and operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->