### PR TITLE
influxdb1: Update to version 1.12.2, fix checkver & autoupdate

### DIFF
--- a/bucket/influxdb1.json
+++ b/bucket/influxdb1.json
@@ -1,12 +1,12 @@
 {
-    "version": "1.11.8",
+    "version": "1.12.2",
     "description": "Scalable datastore for metrics, events, and real-time analytics.",
     "homepage": "https://www.influxdata.com/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://dl.influxdata.com/influxdb/releases/influxdb-1.11.8-windows-amd64.zip",
-            "hash": "8cc0d67a92a72da19f408e432208ee3ec76cc618a8ae2fb235578e985db45909"
+            "url": "https://download.influxdata.com/influxdb/releases/v1.12.2/influxdb-1.12.2-windows.zip",
+            "hash": "bd2bd7a7c1a9aee521a814448b292bb2be1cab2b49dbff069abc70f4920de28a"
         }
     },
     "persist": "influxdb.conf",
@@ -16,18 +16,49 @@
         "influxd.exe"
     ],
     "checkver": {
-        "url": "https://portal.influxdata.com/versions.json",
-        "jsonpath": "$.influxdb_stable.version",
+        "script": [
+            " $repo = \"influxdata/influxdb\" ",
+            " $perPage = 100 ",
+            " $pageNumber = 1 ",
+            " $regexp = \"\"",
+            " $found = $false ",
+            " $latestV1 = [Version]::new(0,0,0,0) ",
+            " $auth = Get-GitHubToken",
+            " $head = @{}",
+            "if($auth) { $head.add('authorization', \"Bearer $auth\") }",
+            " while (-not $found) { ",
+            "     $url = \"https://api.github.com/repos/$repo/tags?per_page=$perPage&page=$pageNumber\" ",
+            "     Write-Host \"Fetching: $url\" ",
+
+            "     $response = Invoke-RestMethod -Uri $url -Headers $head ",
+
+            "     if ($response.Count -eq 0) { ",
+            "         break  # No more tags ",
+            "     } ",
+
+            "     foreach ($tag in $response) { ",
+            "         if ($tag.name -match \"^v(1\\.\\d+\\.\\d+)$\") { ",
+            "             $latestV1 = [Version]::new($matches[1]) ",
+            "             $found = $true ",
+            "             break ",
+            "         } ",
+            "     } ",
+
+            "     $pageNumber++ ",
+            " } ",
+
+            " if ($found) { ",
+            "     Write-Output $latestV1",
+            " } else { ",
+            "     Write-Host { error \"No v1.x.x release found.\"; }",
+            " } "
+        ],
         "regex": "([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dl.influxdata.com/influxdb/releases/influxdb-$version-windows-amd64.zip",
-                "hash": {
-                    "url": "https://portal.influxdata.com/versions.json",
-                    "jsonpath": "$.influxdb_stable.downloads[?(@.platform =~ /^Windows/)].sha256"
-                }
+                "url": "https://download.influxdata.com/influxdb/releases/v$version/influxdb-$version-windows.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
influxdb decided to use a new download location (url + path). 

A versions overview is nowhere to be found, thus scripting the github api to retrieve tags. Since influxdb releases 3 major versions, the tag could be on the second page (pagesize 100), therefore looping till v1 is found. I wasn't able to find the hash location, although it is mentioned in https://www.influxdata.com/downloads/#:~:text=get%20release%20updates-,InfluxDB%20OSS%201.x,-InfluxDB%20is%20a when platform is selected. 

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic version detection now tracks the latest InfluxDB v1.x release for Windows, improving update reliability.
- Chores
  - Updated InfluxDB package to version 1.12.2 for 64-bit Windows, including checksum refresh.
  - Switched to a templated download URL for future versioned releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->