### PR TITLE
nodejs24: Add version 24.10.0

### DIFF
--- a/bucket/nodejs24.json
+++ b/bucket/nodejs24.json
@@ -1,0 +1,49 @@
+{
+    "version": "24.10.0",
+    "description": "An asynchronous event driven JavaScript runtime designed to build scalable network applications.",
+    "homepage": "https://nodejs.org",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://nodejs.org/dist/v24.10.0/node-v24.10.0-win-x64.7z",
+            "hash": "36b3dffd682813134698103842d52cdaf2d56ddedbf3a48e430812126a275f85",
+            "extract_dir": "node-v24.10.0-win-x64"
+        },
+        "arm64": {
+            "url": "https://nodejs.org/dist/v24.10.0/node-v24.10.0-win-arm64.7z",
+            "hash": "eecfbb713407222f89d70e60dd92503705380c2406dfe195f29bd8455c46baa0",
+            "extract_dir": "node-v24.10.0-win-arm64"
+        }
+    },
+    "persist": [
+        "bin",
+        "cache"
+    ],
+    "env_add_path": [
+        "bin",
+        "."
+    ],
+    "post_install": [
+        "# Set npm prefix to install modules inside bin and npm cache so they persist",
+        "Set-Content -Value \"prefix=$persist_dir\\bin`ncache=$persist_dir\\cache\" -Path \"$dir\\node_modules\\npm\\npmrc\""
+    ],
+    "checkver": {
+        "url": "https://nodejs.org/dist/latest-v24.x/",
+        "regex": "node-v([\\d.]+)-win-x64\\.7z"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-x64.7z",
+                "extract_dir": "node-v$version-win-x64"
+            },
+            "arm64": {
+                "url": "https://nodejs.org/dist/v$version/node-v$version-win-arm64.7z",
+                "extract_dir": "node-v$version-win-arm64"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHASUMS256.txt.asc"
+        }
+    }
+}


### PR DESCRIPTION
It's this time of the year when Node.js odd version becomes current and the latest even version has not yet been promoted to LTS, hence this PR.

Closes #2523

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Node.js 24.10.0 on Windows (64-bit and arm64 architectures)
  * Automatic version checking and updates enabled for Node.js 24.x builds on Windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->