### PR TITLE
dotnet10-sdk: Add version 10.0.100

### DIFF
--- a/bucket/dotnet10-sdk.json
+++ b/bucket/dotnet10-sdk.json
@@ -1,0 +1,51 @@
+{
+    "version": "10.0.100",
+    "description": ".NET is a free, cross-platform, open source developer platform for building many different types of applications.",
+    "homepage": "https://www.microsoft.com/net/",
+    "license": "MIT",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x64.zip",
+            "hash": "sha512:24b033418a3969effd49b4651ef7ebbffeb284773b99545d78dce61a82e57f38db7facdb013c609ba15573c072f0e093363ae470824a6847f3c6111078c1fb64"
+        },
+        "32bit": {
+            "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-win-x86.zip",
+            "hash": "sha512:78988da917520400c4a6ebd3cb166d3c6e7fcb6b34a10c4c9b95114d813ce34f190ea142a54e56462699c193a90482a64ac31b79dfb009205be0eb7676055e9a"
+        },
+        "arm64": {
+            "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/10.0.100/dotnet-sdk-10.0.100-win-arm64.zip",
+            "hash": "sha512:3d03d6ff062f77698fb61661985fe2d44070be313f2d52640ab7d9c4dac742365a4fe74eece66fd51a03b9fd9ae077648d638641d82c2432c5ea06ea676259af"
+        }
+    },
+    "env_add_path": ".",
+    "env_set": {
+        "DOTNET_ROOT": "$dir",
+        "MSBuildSDKsPath": "$dir\\sdk\\$version\\Sdks"
+    },
+    "pre_uninstall": "info 'If the uninstall fails with a message saying that access is denied, you may need to log out of your current account, log back in and try again.'",
+    "checkver": {
+        "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json",
+        "jsonpath": "$..releases-index[?(@.channel-version == '10.0')].latest-sdk",
+        "regex": "([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x64.zip"
+            },
+            "32bit": {
+                "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-x86.zip"
+            },
+            "arm64": {
+                "url": "https://dotnetcli.azureedge.net/dotnet/Sdk/$version/dotnet-sdk-$version-win-arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/$majorVersion.$minorVersion/releases.json",
+            "regex": "(?s)$basename.*?$sha512"
+        }
+    }
+}


### PR DESCRIPTION
### Changes
~~We'll hold off on any changes until the discussion(https://github.com/ScoopInstaller/Extras/issues/16577) has concluded.~~

[.NET 10](https://dotnet.microsoft.com/en-us/download) was released on November 11, 2025. This PR makes the following changes:
- dotnet10-sdk: Add version 10.0.100.

<!-- Provide a general summary of your changes in the title above -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added .NET 10 SDK installer with multi-architecture support and automatic environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->