### PR TITLE
goneovim-nightly: Update to version 20251024, add arm64 support, fix checkver & autoupdate

### DIFF
--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "20251019",
+    "version": "20251024",
     "description": "Neovim GUI which uses a Golang Qt backend",
     "homepage": "https://github.com/akiyosi/goneovim",
     "license": "MIT",
@@ -8,11 +8,16 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows.zip",
-            "hash": "38dcf3f388d7297baa69739ed5188f2620c06f364ffc6cbf5e9cf2fb2e2c6991"
+            "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows-x86_64.zip",
+            "hash": "ffbfe2303b1d06fb6cc478b8ffadbc64f726f0d4585673550fde33ac87f70205",
+            "extract_dir": "goneovim-windows-x86_64"
+        },
+        "arm64": {
+            "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows-arm64.zip",
+            "hash": "37a83ee185f76d325424eb4440935c6748dc67c4471d96a8a4e832cca6d9a218",
+            "extract_dir": "goneovim-windows-arm64"
         }
     },
-    "extract_dir": "goneovim-windows",
     "bin": "goneovim.exe",
     "shortcuts": [
         [
@@ -22,14 +27,17 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repositories/107124394/releases/tags/nightly",
-        "jsonpath": "$.assets[?(@.name=='goneovim-windows.zip')].updated_at",
+        "jsonpath": "$.assets[?(@.name =~ /goneovim-windows-(x86_64|arm64).zip/)].updated_at",
         "regex": ".*(?<year>\\d{4})\\D(?<month>\\d{2})\\D(?<day>\\d{2}).*",
         "replace": "${year}${month}${day}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows.zip"
+                "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/akiyosi/goneovim/releases/download/nightly/goneovim-windows-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
The archive name for goneovim-nightly has been changed, so I will fix it. Also, an arm64 version has been added, so I will add it to the manifest.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
Closes #2540 

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced native ARM64 Windows architecture support in nightly builds, enabling users on ARM-based Windows systems to access the latest nightly releases.

* **Chores**
  * Updated to latest nightly version (20251024).
  * Enhanced Windows package distribution configuration for improved architecture-specific support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->