### PR TITLE
(chore): Run formatjson.ps1 for all manifests

### DIFF
--- a/bucket/docker-nightly.json
+++ b/bucket/docker-nightly.json
@@ -36,7 +36,6 @@
         "Docker Machine": "docker-machine",
         "Kubernetes Client": "kubectl",
         "Kubernetes Standalone": "minikube",
-        "Linux container support on Windows": "lcow",
         "Linux container support on Windows": "versions/lcow",
         "sudo": [
             "sudo",

--- a/bucket/dotnet-nightly.json
+++ b/bucket/dotnet-nightly.json
@@ -1,19 +1,17 @@
 {
-    "version":  "nightly",
+    "version": "nightly",
     "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
-    "homepage":  "http://dotnet.github.io/",
-    "license":  "MIT",
-    "architecture":  {
-        "64bit":  {
-            "url":  "https://dotnetcli.blob.core.windows.net/dotnet/dev/Installers/Latest/dotnet-win-x64.latest.msi"
+    "homepage": "http://dotnet.github.io/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/dev/Installers/Latest/dotnet-win-x64.latest.msi"
         }
     },
-    "extract_dir":  "dotnet",
-    "bin":  [
-        "bin\\dotnet.exe"
-    ],
+    "extract_dir": "dotnet",
+    "bin": "bin\\dotnet.exe",
     "env_set": {
-        "DOTNET_HOME":  "$dir"
+        "DOTNET_HOME": "$dir"
     },
     "notes": [
         "dotnet cli has the following prerequisites:",

--- a/bucket/lua52.json
+++ b/bucket/lua52.json
@@ -1,50 +1,50 @@
 {
-  "version": "5.2.4",
-  "description": "A powerful, efficient, lightweight, embeddable scripting language (version 5.2)",
-  "homepage": "http://www.lua.org",
-  "license": "MIT",
-  "architecture": {
-      "64bit": {
-          "url": [
-              "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Tools%20Executables/lua-5.2.4_Win64_bin.zip",
-              "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Windows%20Libraries/Dynamic/lua-5.2.4_Win64_dllw6_lib.zip"
-          ],
-          "hash": [
-              "6cc8153640b5c1fc4632f18dadaa8696c5b7aef85e885245280d7e31011549d9",
-              "1f301605fd304754e179c37803af78d930175f7ca7301be62d97ff2228dee3dd"
-          ]
-      },
-      "32bit": {
-          "url": [
-              "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Tools%20Executables/lua-5.2.4_Win32_bin.zip",
-              "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Windows%20Libraries/Dynamic/lua-5.2.4_Win32_dllw6_lib.zip"
-          ],
-          "hash": [
-              "2ab5a24ac1a78bb88bde0bb75ad09c7fabc2c9f886fbf4e9f72e5b7745a9f76a",
-              "95240e52d0d10c5b4575d11ee35428f171b0819b6a9d543685cafe16610f6607"
-          ]
-      }
-  },
-  "bin": [
-      [
-          "lua52.exe",
-          "lua52"
-      ],
-      [
-          "lua52.exe",
-          "lua"
-      ],
-      [
-          "luac52.exe",
-          "luac52"
-      ],
-      [
-          "luac52.exe",
-          "luac"
-      ]
-  ],
-  "env_set": {
-      "LUA_PATH": "$dir",
-      "LUA_CPATH": "$dir"
-  }
+    "version": "5.2.4",
+    "description": "A powerful, efficient, lightweight, embeddable scripting language (version 5.2)",
+    "homepage": "http://www.lua.org",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Tools%20Executables/lua-5.2.4_Win64_bin.zip",
+                "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Windows%20Libraries/Dynamic/lua-5.2.4_Win64_dllw6_lib.zip"
+            ],
+            "hash": [
+                "6cc8153640b5c1fc4632f18dadaa8696c5b7aef85e885245280d7e31011549d9",
+                "1f301605fd304754e179c37803af78d930175f7ca7301be62d97ff2228dee3dd"
+            ]
+        },
+        "32bit": {
+            "url": [
+                "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Tools%20Executables/lua-5.2.4_Win32_bin.zip",
+                "https://downloads.sourceforge.net/project/luabinaries/5.2.4/Windows%20Libraries/Dynamic/lua-5.2.4_Win32_dllw6_lib.zip"
+            ],
+            "hash": [
+                "2ab5a24ac1a78bb88bde0bb75ad09c7fabc2c9f886fbf4e9f72e5b7745a9f76a",
+                "95240e52d0d10c5b4575d11ee35428f171b0819b6a9d543685cafe16610f6607"
+            ]
+        }
+    },
+    "bin": [
+        [
+            "lua52.exe",
+            "lua52"
+        ],
+        [
+            "lua52.exe",
+            "lua"
+        ],
+        [
+            "luac52.exe",
+            "luac52"
+        ],
+        [
+            "luac52.exe",
+            "luac"
+        ]
+    ],
+    "env_set": {
+        "LUA_PATH": "$dir",
+        "LUA_CPATH": "$dir"
+    }
 }

