### PR TITLE
gcc-arm-none-eabi10.3: Add version 10.3-2021.10

### DIFF
--- a/bucket/gcc-arm-none-eabi10.3.json
+++ b/bucket/gcc-arm-none-eabi10.3.json
@@ -1,0 +1,22 @@
+{
+    "version": "10.3-2021.10",
+    "description": "Pre-built GNU Toolchain for the Arm Architecture",
+    "homepage": "https://developer.arm.com/downloads/-/gnu-rm",
+    "license": "GPL-3.0-or-later",
+    "url": "https://developer.arm.com/-/media/files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-win32.zip",
+    "hash": "md5:2bc8f0c4c4659f8259c8176223eeafc1",
+    "extract_dir": "gcc-arm-none-eabi-10.3-2021.10",
+    "env_add_path": "bin",
+    "checkver": {
+        "url": "https://developer.arm.com/downloads/-/gnu-rm",
+        "regex": "gcc-arm-none-eabi-(10\\.3-[\\d.]+)-win32.zip"
+    },
+    "autoupdate": {
+        "url": "https://developer.arm.com/-/media/files/downloads/gnu-rm/$version/gcc-arm-none-eabi-$version-win32.zip",
+        "extract_dir": "gcc-arm-none-eabi-$version",
+        "hash": {
+            "url": "https://developer.arm.com/downloads/-/gnu-rm",
+            "find": "gcc-arm-none-eabi-$version-win32.zip.*[\\s]*.*[\\s]*<dd>MD5:\\s?$md5"
+        }
+    }
+}

--- a/bucket/gcc-arm-none-eabi10.3.json
+++ b/bucket/gcc-arm-none-eabi10.3.json
@@ -1,6 +1,6 @@
 {
     "version": "10.3-2021.10",
-    "description": "Pre-built GNU Toolchain for the Arm Architecture",
+    "description": "Pre-built GNU Toolchain for the Arm Architecture (version 10.3).",
     "homepage": "https://developer.arm.com/downloads/-/gnu-rm",
     "license": "GPL-3.0-or-later",
     "url": "https://developer.arm.com/-/media/files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-win32.zip",
@@ -13,10 +13,10 @@
     },
     "autoupdate": {
         "url": "https://developer.arm.com/-/media/files/downloads/gnu-rm/$version/gcc-arm-none-eabi-$version-win32.zip",
-        "extract_dir": "gcc-arm-none-eabi-$version",
         "hash": {
             "url": "https://developer.arm.com/downloads/-/gnu-rm",
             "find": "gcc-arm-none-eabi-$version-win32.zip.*[\\s]*.*[\\s]*<dd>MD5:\\s?$md5"
-        }
+        },
+        "extract_dir": "gcc-arm-none-eabi-$version"
     }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

Add the most widely used stable older version of `gcc-arm-none-eabi`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GNU Arm Embedded Toolchain (v10.3-2021.10) as an installable option.
  * Added automatic update checking for new releases and built-in download integrity verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->