### PR TITLE
greenshot-unstable: Update to version 1.3.299, fix checkver & autoupdate

### DIFF
--- a/bucket/greenshot-unstable.json
+++ b/bucket/greenshot-unstable.json
@@ -1,10 +1,10 @@
 {
-    "version": "1.3.292",
+    "version": "1.3.299",
     "description": "Light-weight screenshot software.",
     "homepage": "https://getgreenshot.org",
     "license": "GPL-3.0-only",
-    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.292/Greenshot-INSTALLER-1.3.292-UNSTABLE.exe",
-    "hash": "724314461c32d199d6ad43a04694602918e9192c78317cde5af0cc22ee44217c",
+    "url": "https://github.com/greenshot/greenshot/releases/download/v1.3.299/Greenshot-INSTALLER-1.3.299-UNSTABLE-UNSIGNED.exe",
+    "hash": "2a03634d14f0de9ae319c06bc4800ee89011374018bb042f15a378e4e82d4951",
     "innosetup": true,
     "pre_install": "if (!(Test-Path \"$persist_dir\\greenshot.ini\")) { New-Item -ItemType File \"$dir\\greenshot.ini\" | Out-Null }",
     "bin": "Greenshot.exe",
@@ -17,9 +17,9 @@
     "persist": "greenshot.ini",
     "checkver": {
         "url": "https://api.github.com/repositories/36756917/releases",
-        "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE"
+        "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE-UNSIGNED"
     },
     "autoupdate": {
-        "url": "https://github.com/greenshot/greenshot/releases/download/v$version/Greenshot-INSTALLER-$version-UNSTABLE.exe"
+        "url": "https://github.com/greenshot/greenshot/releases/download/v$version/Greenshot-INSTALLER-$version-UNSTABLE-UNSIGNED.exe"
     }
 }


### PR DESCRIPTION
Greenshot unstable added `UNSIGNED` to the end of the exe name for unstable releases.  This PR updates the URLs for the new naming scheme.

Closes #2461

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - None.

- Chores
  - Updated Greenshot (unstable) to version 1.3.299.
  - Switched installer source to the UNSIGNED unstable build to match upstream availability.
  - Refreshed download URL and checksum for the new build.
  - Adjusted release detection and auto-update to track the UNSIGNED variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->