### PR TITLE
v2rayn-pre: Update to version 7.15.0, drop 32bit support, fix checkver & autoupdate

### DIFF
--- a/bucket/v2rayn-pre.json
+++ b/bucket/v2rayn-pre.json
@@ -1,68 +1,44 @@
 {
-    "version": "6.60",
-    "description": "A V2Ray client for Windows, support Xray & v2fly core",
+    "version": "7.15.0",
+    "description": "v2rayN (pre-release) is a GUI client for V2Ray, with support for Xray and sing-box.",
     "homepage": "https://github.com/2dust/v2rayN",
     "license": "GPL-3.0-only",
-    "depends": "xray",
     "suggest": {
         ".NET Desktop Runtime": "extras/windowsdesktop-runtime-lts",
         "v2fly-core": "v2ray"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN.zip",
-            "hash": "fc1243faee5ebdf501d1416ae8567a993638c9ead92f94c4121feb6771f549d5"
-        },
-        "32bit": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN-32.zip",
-            "hash": "049cd293cd5bf2f7cfd5b3306428d9216323623de3301bc29f336b9ed0de42b2"
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.15.0/v2rayN-windows-64.zip",
+            "hash": "078ce3fc4a7e7e333cc217bfa1b068e09ad4149549a10bf8525b3f1f9741f363",
+            "extract_dir": "v2rayN-windows-64"
         },
         "arm64": {
-            "url": "https://github.com/2dust/v2rayN/releases/download/6.60/v2rayN-arm64.zip",
-            "hash": "31816af0a576c9540d1c73174ff193c12b5384d3f1fc16ac5aaee461778da397"
+            "url": "https://github.com/2dust/v2rayN/releases/download/7.15.0/v2rayN-windows-arm64.zip",
+            "hash": "05974a93416dcb142adf9969ce46942304fec76e9b3cc5eeba55cbf6ca7361d0",
+            "extract_dir": "v2rayN-windows-arm64"
         }
     },
-    "extract_dir": "v2rayN",
-    "pre_install": [
-        "foreach ($form in @('*.exe', '*.dat')) {",
-        "    foreach ($_ in Get-ChildItem \"$(appdir xray $global)\\current\" -File) {",
-        "        $name = $_.Name",
-        "        if ($name -Like $form) {",
-        "            Write-Host \"Creating hardlink for $name\"",
-        "            New-Item -ItemType HardLink -Path \"$dir\\bin\\Xray\" -Name $name -Target \"$(appdir xray $global)\\current\\$name\" | Out-Null",
-        "        }",
-        "    }",
-        "}"
-    ],
     "bin": "v2rayN.exe",
     "shortcuts": [
         [
             "v2rayN.exe",
-            "v2rayN"
+            "v2rayN (Pre-release)"
         ]
     ],
     "persist": "guiConfigs",
-    "uninstaller": {
-        "script": [
-            "if (Test-Path \"$dir\\guiConfigs\\config.json\") {",
-            "    Copy-Item \"$dir\\guiConfigs\\config.json\" \"$persist_dir\\guiConfigs\\config.json\" | Out-Null",
-            "}"
-        ]
-    },
     "checkver": {
         "url": "https://api.github.com/repositories/199570071/releases",
-        "regex": "download/([\\d.]+)/"
+        "jsonpath": "$[?(@.prerelease == true)].tag_name",
+        "regex": "(?:v|V)?([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN.zip"
-            },
-            "32bit": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-32.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-64.zip"
             },
             "arm64": {
-                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-arm64.zip"
+                "url": "https://github.com/2dust/v2rayN/releases/download/$version/v2rayN-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
This PR makes the following changes:
- `v2rayn-pre`: Update to version 7.15.0, drop 32bit support, fix checkver & autoupdate.

Relates to:
-  https://github.com/ScoopInstaller/Extras/pull/15727

<!-- Provide a general summary of your changes in the title above -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated v2rayN (Pre-release) to version 7.15.0 with refreshed description.
  - Streamlined packages to per-architecture releases (64-bit and ARM64); discontinued 32-bit support.
  - Removed external dependency on Xray.
  - Shortcut now labeled “v2rayN (Pre-release)” for clearer identification.
  - Simplified installation layout and removed legacy installer/uninstaller steps.
  - Improved version checking and auto-update to better track pre-release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->