### PR TITLE
ffmpeg(-shared)-yt-dlp-nightly: Add version 20251116-121761-g643e2e10f9

### DIFF
--- a/bucket/ffmpeg-shared-yt-dlp-nightly.json
+++ b/bucket/ffmpeg-shared-yt-dlp-nightly.json
@@ -1,0 +1,56 @@
+{
+    "version": "20251116-121761-g643e2e10f9",
+    "description": "FFmpeg nightly build (shared) for yt-dlp.",
+    "homepage": "https://github.com/yt-dlp/FFmpeg-Builds",
+    "license": "MIT",
+    "suggest": {
+        "yt-dlp": "yt-dlp"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-win64-gpl-shared.zip",
+            "hash": "dd97aff2b4f26c74a69fc2a8084a09c9c5d84875d0c9f5c230ce20ae02588437",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-win64-gpl-shared"
+        },
+        "32bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-win32-gpl-shared.zip",
+            "hash": "202bb3589720fb064356ba8b468bd2fcf4c54d8ff42ae993d8aec5938acd93cb",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-win32-gpl-shared"
+        },
+        "arm64": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-winarm64-gpl-shared.zip",
+            "hash": "7d495383ab38ea8fbaf723d81bf08723d69a9b398a764cf3d233cfa439f4c1fe",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-winarm64-gpl-shared"
+        }
+    },
+    "bin": [
+        "bin\\ffmpeg.exe",
+        "bin\\ffplay.exe",
+        "bin\\ffprobe.exe"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repositories/377430603/releases",
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl-shared\\.zip/i)].browser_download_url",
+        "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl-shared\\.zip",
+        "replace": "${year}${month}${day}-${commitnum}-g${commithash}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-win64-gpl-shared.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-win64-gpl-shared"
+            },
+            "32bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-win32-gpl-shared.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-win32-gpl-shared"
+            },
+            "arm64": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-winarm64-gpl-shared.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-winarm64-gpl-shared"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.sha256"
+        }
+    }
+}

--- a/bucket/ffmpeg-yt-dlp-nightly.json
+++ b/bucket/ffmpeg-yt-dlp-nightly.json
@@ -1,0 +1,56 @@
+{
+    "version": "20251116-121761-g643e2e10f9",
+    "description": "FFmpeg nightly build for yt-dlp.",
+    "homepage": "https://github.com/yt-dlp/FFmpeg-Builds",
+    "license": "MIT",
+    "suggest": {
+        "yt-dlp": "yt-dlp"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-win64-gpl.zip",
+            "hash": "5fe6626ba2edef1389fc84d0561542347ea6ccd90f283acfa985ea6d1fcc5dc3",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-win64-gpl"
+        },
+        "32bit": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-win32-gpl.zip",
+            "hash": "b4ab8a03925ab1c0d87d7c72859b0ce8d461e8828a851d3326cb256b31e16fef",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-win32-gpl"
+        },
+        "arm64": {
+            "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-11-16-14-11/ffmpeg-N-121761-g643e2e10f9-winarm64-gpl.zip",
+            "hash": "6ec3af862318ad8230480f8728412b57464a1cf65d90e0ba1dae5467a6267700",
+            "extract_dir": "ffmpeg-N-121761-g643e2e10f9-winarm64-gpl"
+        }
+    },
+    "bin": [
+        "bin\\ffmpeg.exe",
+        "bin\\ffplay.exe",
+        "bin\\ffprobe.exe"
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repositories/377430603/releases",
+        "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl\\.zip/i)].browser_download_url",
+        "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl\\.zip",
+        "replace": "${year}${month}${day}-${commitnum}-g${commithash}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-win64-gpl.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-win64-gpl"
+            },
+            "32bit": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-win32-gpl.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-win32-gpl"
+            },
+            "arm64": {
+                "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-$matchBuildtime/ffmpeg-N-$matchCommitnum-g$matchCommithash-winarm64-gpl.zip",
+                "extract_dir": "ffmpeg-N-$matchCommitnum-g$matchCommithash-winarm64-gpl"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.sha256"
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Relates to: https://github.com/yt-dlp/FFmpeg-Builds/issues/72
- Relates to: #2478
- Closes: #2572
- Relates to: #2595

The upstream no longer provides stable releases, and the binaries for the last stable release have been removed.

### Changes
This PR makes the following changes:
- `ffmpeg(-shared)-yt-dlp-nightly`: Add version 20251116-121761-g643e2e10f9

<!-- Provide a general summary of your changes in the title above -->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FFmpeg nightly build packages for yt-dlp with automatic version checking and updates from GitHub.
  * Support for multiple architectures: 64-bit, 32-bit, and ARM64.
  * Provides both standalone and shared FFmpeg package variants.
  * Nightly builds include ffmpeg, ffplay, and ffprobe utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->