### PR TITLE
olive-editor: Add version 0.2.0-nightly

### DIFF
--- a/bucket/olive-editor.json
+++ b/bucket/olive-editor.json
@@ -1,0 +1,49 @@
+{
+    "version": "0.2.0-nightly",
+    "description": "Non-linear video editor aiming to provide a fully-featured alternative to high-end professional video editing software.",
+    "homepage": "https://olivevideoeditor.org",
+    "license": "GPL-3.0-only",
+    "suggest": {
+        "vcredist2022": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/olive-editor/olive/releases/download/0.2.0-nightly/Olive-8ac191ce-Windows-x86_64-Portable.zip",
+            "hash": "b0ed9c8291093c29b01090ec49198af001c9d881c35f49ccf0f5030df994c4a5"
+        }
+    },
+    "extract_dir": "olive-editor",
+    "pre_install": [
+        "$ConfigFile = [string] [System.IO.Path]::Join($dir, 'config.xml')",
+        "if (-not [System.IO.File]::Exists($ConfigFile)) {",
+        "    $null = New-Item -Path $ConfigFile -ItemType File",
+        "    '<?xml version=\"1.0\" encoding=\"UTF-8\"?>', '<Configuration>', '</Configuration>' | ForEach-Object -Process {",
+        "        $null = Out-File -Append -FilePath $ConfigFile -Encoding 'UTF8' -InputObject $_",
+        "    }",
+        "}",
+        "$null = Remove-Item -Path \"$dir\\vc_redist.x64.exe\""
+    ],
+    "bin": "olive-editor.exe",
+    "shortcuts": [
+        [
+            "olive-editor.exe",
+            "Olive Editor"
+        ]
+    ],
+    "persist": "config.xml",
+    "checkver": {
+        "script": [
+            "$Releases = [PSCustomObject[]](Invoke-RestMethod -Method 'Get' -Uri 'https://api.github.com/repos/olive-editor/olive/releases')",
+            "$Latest = [PSCustomObject]($Releases.Where{$_.'prerelease'}[0])",
+            "$Latest.'tag_name', $Latest.'tag_name', $Latest.'assets'.'Name'.Where{$_.Endswith('Windows-x86_64-Portable.zip')}[0] -join '|'"
+        ],
+        "regex": "(?<version>.+)\\|(?<tagname>.+)\\|(?<filename>.+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/olive-editor/olive/releases/download/$matchTagname/$matchFilename"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Relates to:

* <https://github.com/ScoopInstaller/Extras/issues/16379>
* <https://github.com/ScoopInstaller/Extras/pull/16534>

Changes to manifest vs. what's in Extras:

* Changed download links to GitHub as homepage is down
* Fixed checkver and autoupdate logic and tried to make it more robust
* Changed to using new portable version, two less files must be persisted
* Fixed config.xml by adding minimum content for the app not to throw an error message at first start
* Added vcredist2022 to suggest, delete the vcredist2022 installer included in the ZIP

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package manifest configuration for Olive Editor enabling automated distribution and updates for Windows 64-bit systems. Includes dependency specifications, installation procedures, and version management integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->