### PR TITLE
zed-pre: Add version 0.228.0

### DIFF
--- a/bucket/zed-pre.json
+++ b/bucket/zed-pre.json
@@ -1,6 +1,6 @@
 {
     "version": "0.228.0",
-    "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source.",
+    "description": "Zed is a high-performance, multiplayer code editor from the creators of Atom and Tree-sitter. It's also open source. (Preview version)",
     "homepage": "https://zed.dev/",
     "license": "AGPL-3.0, Apache-2.0, GPL-3.0",
     "notes": "Please manually disable Zed's auto-update feature in the settings to prevent the updater from installing the program in unintended locations.",
@@ -24,7 +24,7 @@
     "shortcuts": [
         [
             "zed.exe",
-            "Zed"
+            "Zed (Preview)"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2701
<!--
Closes #XXXX
or
Relates to #XXXX
-->

Relates to https://github.com/deevus/zed-windows-builds/issues/50 — the current packager for `zed-nightly`.

Since upstream Zed provides official preview builds, I think it seems reasonable to have them here (vs the unofficial `zed-nightly` builds that are currently in this bucket).

As far as I can tell, there is no easy way to install Zed preview versions via scoop currently, so I decided to add it myself.

Upstream still doesn't provide official nightly builds for download, so the current `nightly` packages may still be valuable to some users, but personally I'd prefer to get my builds from the original packager, which this change does. 

Manifest is mostly copied from https://github.com/ScoopInstaller/Extras/blob/master/bucket/zed.json

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-release package now available (v0.228.0) with native 64-bit and ARM64 builds.
  * Installer support and configured shortcuts/executable for easy access.
* **Chores**
  * Enabled prerelease detection and automatic update behavior for streamlined updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->