### PR TITLE
cherry-studio-pre: Update to version 1.7.0-rc.1, add arm64 support, switch to portable release

### DIFF
--- a/bucket/cherry-studio-pre.json
+++ b/bucket/cherry-studio-pre.json
@@ -1,22 +1,22 @@
 {
-    "version": "1.7.0-beta.6",
+    "version": "1.7.0-rc.1",
     "description": "A desktop client that supports for multiple LLM providers (Pre-release).",
     "homepage": "https://cherry-ai.com",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.7.0-beta.6/Cherry-Studio-1.7.0-beta.6-x64-portable.exe#/Cherry-Studio.exe",
-            "hash": "bb38111d48d353f7634c77c62fb2748690c553862f9fa9254cfca0475f3d2156"
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.7.0-rc.1/Cherry-Studio-1.7.0-rc.1-x64-portable.exe#/Cherry-Studio.exe",
+            "hash": "4fece2600993c275493db236edb1c6856948d7f535de96e59acb067559bd143e"
         },
         "arm64": {
-            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.7.0-beta.6/Cherry-Studio-1.7.0-beta.6-arm64-portable.exe#/Cherry-Studio.exe",
-            "hash": "693057693f4961521e68a18e65bfc48b64de681686f102c278c7afc094524117"
+            "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v1.7.0-rc.1/Cherry-Studio-1.7.0-rc.1-arm64-portable.exe#/Cherry-Studio.exe",
+            "hash": "ab9ee5d6cbb48487cb795316aa5e155c2bc66a29fcf0be25affac8c00689f487"
         }
     },
     "shortcuts": [
         [
             "Cherry-Studio.exe",
-            "Cherry Studio Preview"
+            "Cherry Studio (Preview)"
         ]
     ],
     "persist": "data",
@@ -28,18 +28,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-x64-portable.exe#/Cherry-Studio.exe",
-                "hash": {
-                    "url": "$baseurl/beta.yml",
-                    "regex": "url: Cherry-Studio-$version-x64-portable\\.exe\\s+sha512: $base64"
-                }
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-x64-portable.exe#/Cherry-Studio.exe"
             },
             "arm64": {
-                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-arm64-portable.exe#/Cherry-Studio.exe",
-                "hash": {
-                    "url": "$baseurl/beta.yml",
-                    "regex": "url: Cherry-Studio-$version-arm64-portable\\.exe\\s+sha512: $base64"
-                }
+                "url": "https://github.com/CherryHQ/cherry-studio/releases/download/v$version/Cherry-Studio-$version-arm64-portable.exe#/Cherry-Studio.exe"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

---

- Correctly fetch pre-release assets
- Rename shortcut to avoid naming conflicts
- Ensure full portability by no longer copying files from `$Env:AppData\CherryStudio`
- Add support for the arm64 architecture

close #2586 

Note: Hash retrieval is dependent on the implementation of CherryHQ/cherry-studio#11288 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 portable build for broader hardware support

* **Updates**
  * Version bumped to 1.7.0-rc.1
  * Distribution switched to portable executables for both x64 and arm64
  * Shortcut name changed to "Cherry-Studio.exe" with display "Cherry Studio (Preview)"
  * Update-checking refined to target prerelease tags for release candidates

* **Removals**
  * Removed automated install/uninstall steps (no post-install or pre-uninstall actions)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->