### PR TITLE
python314: Add version 3.14.0

### DIFF
--- a/bucket/python314.json
+++ b/bucket/python314.json
@@ -83,7 +83,6 @@
             "idle3"
         ],
         [
-        [
             "Lib\\idlelib\\idle.bat",
             "idle314"
         ]


### PR DESCRIPTION
Add Python 3.14.0 configuration with installer scripts and paths.

- [ ] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Python 3.14 package for 64-bit, 32-bit, and ARM64.
  * Bootstraps pip after installation and performs post-install setup for immediate use.
  * Installs command shims (python, python3, idle) and desktop shortcuts.
  * Persists Scripts and site-packages across updates.
  * Optionally updates PATHEXT for global installs and restores it on uninstall.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->