### PR TITLE
processhacker-nightly: Deprecate manifest

### DIFF
--- a/deprecated/processhacker-nightly.json
+++ b/deprecated/processhacker-nightly.json
@@ -1,20 +1,18 @@
 {
-    "##": "The manifest was deprecated after 2026-01-01.",
     "version": "3.0.4953",
     "description": "A powerful, multi-purpose tool that helps you monitor system resources, debug software and detect malware.",
     "homepage": "https://processhacker.sourceforge.io/nightly.php",
     "license": "GPL-3.0-only",
-    "notes": "The program renamed to System Informer, please install 'versions/systeminformer-nightly' instead, this manifest was deprecated after 2026-01-01.",
     "architecture": {
-        "32bit": {
-            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/3.0.4953/processhacker-3.0.4953-bin.zip",
-            "hash": "a5c3eecb80afc94cd28511dbca55b297dbd414ec061d309b1777730bbd8933ea",
-            "extract_dir": "32bit"
-        },
         "64bit": {
             "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/3.0.4953/processhacker-3.0.4953-bin.zip",
             "hash": "a5c3eecb80afc94cd28511dbca55b297dbd414ec061d309b1777730bbd8933ea",
             "extract_dir": "64bit"
+        },
+        "32bit": {
+            "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/3.0.4953/processhacker-3.0.4953-bin.zip",
+            "hash": "a5c3eecb80afc94cd28511dbca55b297dbd414ec061d309b1777730bbd8933ea",
+            "extract_dir": "32bit"
         }
     },
     "post_install": [
@@ -37,5 +35,12 @@
     "persist": [
         "ProcessHacker.exe.settings.xml",
         "usernotesdb.xml"
-    ]
+    ],
+    "checkver": {
+        "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases",
+        "regex": "/tag/([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://github.com/ProcessHackerRepoTool/nightly-builds-mirror/releases/download/$version/processhacker-$version-bin.zip"
+    }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
> Process Hacker has been renamed to System Informer

- Relates to #784
- Closes #2668
- Relates to https://github.com/ScoopInstaller/Extras/pull/16912

<!---->
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * systeminformer-nightly bumped to a new nightly release (3.2.25365.952); download links and checksums updated.

* **Documentation**
  * Added synchronization metadata to systeminformer-nightly.
  * processhacker-nightly marked deprecated with guidance to use systeminformer-nightly (deprecation effective after 2026-01-01).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->