### PR TITLE
git-flow-next-pre: Add version 0.1.1

### DIFF
--- a/bucket/git-flow-next-pre.json
+++ b/bucket/git-flow-next-pre.json
@@ -1,50 +1,28 @@
 {
     "version": "0.1.1",
-    "description": "A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh.",
+    "description": "A modern reimplementation of git-flow in Go that offers greater flexibility while maintaining backward compatibility with the original git-flow and git-flow-avh. (Pre-release)",
     "homepage": "https://github.com/gittower/git-flow-next",
     "license": "BSD-2-Clause",
     "architecture": {
         "64bit": {
             "url": "https://github.com/gittower/git-flow-next/releases/download/v0.1.1/git-flow-next-v0.1.1-windows-amd64.zip",
-            "hash": "ac527e9a0e5dbbd5682ed44a0aace9f57617d7ea54bf563d538040306ce2a254",
-            "bin": [
-                [
-                    "git-flow-v0.1.1-windows-amd64.exe",
-                    "git-flow"
-                ]
-            ]
+            "hash": "ac527e9a0e5dbbd5682ed44a0aace9f57617d7ea54bf563d538040306ce2a254"
         },
         "32bit": {
             "url": "https://github.com/gittower/git-flow-next/releases/download/v0.1.1/git-flow-next-v0.1.1-windows-386.zip",
-            "hash": "8fb28620444262607cd574d57f48a929341acc34374b53dfdc9355d1461c7644",
-            "bin": [
-                [
-                    "git-flow-v0.1.1-windows-386.exe",
-                    "git-flow"
-                ]
-            ]
+            "hash": "8fb28620444262607cd574d57f48a929341acc34374b53dfdc9355d1461c7644"
         }
     },
+    "pre_install": "Get-ChildItem \"$dir\\git-flow*.exe\" | Select-Object -First 1 | Rename-Item -NewName 'git-flow.exe'",
+    "bin": "git-flow.exe",
     "checkver": "github",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-amd64.zip",
-                "bin": [
-                    [
-                        "git-flow-v$version-windows-amd64.exe",
-                        "git-flow"
-                    ]
-                ]
+                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-amd64.zip"
             },
             "32bit": {
-                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-386.zip",
-                "bin": [
-                    [
-                        "git-flow-v$version-windows-386.exe",
-                        "git-flow"
-                    ]
-                ]
+                "url": "https://github.com/gittower/git-flow-next/releases/download/v$version/git-flow-next-v$version-windows-386.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

Closes #2529 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows installer distribution manifest for version 0.1.1, providing separate 64-bit and 32-bit installers with integrity-checked downloads, a pre-install step, centralized checksum verification, and automatic update mapping to streamline installations and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->