### PR TITLE
firefox-beta@144.0b5: Update homepage & checkver

### DIFF
--- a/bucket/firefox-beta.json
+++ b/bucket/firefox-beta.json
@@ -1,7 +1,7 @@
 {
     "version": "144.0b5",
     "description": "Beta builds of Firefox: the popular open source web browser.",
-    "homepage": "https://www.mozilla.org/en-US/firefox/beta/",
+    "homepage": "https://www.firefox.com/en-US/channel/desktop/#beta",
     "license": "MPL-2.0",
     "notes": [
         "To set profile 'Scoop-Beta' as *DEFAULT*, or profiles/settings was lost after update:",
@@ -50,9 +50,8 @@
         "profile"
     ],
     "checkver": {
-        "url": "https://aus5.mozilla.org/update/6/Firefox/93.0/_/WINNT_x86_64-msvc-x64/en-US/beta/_/_/_/_/update.xml",
-        "xpath": "/updates/update/patch/@URL",
-        "regex": "firefox-([\\db.]+)-"
+        "url": "https://product-details.mozilla.org/1.0/firefox_versions.json",
+        "jsonpath": "$.LATEST_FIREFOX_RELEASED_DEVEL_VERSION"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
- Close #2485
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the homepage link to the official Firefox Beta channel page for clearer, authoritative reference.
  - Migrated version detection for autoupdate from an XML endpoint to a JSON-based source, improving reliability and consistency when checking for new releases and reducing update failures. No changes to user-facing functionality, but users should experience smoother and more accurate update checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->