### PR TITLE
fix(zed-nightly): update checkver regex for ISO date format

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2025-12-31",
+    "version": "2026-01-11",
     "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/12-31-2025/zed.zip",
-            "hash": "b0c36ae44bfbd790979cae3a910ce33b678c1b86d6a094b98239c2b2b9cfc438"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-11/zed.zip",
+            "hash": "eec93f96f06c575bc2045c1873d691d4ea66df1924a81459e774747c201a1fc7"
         }
     },
     "extract_dir": "zed",
@@ -19,8 +19,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
-        "regex": "(?<version>(?<month>\\d{2})-(?<day>\\d{2})-(?<year>\\d{4}))",
-        "replace": "${year}-${month}-${day}"
+        "regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
     },
     "autoupdate": {
         "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/zed.zip",

--- a/bucket/zed-opengl-nightly.json
+++ b/bucket/zed-opengl-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2025-12-31",
+    "version": "2026-01-11",
     "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/12-31-2025/zed-opengl.zip",
-            "hash": "369a5580b12c375009c4466d7baa52fa28994f4e8cecd426a211832771b46b93"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-11/zed-opengl.zip",
+            "hash": "342311ac0f398bd9eb0f82750a51cf02cc68e32a5995cc9de44de6da7c2f50f3"
         }
     },
     "extract_dir": "zed",
@@ -19,8 +19,7 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
-        "regex": "(?<version>(?<month>\\d{2})-(?<day>\\d{2})-(?<year>\\d{4}))",
-        "replace": "${year}-${month}-${day}"
+        "regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
     },
     "autoupdate": {
         "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/zed-opengl.zip",


### PR DESCRIPTION
## Summary

- Updates `zed-nightly.json` and `zed-opengl-nightly.json` checkver regex to match new ISO date format (`YYYY-MM-DD`)
- Removes unnecessary `replace` property since tags are now in the format Scoop expects

## Context

The upstream [zed-windows-builds](https://github.com/deevus/zed-windows-builds) repository changed nightly release tags from `MM-DD-YYYY` to `YYYY-MM-DD` format to fix GitHub API sorting issues.

See: https://github.com/deevus/zed-windows-builds/pull/115

## Changes

**Before:**
```json
"regex": "(?<version>(?<month>\\d{2})-(?<day>\\d{2})-(?<year>\\d{4}))",
"replace": "${year}-${month}-${day}"
```

**After:**
```json
"regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
```

## Verification

The first ISO-format release is now live: https://github.com/deevus/zed-windows-builds/releases/tag/2026-01-11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped nightly builds to 2026-01-11.
  * Updated download links and corresponding checksums for the new nightly artifacts.
  * Standardized version/date parsing to a year-first (YYYY-MM-DD) format, removing the prior conversion step.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->