### PR TITLE
prismlauncher-git: Switch to MinGW builds, add arm64 support

### DIFF
--- a/bucket/prismlauncher-git.json
+++ b/bucket/prismlauncher-git.json
@@ -14,6 +14,10 @@
         "64bit": {
             "url": "https://nightly.link/PrismLauncher/PrismLauncher/workflows/build/develop/PrismLauncher-Windows-MinGW-w64-Portable-92738fe-Debug.zip",
             "hash": "07c4110b07154e974f2ba1d6c31ec508de9cabe5971ee15492e2f1b4de556fb6"
+        },
+        "arm64": {
+            "url": "https://nightly.link/PrismLauncher/PrismLauncher/workflows/build/develop/PrismLauncher-Windows-MinGW-arm64-Portable-92738fe-Debug.zip",
+            "hash": "073daab856f0800e0a35402b2f9c060ca5b7693b0d7916008f78f9c66d2b9bab"
         }
     },
     "post_install": [
@@ -51,6 +55,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://nightly.link/PrismLauncher/PrismLauncher/workflows/build/develop/PrismLauncher-Windows-MinGW-w64-Portable-$matchSha-Debug.zip"
+            },
+            "arm64": {
+                "url": "https://nightly.link/PrismLauncher/PrismLauncher/workflows/build/develop/PrismLauncher-Windows-MinGW-arm64-Portable-$matchSha-Debug.zip"
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Closes: #2625
- Relates to: #856
- Relates to: #2551

The MSVC builds suffer from compatibility issues. 

### Changes
This PR makes the following changes:
- `prismlauncher-git`: Switch to MinGW builds, add arm64 support.

<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Windows ARM64 architecture support, enabling downloads and auto-updates for ARM64-based systems.

* **Chores**
  * Updated download URLs for Windows 64-bit distributions.
  * Refreshed auto-update configurations to support new architecture variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->