### PR TITLE
freecad-weekly: Update to version 2025.09.24, fix checkver & autoupdate

### DIFF
--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -1,15 +1,15 @@
 {
-    "version": "2025.09.17",
+    "version": "2025.09.24",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2025.09.17/FreeCAD_weekly-2025.09.17-Windows-x86_64-py311.7z",
-            "hash": "fe5ebb972cce583a4522a649e2ad9a78e1f6ca574e1590d7af30fcff19f77945"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2025.09.24/FreeCAD_weekly-2025.09.24-Windows-x86_64-py311.7z",
+            "hash": "9b112087ea8169d53e4e7721f6ccd749c0e86de4b0aa0d9d3ec8cad83b726dfa"
         }
     },
-    "extract_dir": "FreeCAD_weekly-2025.09.17-Windows-x86_64-py311",
+    "extract_dir": "FreeCAD_weekly-2025.09.24-Windows-x86_64-py311",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
@@ -19,7 +19,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
-        "regex": "FreeCAD_weekly-([\\d]+\\.[\\d]+\\.[\\d]+)-Windows-x86_64"
+        "regex": "FreeCAD_weekly-([\\d.]+)-Windows-x86_64"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -27,10 +27,6 @@
                 "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64-py311.7z"
             }
         },
-        "hash": {
-            "url": "$url-SHA256.txt",
-            "regex": "(?sm):\\s+([a-fA-F\\d\\s]+)CertUtil"
-        },
         "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64-py311"
     }
 }

--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -1,15 +1,15 @@
 {
-    "version": "43071",
+    "version": "2025.09.17",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/weekly-builds/FreeCAD_weekly-builds-43071-conda-Windows-x86_64-py311.7z",
-            "hash": "575945d0923caff6518bf34ca8f7e1b6e6ab137545bf1507c03fa7951af37d73"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2025.09.17/FreeCAD_weekly-2025.09.17-Windows-x86_64-py311.7z",
+            "hash": "fe5ebb972cce583a4522a649e2ad9a78e1f6ca574e1590d7af30fcff19f77945"
         }
     },
-    "extract_dir": "FreeCAD_weekly-builds-43071-conda-Windows-x86_64-py311",
+    "extract_dir": "FreeCAD_weekly-2025.09.17-Windows-x86_64-py311",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
@@ -18,19 +18,19 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FreeCAD/FreeCAD-Bundle/releases/tags/weekly-builds",
-        "regex": "FreeCAD_weekly-builds-([\\d]+)-conda-Windows"
+        "url": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
+        "regex": "FreeCAD_weekly-([\\d]+\\.[\\d]+\\.[\\d]+)-Windows-x86_64"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD-Bundle/releases/download/weekly-builds/FreeCAD_weekly-builds-$version-conda-Windows-x86_64-py311.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64-py311.7z"
             }
         },
         "hash": {
             "url": "$url-SHA256.txt",
             "regex": "(?sm):\\s+([a-fA-F\\d\\s]+)CertUtil"
         },
-        "extract_dir": "FreeCAD_weekly-builds-$version-conda-Windows-x86_64-py311"
+        "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64-py311"
     }
 }


### PR DESCRIPTION
To reflect new location of weekly builds.

- Closes #2470


- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Updated FreeCAD Weekly to version 2025.09.24 for Windows (x86_64) with release-based naming.

- Bug Fixes
  - Fixed download URL, extraction directory, and checksum to match the dated release artifacts.

- Chores
  - Switched version checking to the official releases endpoint and updated regex.
  - Adjusted auto-update URL and extract directory patterns to use the new release date variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->