### PR TITLE
systeminformer-nightly: Update to version 3.2.25263.236, fix checkver & autoupdate

### DIFF
--- a/bucket/systeminformer-nightly.json
+++ b/bucket/systeminformer-nightly.json
@@ -1,9 +1,9 @@
 {
-    "version": "3.2.25263",
+    "version": "3.2.25263.236",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://systeminformer.sourceforge.io",
     "license": "MIT",
-    "url": "https://github.com/winsiderss/si-builds/releases/download/3.2.25263/systeminformer-3.2.25263-bin.zip",
+    "url": "https://github.com/winsiderss/si-builds/releases/download/3.2.25263.236/systeminformer-build-bin.zip",
     "hash": "6783bc5c7dbddbfb2e2cf34b29a9a22adf587ad1ae62c3b2680407432c07ea1f",
     "architecture": {
         "32bit": {
@@ -36,14 +36,9 @@
     ],
     "pre_uninstall": "'SystemInformer.exe.settings.xml', 'usernotesdb.xml' | ForEach-Object { Copy-Item \"$dir\\$_\" \"$persist_dir\\$_\" -ErrorAction 'SilentlyContinue' }",
     "checkver": {
-        "url": "https://systeminformer.sourceforge.io/canary",
-        "regex": "systeminformer-([\\d.]+)"
+        "github": "https://github.com/winsiderss/si-builds"
     },
     "autoupdate": {
-        "url": "https://github.com/winsiderss/si-builds/releases/download/$version/systeminformer-$version-bin.zip",
-        "hash": {
-            "url": "https://systeminformer.sourceforge.io/canary",
-            "regex": "(?s)Binaries.*SHA-256.*?$sha256"
-        }
+        "url": "https://github.com/winsiderss/si-builds/releases/download/$version/systeminformer-build-bin.zip"
     }
 }


### PR DESCRIPTION
- The 3 versions of `systeminformer-nightly` released in the last 24 hours use the filename `systeminformer-build-bin.zip` instead of `systeminformer-$version-bin.zip`. Changed the manifest to fix this.

- Changed `checkver` to use GitHub instead of SourceForge. Since GitHub now provides hashes for their release assets I don't see a point in using SourceForge for getting the hashes.

Output of `checkurls.ps1` and `checkver.ps1` for the updated manifest:
<details><summary>checkurls.ps1</summary>

```console
❯ ..\bin\checkurls.ps1 systeminformer-nightly
[U]RLs
 | [O]kay
 |  | [F]ailed
 |  |  |
[1][1][0] systeminformer-nightly
```

</details>
<details><summary>checkver.ps1</summary>

```console
❯ $env:SCOOP_DEBUG = 'true'; ..\bin\checkver.ps1 systeminformer-nightly -Force
systeminformer-nightly: 3.2.25263.236 (scoop version is 3.2.25263.236)
Forcing autoupdate!
Autoupdating systeminformer-nightly
DEBUG[1758351117] [$updatedProperties] = [url hash] -> C:\Scoop\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1758351117] $substitutions (hashtable) -> C:\Scoop\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1758351117] $substitutions.$basename                      systeminformer-build-bin.zip
DEBUG[1758351117] $substitutions.$matchHead                     3.2.25263
DEBUG[1758351117] $substitutions.$baseurl                       https://github.com/winsiderss/si-builds/releases/download/3.2.25263.236
DEBUG[1758351117] $substitutions.$minorVersion                  2
DEBUG[1758351117] $substitutions.$majorVersion                  3
DEBUG[1758351117] $substitutions.$url                           https://github.com/winsiderss/si-builds/releases/download/3.2.25263.236/systeminformer-build-bin.z…
DEBUG[1758351117] $substitutions.$underscoreVersion             3_2_25263_236
DEBUG[1758351117] $substitutions.$cleanVersion                  3225263236
DEBUG[1758351117] $substitutions.$buildVersion                  236
DEBUG[1758351117] $substitutions.$dashVersion                   3-2-25263-236
DEBUG[1758351117] $substitutions.$patchVersion                  25263
DEBUG[1758351117] $substitutions.$match1                        3.2.25263.236
DEBUG[1758351117] $substitutions.$basenameNoExt                 systeminformer-build-bin
DEBUG[1758351117] $substitutions.$urlNoExt                      https://github.com/winsiderss/si-builds/releases/download/3.2.25263.236/systeminformer-build-bin
DEBUG[1758351117] $substitutions.$matchTail                     .236
DEBUG[1758351117] $substitutions.$preReleaseVersion             3.2.25263.236
DEBUG[1758351117] $substitutions.$version                       3.2.25263.236
DEBUG[1758351117] $substitutions.$dotVersion                    3.2.25263.236
DEBUG[1758351117] $hashfile_url = $null -> C:\Scoop\apps\scoop\current\lib\autoupdate.ps1:224:5
DEBUG[1758351117] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/winsiderss/si-builds/releases/download/3.2.25263.236/systeminformer-build-bin.zip')].digest -> C:\Scoop\apps\scoop\current\lib\autoupdate.ps1:132:5
Found: 6783bc5c7dbddbfb2e2cf34b29a9a22adf587ad1ae62c3b2680407432c07ea1f using Github Mode
Writing updated systeminformer-nightly manifest
```
</details>

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2476 

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
