### PR TITLE
pragtical-rolling: Add version 20251112-8a82035-449

### DIFF
--- a/bucket/pragtical-rolling.json
+++ b/bucket/pragtical-rolling.json
@@ -1,0 +1,39 @@
+{
+    "version": "20251112-8a82035-449",
+    "description": "The practical and pragmatic code editor (rolling release).",
+    "homepage": "https://pragtical.dev/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/pragtical/pragtical/releases/download/rolling/pragtical-rolling-windows-x86_64.zip",
+            "hash": "d07ad2dbc5342ba507ba11273b519fd2b5f87a5b9166448fbb4b1157d994889b"
+        }
+    },
+    "extract_dir": "pragtical",
+    "bin": "pragtical.exe",
+    "shortcuts": [
+        [
+            "pragtical.exe",
+            "Pragtical"
+        ]
+    ],
+    "persist": "user",
+    "checkver": {
+        "url": "https://api.github.com/repos/pragtical/pragtical/actions/workflows/rolling.yml/runs?branch=master&status=success",
+        "script": [
+            "$sha = json_path $page $.workflow_runs[0].head_sha",
+            "$runId = json_path $page $.workflow_runs[0].run_number",
+            "$date = json_path $page $.workflow_runs[0].created_at",
+            "Write-Output \"$runId $date $sha\""
+        ],
+        "regex": "^(?<runId>[^ ]+) (?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[^ ]+ (?<hash>.{7})(?<rest>.*)$",
+        "replace": "${year}${month}${day}-${hash}-${runId}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/pragtical/pragtical/releases/download/rolling/pragtical-rolling-windows-x86_64.zip"
+            }
+        }
+    }
+}

--- a/bucket/pragtical-rolling.json
+++ b/bucket/pragtical-rolling.json
@@ -21,12 +21,14 @@
     "checkver": {
         "url": "https://api.github.com/repos/pragtical/pragtical/actions/workflows/rolling.yml/runs?branch=master&status=success",
         "script": [
-            "$sha = json_path $page $.workflow_runs[0].head_sha",
-            "$runId = json_path $page $.workflow_runs[0].run_number",
-            "$date = json_path $page $.workflow_runs[0].created_at",
-            "Write-Output \"$runId $date $sha\""
+            "$content = ConvertFrom-Json $page",
+            "if ((-not $content) -or (-not $content.workflow_runs) -or ($content.workflow_runs.Count -eq 0)) {",
+            "    return $null",
+            "}",
+            "$release = $content.workflow_runs[0]",
+            "Write-Output \"$($release.run_number) $($release.created_at | Get-Date -Format 'yyyy-MM-dd') $($release.head_sha)\""
         ],
-        "regex": "^(?<runId>[^ ]+) (?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[^ ]+ (?<hash>.{7})(?<rest>.*)$",
+        "regex": "^(?<runId>\\d+) (?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}) (?<hash>.{7})(?<rest>.*)$",
         "replace": "${year}${month}${day}-${hash}-${runId}"
     },
     "autoupdate": {


### PR DESCRIPTION
Add the rolling version of [extras/pragtical](https://github.com/ScoopInstaller/Extras/blob/master/bucket/pragtical.json).

Closes #2579

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) 

Thoroughly tested for months in my own bucket, see https://github.com/Vinfall/sb/commits/main/bucket/pragtical-rolling.json.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a rolling-release channel for Pragtical on Windows x86_64.
  * Automatic update support so opted-in users receive latest development builds.
  * Enhanced version reporting that includes build identifier and timestamp for clearer tracking.
  * Installer now delivers the executable, creates shortcuts, and preserves user data across updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->