### PR TITLE
geogebra5: Add file associations, fix checkver

### DIFF
--- a/bucket/geogebra5.json
+++ b/bucket/geogebra5.json
@@ -1,14 +1,26 @@
 {
     "version": "5.2.909.9",
     "description": "A dynamic mathematics software for education that brings together geometry, algebra, spreadsheets, graphing, statistics and calculus.",
-    "homepage": "https://www.geogebra.org/",
+    "homepage": "https://www.geogebra.org",
     "license": {
         "identifier": "Freeware",
         "url": "https://www.geogebra.org/license"
     },
+    "notes": [
+        "To register file associations, please execute the following command:",
+        "reg import \"$dir\\install-associations.reg\""
+    ],
     "url": "https://download.geogebra.org/installers/5.2/GeoGebra-Windows-Portable-5-2-909-9.zip",
     "hash": "a3a6b6738e7343edc771501fd38bc3a6816a93fd15760e859317c0dd5d65730d",
     "extract_dir": "GeoGebra 5.2.909.9",
+    "post_install": [
+        "$geogebra_path = $dir -replace '\\\\', '\\\\'",
+        "Get-ChildItem -Path \"$bucketsdir\\$bucket\\scripts\\$app\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding ascii",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE' }",
+        "    $content -replace '{{geogebra_dir}}', $geogebra_path | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
+        "}"
+    ],
     "bin": [
         [
             "GeoGebra.exe",
@@ -21,13 +33,23 @@
             "GeoGebra 5"
         ]
     ],
+    "uninstaller": {
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" *> $null }"
+    },
     "checkver": {
-        "url": "https://download.geogebra.org/installers/5.2/version.txt",
-        "regex": "(\\d+)-(\\d+)-(\\d+)-(\\d+)",
-        "replace": "${1}.${2}.${3}.${4}"
+        "script": [
+            "$name_filter = 'GeoGebra-Windows-Portable-*.zip'",
+            "$release_url = 'https://download.geogebra.org/installers/5.2/'",
+            "$download_page = Invoke-WebRequest -Uri $release_url -UseBasicParsing",
+            "$version_sort = { if ($_.href -match '(?!-)[\\d-]+') { [version]($Matches[0] -replace '-', '.') } }",
+            "$name_list = $download_page.links | Where-Object href -Like $name_filter | Sort-Object $version_sort -Descending | Select-Object -ExpandProperty href",
+            "$latest_version = $name_list[0] -replace '[^\\d]+([\\d-]+).+', '$1' -replace '-', '.'",
+            "Write-Output $latest_version"
+        ],
+        "regex": "([\\d.]+)"
     },
     "autoupdate": {
-        "url": "https://download.geogebra.org/installers/5.2/GeoGebra-Windows-Portable-$dashVersion.zip",
+        "url": "https://download.geogebra.org/installers/$majorVersion.$minorVersion/GeoGebra-Windows-Portable-$dashVersion.zip",
         "extract_dir": "GeoGebra $version"
     }
 }

--- a/scripts/geogebra5/install-associations.reg
+++ b/scripts/geogebra5/install-associations.reg
@@ -1,0 +1,39 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.ggb\OpenWithProgIDs]
+"GeoGebra.File"=hex(0):
+
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File]
+@="GeoGebra File"
+"FriendlyTypeName"="GeoGebra File"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File\DefaultIcon]
+@="\"{{geogebra_dir}}\\GeoGebra.exe\",0"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File\shell]
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File\shell\open]
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File\shell\open\command]
+@="\"{{geogebra_dir}}\\GeoGebra.exe\" \"%1\""
+
+
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\.ggt\OpenWithProgIDs]
+"GeoGebra.Tool"=hex(0):
+
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool]
+@="GeoGebra Tool"
+"FriendlyTypeName"="GeoGebra Tool"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool\DefaultIcon]
+@="\"{{geogebra_dir}}\\GeoGebra.exe\",0"
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool\shell]
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool\shell\open]
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool\shell\open\command]
+@="\"{{geogebra_dir}}\\GeoGebra.exe\" \"%1\""

--- a/scripts/geogebra5/uninstall-associations.reg
+++ b/scripts/geogebra5/uninstall-associations.reg
@@ -1,0 +1,12 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\.ggb\OpenWithProgIDs]
+"GeoGebra.File"=-
+
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.File]
+
+
+[HKEY_CURRENT_USER\SOFTWARE\Classes\.ggt\OpenWithProgIDs]
+"GeoGebra.Tool"=-
+
+[-HKEY_CURRENT_USER\SOFTWARE\Classes\GeoGebra.Tool]


