### PR TITLE
zed-nightly@2025-11-13: Fix extraction, switch shim to the CLI binary

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -11,7 +11,6 @@
     },
     "extract_dir": "zed",
     "bin": "bin\\zed.exe",
-    "bin": "zed.exe",
     "shortcuts": [
         [
             "zed.exe",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

The .zip file's structure has changed and `zed.exe` is now in a `zed` directory in the .zip file.

Relates to:
- #2583

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated manifest to include a top-level extraction directory setting and an additional binary path entry.
  * Manifest now lists both the original executable reference and an alternate path under the extraction directory.
  * This configuration change alters how setup/extraction details are declared and may affect tools that read the manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->