### PR TITLE
chromium-nosync@138.0.7204.184-r1465706: Add discontinued notes, remove checkver

### DIFF
--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -4,7 +4,11 @@
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
-    "notes": "This build is not provided anymore, you should look for alternatives like ungoogled-chromium or chromium",
+    "notes": [
+        "This build will no longer receive updates. See:",
+        "https://github.com/Hibbiki/chromium-win64/commit/09101f3",
+        "Consider alternatives such as 'extras/chromium' or 'extras/ungoogled-chromium'."
+    ],
     "architecture": {
         "64bit": {
             "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v138.0.7204.184-r1465706/chrome.nosync.7z",

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -33,10 +33,6 @@
         "}"
     ],
     "persist": "User Data",
-    "checkver": {
-        "url": "https://github.com/Hibbiki/chromium-win64/releases/latest",
-        "regex": ">v([\\d.]+-r\\d+)</h1>"
-    },
     "autoupdate": {
         "architecture": {
             "64bit": {

--- a/bucket/chromium-nosync.json
+++ b/bucket/chromium-nosync.json
@@ -4,6 +4,7 @@
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
+    "notes": "This build is not provided anymore, you should look for alternatives like ungoogled-chromium or chromium",
     "architecture": {
         "64bit": {
             "url": "https://github.com/Hibbiki/chromium-win64/releases/download/v138.0.7204.184-r1465706/chrome.nosync.7z",


### PR DESCRIPTION
chromium-nosync is no longer updated: https://github.com/Hibbiki/chromium-win64/commit/09101f314e66e4bc70082d6db7cb31cad8423419
Last version is 138 where Chromium is now 140.

Closes #2473

- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a deprecation notice informing users this build will no longer receive updates and suggesting alternative options and references.
- **Chores**
  - Simplified update behavior by removing the explicit external version-check step; automatic updates remain in place without the separate check endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->