### PR TITLE
qbittorrent-nightly: Add file associations

### DIFF
--- a/bucket/qbittorrent-nightly.json
+++ b/bucket/qbittorrent-nightly.json
@@ -6,6 +6,13 @@
         "identifier": "GPL-2.0-only",
         "url": "https://github.com/qbittorrent/qBittorrent/blob/master/COPYING"
     },
+    "notes": [
+        "For file associations, run:",
+        "reg import \"$dir\\install-associations.reg\""
+    ],
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
         "64bit": {
             "url": "https://nightly.link/qbittorrent/qBittorrent/workflows/ci_windows.yaml/master/qBittorrent-CI_Windows-x64_libtorrent-2.0.11.zip",
@@ -36,6 +43,16 @@
         "    }",
         "}"
     ],
+    "post_install": [
+        "'install-associations', 'uninstall-associations' | ForEach-Object {",
+        "    if (Test-Path \"$bucketsdir\\$bucket\\scripts\\$app\\$_.reg\") {",
+        "        $qbitPath = \"$dir\".Replace('\\', '\\\\')",
+        "        $content = (Get-Content \"$bucketsdir\\$bucket\\scripts\\$app\\$_.reg\").Replace('$qbit', $qbitPath)",
+        "        if ($global) { $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE') }",
+        "        Set-Content \"$dir\\$_.reg\" $content -Encoding Ascii -Force",
+        "    }",
+        "}"
+    ],
     "bin": "qbittorrent.exe",
     "shortcuts": [
         [
@@ -44,6 +61,9 @@
         ]
     ],
     "persist": "profile",
+    "uninstaller": {
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }"
+    },
     "checkver": {
         "script": [
             "try {",

--- a/scripts/qbittorrent-nightly/install-associations.reg
+++ b/scripts/qbittorrent-nightly/install-associations.reg
@@ -1,0 +1,50 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\qBittorrent]
+"InstallLocation"="$qbit"
+
+; Register qBittorrent as possible default program for .torrent files and magnet links
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities]
+"ApplicationDescription"="A BitTorrent client in Qt"
+"ApplicationName"="qBittorrent"
+
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities\FileAssociations]
+".torrent"="qBittorrent.File.Torrent"
+
+[HKEY_CURRENT_USER\Software\qBittorrent\Capabilities\UrlAssociations]
+"magnet"="qBittorrent.Url.Magnet"
+
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"qBittorrent"="Software\\qBittorrent\\Capabilities"
+
+; Register qBittorrent ProgIDs
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent]
+@="Torrent File"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent\DefaultIcon]
+@="\"$qbit\\qbittorrent.exe\",1"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet]
+@="Magnet URI"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet\DefaultIcon]
+@="\"$qbit\\qbittorrent.exe\",1"
+
+[HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""
+
+[HKEY_CURRENT_USER\Software\Classes\.torrent]
+"Content Type"="application/x-bittorrent"
+"PerceivedType"="application"
+@="qBittorrent.File.Torrent"
+
+[HKEY_CURRENT_USER\Software\Classes\magnet]
+@="URL:Magnet URI"
+"Content Type"="application/x-magnet"
+"URL Protocol"=""
+
+[HKEY_CURRENT_USER\Software\Classes\magnet\shell\open\command]
+@="\"$qbit\\qbittorrent.exe\" \"%1\""

--- a/scripts/qbittorrent-nightly/uninstall-associations.reg
+++ b/scripts/qbittorrent-nightly/uninstall-associations.reg
@@ -1,0 +1,12 @@
+Windows Registry Editor Version 5.00
+
+[-HKEY_CURRENT_USER\Software\qBittorrent]
+[HKEY_CURRENT_USER\Software\RegisteredApplications]
+"qBittorrent"=-
+[-HKEY_CURRENT_USER\Software\Classes\qBittorrent.File.Torrent]
+[-HKEY_CURRENT_USER\Software\Classes\qBittorrent.Url.Magnet]
+[-HKEY_CURRENT_USER\Software\Classes\.torrent]
+[-HKEY_CURRENT_USER\Software\Classes\magnet]
+
+; Delete associations that Windows Explorer did on its own.
+[-HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.torrent]


### PR DESCRIPTION
### Changes
This PR:
- Add file associations for `qbittorrent-nightly` (synced from https://github.com/ScoopInstaller/Extras/pull/14839).
- Suggest installing vcredist2022 (aka vcredist-v14 / vcredist2015+ ) to avoid startup failure.
> Faulting application name: qbittorrent.exe, version: 0.0.0.0, time stamp: 0x69559bc1
Faulting module name: MSVCP140.dll, version: 14.36.32532.0, time stamp: 0x04a30cf0
Exception code: 0xc0000005
Fault offset: 0x0000000000012f58

### Related PRs/Issues
- Relates to https://github.com/ScoopInstaller/Extras/pull/14839
- Relates to https://github.com/ScoopInstaller/Extras/issues/14838
<!-- -->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally register qBittorrent as the default handler for .torrent files and magnet links during install; installer will remove those associations during uninstall.
  * Installer suggests the Visual C++ Redistributable (vcredist) as an optional dependency.

* **Documentation**
  * Installer includes end-user guidance and an optional command to apply or restore file/URL association settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->