### PR TITLE
raddebugger-alpha: Add version 0.9.24-alpha

### DIFF
--- a/bucket/raddebugger-alpha.json
+++ b/bucket/raddebugger-alpha.json
@@ -14,10 +14,16 @@
         "raddbg.exe",
         "radlink.exe"
     ],
+    "shortcuts": [
+        [
+            "raddbg.exe",
+            "RAD Debugger"
+        ]
+    ],
     "checkver": {
-        "url": "https://api.github.com/repos/EpicGamesExt/raddebugger/releases/latest",
-        "jsonpath": "$.tag_name",
-        "regex": "v(.+)"
+        "url": "https://api.github.com/repos/EpicGamesExt/raddebugger/releases",
+        "jsonpath": "$.[?(@.tag_name =~ /v[\\d.]+-alpha/)].tag_name",
+        "regex": "v([\\d.]+-alpha)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Add the alpha release of raddebugger

Relates to:
- https://github.com/ScoopInstaller/Extras/issues/15611
- https://github.com/ScoopInstaller/Extras/pull/15973
- https://github.com/ScoopInstaller/Extras/issues/17689

---

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added installation manifest for raddebugger alpha package (v0.9.24-alpha) with automatic update detection and start menu integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->