### PR TITLE
ffmpeg(-shared)-nightly: Add arm64 support

### DIFF
--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -8,6 +8,11 @@
             "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip",
             "hash": "69325405e56b0f22e77a573f0f49a8480f7dcc5eb3d837ab511d7aae37c93f51",
             "extract_dir": "ffmpeg-master-latest-win64-gpl"
+        },
+        "arm64": {
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-gpl.zip",
+            "hash": "2efe476b66eb51971fa061f4d368b84ffc76037d415cee42460aae6350671563",
+            "extract_dir": "ffmpeg-master-latest-winarm64-gpl"
         }
     },
     "bin": [
@@ -23,6 +28,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-winarm64-gpl.zip"
             }
         }
     }

--- a/bucket/ffmpeg-shared-nightly.json
+++ b/bucket/ffmpeg-shared-nightly.json
@@ -8,6 +8,11 @@
             "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-27-13-18/ffmpeg-N-121253-g8a34faa250-win64-gpl-shared.zip",
             "hash": "dae57984de5a16ba7f00d895f0be608486f9b1553197800df53e9f74eaaff9e1",
             "extract_dir": "ffmpeg-N-121253-g8a34faa250-win64-gpl-shared"
+        },
+        "arm64": {
+            "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2025-09-27-13-18/ffmpeg-N-121253-g8a34faa250-winarm64-gpl-shared.zip",
+            "hash": "1896624a668a76faa81a0ffee6358a457672cc1e7eb8163b733b9798a9e54ea0",
+            "extract_dir": "ffmpeg-N-121253-g8a34faa250-winarm64-gpl-shared"
         }
     },
     "bin": [
@@ -25,6 +30,10 @@
             "64bit": {
                 "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-$matchTime/ffmpeg-N-$version-g$matchHash-win64-gpl-shared.zip",
                 "extract_dir": "ffmpeg-N-$version-g$matchHash-win64-gpl-shared"
+            },
+            "arm64": {
+                "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-$matchTime/ffmpeg-N-$version-g$matchHash-winarm64-gpl-shared.zip",
+                "extract_dir": "ffmpeg-N-$version-g$matchHash-winarm64-gpl-shared"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows ARM64 build support for FFmpeg Nightly and FFmpeg Shared Nightly with auto-update.

* **Chores**
  * Updated FFmpeg Nightly to the latest build; refreshed 64-bit checksum.
  * Updated FFmpeg Shared Nightly (build updated); added ARM64 artifacts and auto-update entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->