### PR TITLE
geogebra5: Update to version 5.4.913.0, fix checkver

### DIFF
--- a/bucket/geogebra5.json
+++ b/bucket/geogebra5.json
@@ -38,14 +38,13 @@
     },
     "checkver": {
         "script": [
-            "$package_entry_url = 'https://download.geogebra.org/package/win-port'",
-            "$request = [System.Net.HttpWebRequest]::Create($package_entry_url)",
+            "$url = 'https://download.geogebra.org/package/win-port'",
+            "$request = [System.Net.HttpWebRequest]::Create($url)",
             "$response = $request.GetResponse()",
-            "$package_name = $response.ResponseUri.AbsoluteUri -replace '.+(?<=/)([^/]+)$', '$1'",
-            "$latest_version = $package_name -replace '[^\\d]+(5-[\\d-]+).+', '$1' -replace '-', '.'",
-            "Write-Output $latest_version"
+            "$response.ResponseUri.AbsoluteUri -match 'Portable-(?<dashVersion>[\\d-]+)\\.zip'",
+            "Write-Output ($Matches['dashVersion'] -replace '-', '.')"
         ],
-        "regex": "([\\d.]+)"
+        "regex": "(5\\.[\\d.]+)"
     },
     "autoupdate": {
         "url": "https://download.geogebra.org/installers/$majorVersion.$minorVersion/GeoGebra-Windows-Portable-$dashVersion.zip",


### PR DESCRIPTION
### Summary

Updates `geogebra5` to version **5.4.913.0** and modernizes the `checkver` script to use a more robust redirection-tracking logic.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Extras/pull/17052 

### Changes

- Update version to **5.4.913.0**.
- **Optimize `checkver` script**:
    - Replaced the previous web-scraping logic (which was hardcoded to the `/5.2/` directory) with a dynamic `HEAD` request using `System.Net.Http.HttpClient`.
    - The new logic follows the redirect from the generic entry point (`/package/win`) to resolve the actual filename and version string.
    - Added compatibility handling for different PowerShell versions by conditionally loading `System.Net.Http`.

### Notes

- The previous `checkver` was prone to failure when the major/minor version changed (e.g., moving from 5.2 to 5.4). The new implementation is version-agnostic and relies on the official redirection service provided by GeoGebra.
- Using a `HEAD` request instead of a full `GET` request (Invoke-WebRequest) is more efficient as it only retrieves metadata without downloading the entire page content.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App geogebra5 -Dir 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions\bucket' -f
geogebra5: 5.4.913.0 (scoop version is 5.4.913.0)
Forcing autoupdate!
Autoupdating geogebra5
DEBUG[1768856424] [$updatedProperties] = [url extract_dir hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1768856424] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1768856424] $substitutions.$match1                        5.4.913.0
DEBUG[1768856424] $substitutions.$basenameNoExt                 GeoGebra-Windows-Portable-5-4-913-0
DEBUG[1768856424] $substitutions.$buildVersion                  0
DEBUG[1768856424] $substitutions.$baseurl                       https://download.geogebra.org/installers/5.4
DEBUG[1768856424] $substitutions.$patchVersion                  913
DEBUG[1768856424] $substitutions.$dashVersion                   5-4-913-0
DEBUG[1768856424] $substitutions.$majorVersion                  5
DEBUG[1768856424] $substitutions.$dotVersion                    5.4.913.0
DEBUG[1768856424] $substitutions.$url                           https://download.geogebra.org/installers/5.4/GeoGebra-Windows-Portable-5-4-913-0.zip
DEBUG[1768856424] $substitutions.$underscoreVersion             5_4_913_0
DEBUG[1768856424] $substitutions.$version                       5.4.913.0
DEBUG[1768856424] $substitutions.$cleanVersion                  549130
DEBUG[1768856424] $substitutions.$matchHead                     5.4.913
DEBUG[1768856424] $substitutions.$matchTail                     .0
DEBUG[1768856424] $substitutions.$preReleaseVersion             5.4.913.0
DEBUG[1768856424] $substitutions.$minorVersion                  4
DEBUG[1768856424] $substitutions.$basename                      GeoGebra-Windows-Portable-5-4-913-0.zip
DEBUG[1768856424] $substitutions.$urlNoExt                      https://download.geogebra.org/installers/5.4/GeoGebra-Windows-Portable-5-4-913-0
DEBUG[1768856424] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Downloading GeoGebra-Windows-Portable-5-4-913-0.zip to compute hashes!
Loading GeoGebra-Windows-Portable-5-4-913-0.zip from cache
Computed hash: 4d3603433e9c984c5858ddd3a73b645a5e908173c50ea49904b79853ef066efc
Writing updated geogebra5 manifest

┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> scoop install Unofficial/geogebra5
Installing 'geogebra5' (5.4.913.0) [64bit] from 'Unofficial' bucket
Loading GeoGebra-Windows-Portable-5-4-913-0.zip from cache.
Checking hash of GeoGebra-Windows-Portable-5-4-913-0.zip... OK.
Extracting GeoGebra-Windows-Portable-5-4-913-0.zip... Done.
Linking D:\Software\Scoop\Local\apps\geogebra5\current => D:\Software\Scoop\Local\apps\geogebra5\5.4.913.0
Creating shim for 'geogebra5'.
Making D:\Software\Scoop\Local\shims\geogebra5.exe a GUI binary.
Creating shortcut for GeoGebra 5 (GeoGebra.exe)
Running post_install script... Done.
'geogebra5' (5.4.913.0) was installed successfully!
Notes
-----
To register file associations, please execute the following command:
- `reg import "D:\Software\Scoop\Local\apps\geogebra5\current\register-file-associations.reg"`
-----
```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GeoGebra Windows Portable to version 5.4.913.0 with a new installer and updated integrity hash.
  * Improved automatic update detection to follow redirects and more reliably extract the package version for future updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->