### PR DESCRIPTION
### Summary

Enhances the manifest with automatic version detection, autoupdate support, optional `.ggb` and `.ggt` file association registration.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Extras/pull/16797

### Changes

- Add `notes` explaining how to register file associations
- Introduce registry scripts for registering or unregistering file associations for `.ggb` and `.ggt` files.
- Add `post_install` logic to generate install-specific `.reg` files with resolved paths
- Add `uninstaller` script to cleanly remove file associations
- Refactor `checkver` to dynamically detect the latest portable ZIP from the official download directory

### Notes

- Choose `https://download.geogebra.org/installers/5.2/version.txt` as the `checkver` source only with caution, due to the following drawbacks:
  - Depend on upstream updates, which may not promptly reflect the latest available version.
  - Risk version oscillation, where the detected version flips between several releases. The image below illustrates the auto-update history of `versions/geogebra5`.

> <img width="1846" height="1080" alt="2025-12-16 182618" src="https://github.com/user-attachments/assets/b2c2e86a-8b34-4547-ae0f-72fdeada0303" />

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App geogebra5 -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions\bucket' -f
geogebra5: 5.2.909.9 (scoop version is 5.2.909.9)
Forcing autoupdate!
Autoupdating geogebra5
DEBUG[1765908035] [$updatedProperties] = [url extract_dir hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1765908035] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1765908035] $substitutions.$version                       5.2.909.9
DEBUG[1765908035] $substitutions.$basenameNoExt                 GeoGebra-Windows-Portable-5-2-909-9
DEBUG[1765908035] $substitutions.$baseurl                       https://download.geogebra.org/installers/5.2
DEBUG[1765908035] $substitutions.$majorVersion                  5
DEBUG[1765908035] $substitutions.$buildVersion                  9
DEBUG[1765908035] $substitutions.$basename                      GeoGebra-Windows-Portable-5-2-909-9.zip
DEBUG[1765908035] $substitutions.$cleanVersion                  529099
DEBUG[1765908035] $substitutions.$urlNoExt                      https://download.geogebra.org/installers/5.2/GeoGebra-Windows-Portable-5-2-909-9
DEBUG[1765908035] $substitutions.$dashVersion                   5-2-909-9
DEBUG[1765908035] $substitutions.$minorVersion                  2
DEBUG[1765908035] $substitutions.$matchTail                     .9
DEBUG[1765908035] $substitutions.$patchVersion                  909
DEBUG[1765908035] $substitutions.$url                           https://download.geogebra.org/installers/5.2/GeoGebra-Windows-Portable-5-2-909-9.zip
DEBUG[1765908035] $substitutions.$underscoreVersion             5_2_909_9
DEBUG[1765908035] $substitutions.$matchHead                     5.2.909
DEBUG[1765908035] $substitutions.$dotVersion                    5.2.909.9
DEBUG[1765908035] $substitutions.$match1                        5.2.909.9
DEBUG[1765908035] $substitutions.$preReleaseVersion             5.2.909.9
DEBUG[1765908035] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Downloading GeoGebra-Windows-Portable-5-2-909-9.zip to compute hashes!
Loading GeoGebra-Windows-Portable-5-2-909-9.zip from cache
Computed hash: a3a6b6738e7343edc771501fd38bc3a6816a93fd15760e859317c0dd5d65730d
Writing updated geogebra5 manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> scoop install Unofficial/geogebra5
Installing 'geogebra5' (5.2.909.9) [64bit] from 'Unofficial' bucket
Loading GeoGebra-Windows-Portable-5-2-909-9.zip from cache.
Checking hash of GeoGebra-Windows-Portable-5-2-909-9.zip ... ok.
Extracting GeoGebra-Windows-Portable-5-2-909-9.zip ... done.
Linking D:\Software\Scoop\Local\apps\geogebra5\current => D:\Software\Scoop\Local\apps\geogebra5\5.2.909.9
Creating shim for 'geogebra5'.
Making D:\Software\Scoop\Local\shims\geogebra5.exe a GUI binary.
Creating shortcut for GeoGebra 5 (GeoGebra.exe)
Running post_install script...done.
'geogebra5' (5.2.909.9) was installed successfully!
Notes
-----
To register file associations, please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\geogebra5\current\register-file-associations.reg"`
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds file association support for GeoGebra files (.ggb, .ggt) with install and uninstall steps so files open directly from the file manager.
  * Adds post-install user-facing notes.

* **Changes**
  * Improved update-check and autoupdate behavior for more reliable version detection.
  * Corrected homepage URL (removed trailing slash).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->