### PR TITLE
godot(-mono)-dev: Add version 4.6-dev1

### DIFF
--- a/bucket/godot-dev.json
+++ b/bucket/godot-dev.json
@@ -1,0 +1,52 @@
+{
+    "version": "4.6-dev1",
+    "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
+    "homepage": "https://godotengine.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_win64.exe.zip",
+            "hash": "sha512:12d5979331872ae1826ef47507ae5e3e3e0255243fa0b8ee6f32a4571803b4007610b7bc80ac25fd82fbe73b047f79e36738d719f639a441d43e31a92ebc2178"
+        },
+        "32bit": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_win32.exe.zip",
+            "hash": "sha512:72af2dde4c1e3d39259ed4b647956eee27c10f3dfc083e63c58d4a2224356a1225ff8dba55c7e321519899f3a57a1dcf80e9a0286111dae91529a4ca898d939a"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_windows_arm64.exe.zip",
+            "hash": "sha512:4beed9c00a9484011e31774b8c0362c3e7e186ee23f7fe3f73e213708164d8326db6ab337c87699506513abae419d6fdddf552dd64fe0d6fb809c2998c990e29"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot.exe'"
+    ],
+    "bin": "godot.exe",
+    "shortcuts": [
+        [
+            "godot.exe",
+            "Godot Engine"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/godotengine/godot-builds/releases",
+        "jsonpath": "$[?(@.tag_name =~ /[\\d.]+-dev\\d+/)].tag_name",
+        "regex": "(?<version>[\\d.]+-dev\\d+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_win64.exe.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_win32.exe.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_windows_arm64.exe.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA512-SUMS.txt"
+        }
+    }
+}

--- a/bucket/godot-mono-dev.json
+++ b/bucket/godot-mono-dev.json
@@ -1,0 +1,58 @@
+{
+    "version": "4.6-dev1",
+    "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
+    "homepage": "https://godotengine.org/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_mono_win64.zip",
+            "hash": "sha512:054a07326a66335e8aaae3319d0be406bcc148f6ab59b4ff26a688a92b274bab5af98c1fee9305796b2cd92b1df9bdd837546c28cbe6a1b1c4268bfa52a84103",
+            "extract_dir": "Godot_v4.6-dev1_mono_win64"
+        },
+        "32bit": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_mono_win32.zip",
+            "hash": "sha512:ec76de1e18ba100b1146cbb22d82f0990675265bad5a7ad286128a7ebda71f8c8615d8e9f4d11914c14cf57a8af312a3401a864c4f4c3f97e1ba0046f9eca7e2",
+            "extract_dir": "Godot_v4.6-dev1_mono_win32"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.6-dev1/Godot_v4.6-dev1_mono_windows_arm64.zip",
+            "hash": "sha512:c580e95fb16bdf60b4acf272be321f3732bd8acc42616e6d9d97321c8c692635c208bcd04c0b2f9a1d4a5f96ebbcb90c507b8fb4b77b1f70407d506aa9f847f3",
+            "extract_dir": "Godot_v4.6-dev1_mono_windows_arm64"
+        }
+    },
+    "pre_install": [
+        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot-mono.exe'"
+    ],
+    "bin": "godot-mono.exe",
+    "shortcuts": [
+        [
+            "godot-mono.exe",
+            "Godot Engine (Mono)"
+        ]
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/godotengine/godot-builds/releases",
+        "jsonpath": "$[?(@.tag_name =~ /[\\d.]+-dev\\d+/)].tag_name",
+        "regex": "(?<version>[\\d.]+-dev\\d+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_win64.zip",
+                "extract_dir": "Godot_v$version_mono_win64"
+            },
+            "32bit": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_win32.zip",
+                "extract_dir": "Godot_v$version_mono_win32"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_windows_arm64.zip",
+                "extract_dir": "Godot_v$version_mono_windows_arm64"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA512-SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- godot(-mono)-dev: Add version 4.6-dev1.

### Related Issues
Relates to:
- Closes #2253

<!-- Provide a general summary of your changes in the title above -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added installable packages for Godot Engine 4.6-dev1 and Godot Mono dev builds.
  * Supports 64-bit, 32-bit, and ARM64 architectures with integrity-checked downloads (SHA-512).
  * Enables automatic version detection and seamless updates for dev releases.
  * Performs pre-install cleanup and ensures correct executables are set per architecture.
  * Provides a launcher shortcut for quick access after installation.
  * Consistent wiring so commands and launchers work immediately post-install.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->