--- a/bucket/thorium-avx2.json
+++ b/bucket/thorium-avx2.json
@@ -8,7 +8,7 @@
     },
     "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M130.0.6723.174/Thorium_AVX2_130.0.6723.174.zip",
     "hash": "0cdeef8c4f32d9cded5c36e72cb949e305a8fb0b559334ebe626d0aa379364f5",
-    "extract_dir":"BIN",
+    "extract_dir": "BIN",
     "bin": [
         [
             "thorium.exe",
@@ -37,7 +37,7 @@
         "github": "https://github.com/Alex313031/Thorium-Win",
         "regex": "/releases/tag/M(?:v|V)?([\\d.]+)"
     },
-    "autoupdate":{
+    "autoupdate": {
         "url": "https://github.com/Alex313031/Thorium-Win/releases/download/M$version/Thorium_AVX2_$version.zip",
         "extract_dir": "Thorium_$version"
     }

--- a/bucket/typora0.11.18.json
+++ b/bucket/typora0.11.18.json
@@ -9,33 +9,33 @@
     "architecture": {
         "64bit": {
             "url": [
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.001",
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.002",
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.003"
-             ],
-             "hash": [
-                 "3c5ade21aa26214bbf2c162061c8bf34be3d4d54475bb3263e28efc0ac2d8658",
-                 "2ac7ca6d1fe00cedc38996641a74a593dc5364ebc32c71ebfce32de5cc72d054",
-                 "0935d035940cdc919b8aeb9a0cad744de3028a1b86aec4f0da9e37c46746ffe5"
-             ]
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.001",
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.002",
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_64bit.7z.003"
+            ],
+            "hash": [
+                "3c5ade21aa26214bbf2c162061c8bf34be3d4d54475bb3263e28efc0ac2d8658",
+                "2ac7ca6d1fe00cedc38996641a74a593dc5364ebc32c71ebfce32de5cc72d054",
+                "0935d035940cdc919b8aeb9a0cad744de3028a1b86aec4f0da9e37c46746ffe5"
+            ]
         },
         "32bit": {
             "url": [
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.001",
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.002",
-                 "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.003"
-             ],
-             "hash": [
-                 "04f067c664153747393a6ca34e5f1cb0d7b0fe8936c13952eed5c197b6088fde",
-                 "6fd89dd8acd94922b9563b3892c2ca9e9f7fcd5b64fb8d6fdb0918a6f382fee7",
-                 "61c77764b5b6bc3a8e105b1b8cb19bf26d630d939e1a35aae1bc07fbdb5e6d3c"
-             ]
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.001",
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.002",
+                "https://raw.githubusercontent.com/ScoopInstaller/Binary/master/typora/typora-0.11.18_32bit.7z.003"
+            ],
+            "hash": [
+                "04f067c664153747393a6ca34e5f1cb0d7b0fe8936c13952eed5c197b6088fde",
+                "6fd89dd8acd94922b9563b3892c2ca9e9f7fcd5b64fb8d6fdb0918a6f382fee7",
+                "61c77764b5b6bc3a8e105b1b8cb19bf26d630d939e1a35aae1bc07fbdb5e6d3c"
+            ]
         }
     },
     "pre_install": [
-         "Get-ChildItem \"$dir\\typora-*.exe\" | Rename-Item -NewName 'dl.exe'",
-         "Expand-InnoArchive \"$dir\\dl.exe\" \"$dir\" -Removal | Out-Null"
-     ],
+        "Get-ChildItem \"$dir\\typora-*.exe\" | Rename-Item -NewName 'dl.exe'",
+        "Expand-InnoArchive \"$dir\\dl.exe\" \"$dir\" -Removal | Out-Null"
+    ],
     "bin": "Typora.exe",
     "shortcuts": [
         [

--- a/bucket/winpython3741.json
+++ b/bucket/winpython3741.json
@@ -52,7 +52,6 @@
             "scripts\\WinPython_PS_Prompt.ps1",
             "winpython_prompt"
         ]
-
     ],
     "shortcuts": [
         [


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- `(chore)`: Run formatjson.ps1 for all manifests.

### Motivation
Relates to:
- https://github.com/ScoopInstaller/GithubActions/pull/61

To avoid existing manifests with lint issues also modified and appear in the commit list when contributors format manifests, I am now submitting a PR to format them all.

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected suggestion mapping for “Linux container support on Windows” in docker-nightly to improve accuracy.

- Style
  - Normalized JSON formatting across manifests (dotnet-nightly, lua52, thorium-avx2, typora0.11.18, winpython3741), including whitespace cleanup and consistent field formatting. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->