### PR TITLE
linqpad5: Update download URL

### DIFF
--- a/bucket/linqpad5.json
+++ b/bucket/linqpad5.json
@@ -33,10 +33,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://linqpad.azureedge.net/public/LINQPad5-AnyCPU.zip"
+                "url": "https://cdn.linqpad.net/public/LINQPad5-AnyCPU.zip"
             },
             "32bit": {
-                "url": "https://linqpad.azureedge.net/public/LINQPad5.zip"
+                "url": "https://cdn.linqpad.net/public/LINQPad5.zip"
             }
         }
     }


### PR DESCRIPTION
Updated download URI to canonical CDN prior to the shutdown of azureedge.net.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched download and autoupdate endpoints to a CDN for all architectures to improve reliability and performance.
  * File integrity hashes remain unchanged, so existing installations and updates continue to validate as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->