### PR TITLE
godot(-mono)-rc: Update to version 4.5.1-rc1, fix checkver & autoupdate, add arm64 support

### DIFF
--- a/bucket/godot-mono-rc.json
+++ b/bucket/godot-mono-rc.json
@@ -1,25 +1,35 @@
 {
-    "version": "4.3-rc3",
+    "version": "4.5.1-rc1",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.3/rc3/mono/Godot_v4.3-rc3_mono_win64.zip",
-            "hash": "sha512:6ed9bee95ceec869a80812b403bdd60a63780ae94148bbbd25dcb62747c02a7fa929d60f0d77d2dad72177d2ca87e83681f3d26c536fa57511350faad22e37c2",
-            "extract_dir": "Godot_v4.3-rc3_mono_win64"
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_mono_win64.zip",
+            "hash": "sha512:7dc2117053d4e5a33e8ca30f3000d7aae3b74022e7538d1b49fd29c2113b10c07c848c62eae6abd60e1dd6b2eb6e2a9b5e8ca7330741744a1dc9672c6196fef4",
+            "extract_dir": "Godot_v4.5.1-rc1_mono_win64"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.3/rc3/mono/Godot_v4.3-rc3_mono_win32.zip",
-            "hash": "sha512:a140bf72d70778dc929b1677315a678271e1b4c26eb5f422ccdb99008773c5b3ecc460e2058bd3f256040e8b704575ac2a5ea15203d177e482b9de8556fd3f17",
-            "extract_dir": "Godot_v4.3-rc3_mono_win32"
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_mono_win32.zip",
+            "hash": "sha512:b12b13f60f073b52a7572e5c1e107de736fd191ae97ff39cf433a91cd5c8248a64306df8d26a7471ab83b116df3d7bd244b10d61108691d195291771f3cf9f69",
+            "extract_dir": "Godot_v4.5.1-rc1_mono_win32"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_mono_windows_arm64.zip",
+            "hash": "sha512:0f4c046bfc369de749e9fda4bc5b750723e735c4d6700c59cb1ebd653c57921490737f1ec05557c40b93e7ea08202ba1d1f62c4ab9a8cff7ad7127b5503a2326",
+            "extract_dir": "Godot_v4.5.1-rc1_mono_windows_arm64"
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*_console.exe\" | Rename-Item -NewName 'godot-mono.console.exe'",
         "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot-mono.exe'"
     ],
-    "bin": "godot-mono.exe",
+    "bin": [
+        [
+            "godot-mono.console.exe",
+            "godot-mono"
+        ]
+    ],
     "shortcuts": [
         [
             "godot-mono.exe",
@@ -27,19 +37,22 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/blog/pre-release/",
-        "regex": "Release candidate: Godot (?<ver>[\\d.]+) RC (?<rc>[\\d.]+)",
-        "replace": "${1}-rc${2}"
+        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "jsonpath": "$[?(@.name =~ /^[\\d.]+-rc\\d+$/)].name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$matchVer/$preReleaseVersion/mono/Godot_v$version_mono_win64.zip",
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_win64.zip",
                 "extract_dir": "Godot_v$version_mono_win64"
             },
             "32bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$matchVer/$preReleaseVersion/mono/Godot_v$version_mono_win32.zip",
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_win32.zip",
                 "extract_dir": "Godot_v$version_mono_win32"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_windows_arm64.zip",
+                "extract_dir": "Godot_v$version_mono_windows_arm64"
             }
         },
         "hash": {

--- a/bucket/godot-rc.json
+++ b/bucket/godot-rc.json
@@ -1,23 +1,32 @@
 {
-    "version": "4.3-rc3",
+    "version": "4.5.1-rc1",
     "description": "A feature-packed, cross-platform game engine to create 2D and 3D games from a unified interface.",
     "homepage": "https://godotengine.org/",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.3/rc3/Godot_v4.3-rc3_win64.exe.zip",
-            "hash": "sha512:bfd90728d9730273c3b236a92901ceb413bfb790342cace9892e75a3fc1fe93ec6b3a6eea6e02500af4f1177ec6d6bf0a9512213e3db72eb93c04ec6e6387bf6"
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_win64.exe.zip",
+            "hash": "sha512:b5d9f01e3123fa06b2768c52b5f8049cf71fa81f4795e0a257d96022f497ce3aed1b390474204f871f2bde5421439066acb8fa5f5b127a3eac74ede1d26a903b"
         },
         "32bit": {
-            "url": "https://downloads.tuxfamily.org/godotengine/4.3/rc3/Godot_v4.3-rc3_win32.exe.zip",
-            "hash": "sha512:1b5c3b68adfbe37e24e1696b6de14c983454a3efef11f44082ccad7d0f5c8d2817f41ba1d55f7cb3dd5bfc15809f7705b493f4a84c3c6385afed2a3c545af2e0"
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_win32.exe.zip",
+            "hash": "sha512:30891da6dd3b34dbdba0073de1f1cedd763aecf72e0ca0b1e6e1f060b7d3cfe6a7e66772794a95773e58cde6fb0a73aa0b19d8e5d83b1bce974c01d5a17903ad"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5.1-rc1/Godot_v4.5.1-rc1_windows_arm64.exe.zip",
+            "hash": "sha512:5629773ff46a987130a292f3a66cb370a9ce027b9e42a8854febba316329873e98f6810ba79b866cbbba4b84a9fadad6f114a0385a462754b8cc58ad04461b61"
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*_console.exe\" | Rename-Item -NewName 'godot.console.exe'",
         "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot.exe'"
     ],
-    "bin": "godot.exe",
+    "bin": [
+        [
+            "godot.console.exe",
+            "godot"
+        ]
+    ],
     "shortcuts": [
         [
             "godot.exe",
@@ -25,17 +34,19 @@
         ]
     ],
     "checkver": {
-        "url": "https://godotengine.org/blog/pre-release/",
-        "regex": "Release candidate: Godot (?<ver>[\\d.]+) RC (?<rc>[\\d.]+)",
-        "replace": "${1}-rc${2}"
+        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "jsonpath": "$[?(@.name =~ /^[\\d.]+-rc\\d+$/)].name"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$matchVer/rc$matchRc/Godot_v$version_win64.exe.zip"
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_win64.exe.zip"
             },
             "32bit": {
-                "url": "https://downloads.tuxfamily.org/godotengine/$matchVer/rc$matchRc/Godot_v$version_win32.exe.zip"
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_win32.exe.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_windows_arm64.exe.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- godot(-mono)-rc: Update to version 4.5.1-rc1, fix checkver & autoupdate, add arm64 support.

### Related Issues
Relates to:
- Closes #2504
- Closes #2505

<!-- Provide a general summary of your changes in the title above -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ARM64 build support for Godot RC and Godot Mono RC; both updated to 4.5.1-rc1.

- **Chores**
  - Switched 64‑bit, 32‑bit, and ARM64 downloads to GitHub releases and refreshed artifact hashes/extract paths.
  - Updated update checks to use GitHub tags with JSONPath and autoupdate URLs using $version.
  - Installer/shortcut behavior adjusted to expose and consistently name console/runtime executables for end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->