### PR TITLE
zed-nightly: Update shortcuts

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -13,7 +13,7 @@
     "shortcuts": [
         [
             "zed.exe",
-            "Zed"
+            "Zed Nightly"
         ]
     ],
     "checkver": {

--- a/bucket/zed-opengl-nightly.json
+++ b/bucket/zed-opengl-nightly.json
@@ -18,7 +18,7 @@
     "shortcuts": [
         [
             "zed-opengl.exe",
-            "Zed"
+            "Zed Nightly"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
Update shortcuts to coexist with extras/zed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the shortcut display name for nightly builds from "Zed" to "Zed Nightly" to clearly distinguish them in menus and shortcuts.
  * Applies to both the standard Nightly and OpenGL Nightly variants.
  * No changes to functionality, downloads, or updates—only the visible shortcut label is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->