### PR TITLE
helium-pre@0.5.8.1: Update description, fix license

### DIFF
--- a/bucket/helium-pre.json
+++ b/bucket/helium-pre.json
@@ -2,7 +2,7 @@
     "version": "0.5.8.1",
     "description": "The Chromium-based web browser made for people, with love. Best privacy by default, unbiased ad-blocking, no bloat and no noise. (Pre-release)",
     "homepage": "https://helium.computer",
-    "license": "BSD-3-Clause, GPL-3.0",
+    "license": "BSD-3-Clause, GPL-3.0-or-later",
     "architecture": {
         "64bit": {
             "url": "https://github.com/imputnet/helium-windows/releases/download/0.5.8.1/helium_0.5.8.1_x64-windows.zip",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
### Summary
[helium browser](https://github.com/imputnet/helium) updated its description recently and the project uses gpl3 for its code and bsd3 clause license for ungoogled chromium's code.

<img width="604" height="370" alt="image" src="https://github.com/user-attachments/assets/262622c3-566e-4c48-b6c6-ee7ce31eceb6" />
<br><br>
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated product description to emphasize a people-first Chromium-based browser with privacy-by-default, unbiased ad-blocking, minimal bloat and noise (pre-release).

* **Chores**
  * Clarified licensing text to list BSD-3-Clause and GPL-3.0-or-later terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->