### PR TITLE
winsw-pre : Add version 3.0.0-alpha.11

### DIFF
--- a/bucket/winsw-pre.json
+++ b/bucket/winsw-pre.json
@@ -1,6 +1,6 @@
 {
     "version": "3.0.0-alpha.11",
-    "description": "A wrapper executable that can be used to host any executable as a Windows service (Preview version)",
+    "description": "A wrapper executable that can be used to host any executable as a Windows service (Pre-release version).",
     "homepage": "https://github.com/winsw/winsw",
     "license": "MIT",
     "architecture": {
@@ -15,9 +15,9 @@
     },
     "bin": "WinSW.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/winsw/winsw/tags",
-        "jsonpath": "$[?(@.name =~ /^v[\\d.]+-(?:alpha|beta|rc)[\\d.]+$/)].name",
-        "regex": "v([\\d.-]+(?:alpha|beta|rc)[\\d.]+)"
+        "url": "https://api.github.com/repos/winsw/winsw/releases",
+        "jsonpath": "$[?(@.prerelease == true)].tag_name",
+        "regex": "v(?<version>[\\w-.]+)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2442

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pre-release Windows Service Wrapper package for 64-bit and 32-bit systems.
  * Enables automatic version checks and auto-update using the project's releases, including prerelease channels.
  * Provides architecture-specific packaged executables for streamlined installation and upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->