### PR TITLE
php84-xdebug@3.5.0-8.4: Switch to Github release

### DIFF
--- a/bucket/php84-xdebug.json
+++ b/bucket/php84-xdebug.json
@@ -17,7 +17,7 @@
         }
     },
     "post_install": [
-        "Rename-Item -Path \"$dir\\php_xdebug-3.5.0-8.4-ts-vs17-x86_64.dll\" -NewName \"php_xdebug.dll\" -Force",
+        "Rename-Item -Path (Get-ChildItem -Path $dir -Filter 'php_xdebug-*-ts-vs17-x86_64.dll' | Select-Object -First 1).FullName -NewName 'php_xdebug.dll' -Force",
         "Remove-Item \"$dir\\*\" -Exclude *.dll -Recurse -Force",
         "$phpconfd = \"$persist_dir\\..\\php84\\cli\\conf.d\"",
         "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",


### PR DESCRIPTION
https://xdebug.org was down for quite a while today.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched PHP 8.4 Xdebug distribution from the historical site to GitHub Releases.
  * Migrated package format from a single DLL artifact to ZIP archives; updated checksums and update-detection logic.
  * Adjusted install behavior to extract the correct DLL from the ZIP and remove extraneous files for compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->