### PR TITLE
godot(-mono)-beta@4.5-beta7: Add arm64 support, update bin & checkver

### DIFF
--- a/bucket/godot-beta.json
+++ b/bucket/godot-beta.json
@@ -11,13 +11,22 @@
         "32bit": {
             "url": "https://github.com/godotengine/godot-builds/releases/download/4.5-beta7/Godot_v4.5-beta7_win32.exe.zip",
             "hash": "sha512:177d481b48ee6cad29f7b9b5cd735ce4cccf86a00975b7a005d573081f6c74ad1fd38ad354a6e5a3e1f313078770afc5a10c6bdcf3752f08b6a2bbc1450c27f7"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5-beta7/Godot_v4.5-beta7_windows_arm64.exe.zip",
+            "hash": "sha512:0538d6b5612c6fd7c202f15b8ca94d32eeeaa0e051c879fefc90808ca208cab0d4d7fea3335246d353eb146dd21365dbdf4afa4a23c681de49adf02f802dd75e"
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*_console.exe\" | Rename-Item -NewName 'godot.console.exe'",
         "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot.exe'"
     ],
-    "bin": "godot.exe",
+    "bin": [
+        [
+            "godot.console.exe",
+            "godot"
+        ]
+    ],
     "shortcuts": [
         [
             "godot.exe",
@@ -25,9 +34,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/godotengine/godot-builds/releases",
-        "regex": "(?<ver>[\\d.]+)-beta(?<beta>[\\d.]+)",
-        "replace": "${1}-beta${2}"
+        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "jsonpath": "$[?(@.name =~ /^[\\d.]+-beta\\d+$/)].name"
     },
     "autoupdate": {
         "architecture": {
@@ -36,6 +44,9 @@
             },
             "32bit": {
                 "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_win32.exe.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_windows_arm64.exe.zip"
             }
         },
         "hash": {

--- a/bucket/godot-mono-beta.json
+++ b/bucket/godot-mono-beta.json
@@ -13,13 +13,23 @@
             "url": "https://github.com/godotengine/godot-builds/releases/download/4.5-beta7/Godot_v4.5-beta7_mono_win32.zip",
             "hash": "sha512:1afaddd349d61ea9c4946f846a89fe952a9b22523321bb0900517dbe9967aafd59eec745ed5f46380dfb986ac0c4033c6e00750c259458b5eb4bb891efa30dc8",
             "extract_dir": "Godot_v4.5-beta7_mono_win32"
+        },
+        "arm64": {
+            "url": "https://github.com/godotengine/godot-builds/releases/download/4.5-beta7/Godot_v4.5-beta7_mono_windows_arm64.zip",
+            "hash": "sha512:43d911e3c49197a9d916a225264b30b5162f3d7911020defe8392b9cb4157caf67479e5112632707cf9c71aa6c2441451bbbe191abb36be8f7f826bac5292c28",
+            "extract_dir": "Godot_v4.5-beta7_mono_windows_arm64"
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\Godot_*_console.*\"",
+        "Get-Item \"$dir\\Godot_*_console.exe\" | Rename-Item -NewName 'godot-mono.console.exe'",
         "Get-Item \"$dir\\Godot_*.exe\" | Rename-Item -NewName 'godot-mono.exe'"
     ],
-    "bin": "godot-mono.exe",
+    "bin": [
+        [
+            "godot-mono.console.exe",
+            "godot-mono"
+        ]
+    ],
     "shortcuts": [
         [
             "godot-mono.exe",
@@ -27,9 +37,8 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/godotengine/godot-builds/releases",
-        "regex": "(?<ver>[\\d.]+)-beta(?<beta>[\\d.]+)",
-        "replace": "${1}-beta${2}"
+        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "jsonpath": "$[?(@.name =~ /^[\\d.]+-beta\\d+$/)].name"
     },
     "autoupdate": {
         "architecture": {
@@ -40,6 +49,10 @@
             "32bit": {
                 "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_win32.zip",
                 "extract_dir": "Godot_v$version_mono_win32"
+            },
+            "arm64": {
+                "url": "https://github.com/godotengine/godot-builds/releases/download/$version/Godot_v$version_mono_windows_arm64.zip",
+                "extract_dir": "Godot_v$version_mono_windows_arm64"
             }
         },
         "hash": {


### PR DESCRIPTION
### Changes
This PR makes the following changes:
- godot(-mono)-beta@4.5-beta7: Add arm64 support, update bin & checkver.

<!-- Provide a general summary of your changes in the title above -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->