### PR TITLE
fix(zed-nightly): use JSONPath to prevent matching created_at timestamps

### DIFF
--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2026-01-11",
+    "version": "2026-01-13",
     "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-11/zed.zip",
-            "hash": "eec93f96f06c575bc2045c1873d691d4ea66df1924a81459e774747c201a1fc7"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-13/zed.zip",
+            "hash": "2d5782e9917d9979e67fb5fa8644971018acbf7dbec3548179bddb8e67e23370"
         }
     },
     "extract_dir": "zed",
@@ -19,12 +19,13 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
-        "regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
+        "jp": "$[*].tag_name",
+        "regex": "(\\d{4}-\\d{2}-\\d{2})"
     },
     "autoupdate": {
-        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/zed.zip",
+        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed.zip",
         "hash": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/sha256sums.txt"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/sha256sums.txt"
         }
     }
 }

--- a/bucket/zed-opengl-nightly.json
+++ b/bucket/zed-opengl-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2026-01-11",
+    "version": "2026-01-13",
     "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-11/zed-opengl.zip",
-            "hash": "342311ac0f398bd9eb0f82750a51cf02cc68e32a5995cc9de44de6da7c2f50f3"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/2026-01-13/zed-opengl.zip",
+            "hash": "1f80389fc73d89da506d793cb18cb7e5f7eda7032c4554eac3b02aed9f8d68de"
         }
     },
     "extract_dir": "zed",
@@ -19,12 +19,13 @@
     ],
     "checkver": {
         "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
-        "regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
+        "jp": "$[*].tag_name",
+        "regex": "(\\d{4}-\\d{2}-\\d{2})"
     },
     "autoupdate": {
-        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/zed-opengl.zip",
+        "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/zed-opengl.zip",
         "hash": {
-            "url": "https://github.com/deevus/zed-windows-builds/releases/download/$matchVersion/sha256sums.txt"
+            "url": "https://github.com/deevus/zed-windows-builds/releases/download/$version/sha256sums.txt"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds JSONPath `$[*].tag_name` to `checkver` to extract only tag names before regex matching
- Updates both `zed-nightly.json` and `zed-opengl-nightly.json` to version 2026-01-13

## Problem

The previous checkver regex `(?<version>(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2}))` matched **any** `YYYY-MM-DD` pattern in the raw JSON response.

The first match was the `created_at` field of the first release (v0.218.7):
```json
{
  "tag_name": "v0.218.7",
  "created_at": "2026-01-11T01:39:44Z",  ← FIRST MATCH
  ...
}
```

Since all nightly releases tag the same commit, they share identical `created_at` timestamps. This caused version detection to always return `2026-01-11` regardless of which nightly releases actually exist.

Evidence from the commit history:
- 2026-01-12: Updated to version 2026-01-12 ✓
- 2026-01-13: Updated to version **2026-01-11** ✗ (regression!)

## Solution

Add JSONPath to extract only `tag_name` fields before applying regex:

**Before:**
```json
"checkver": {
    "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
    "regex": "(?<version>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2}))"
}
```

**After:**
```json
"checkver": {
    "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases",
    "jp": "$[*].tag_name",
    "regex": "(\\d{4}-\\d{2}-\\d{2})"
}
```

This follows the same pattern used by other manifests like `flux.json` and `vgmstream.json`.

## References

- Root cause analysis: https://github.com/deevus/zed-windows-builds/issues/114
- Previous fix (ISO date format): https://github.com/ScoopInstaller/Versions/pull/2680

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated nightly versions from 2026-01-11 to 2026-01-13.
  * Refreshed download URLs and verification checksums for the updated nightly builds.
  * Improved automatic update templates and enhanced version-detection to better recognize date-formatted releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->