### PR TITLE
obs-studio-pre: Update to version 32.1.0-rc1, add arm64 support, fix autoupdate

### DIFF
--- a/bucket/obs-studio-pre.json
+++ b/bucket/obs-studio-pre.json
@@ -6,19 +6,25 @@
     "architecture": {
         "arm64": {
             "url": "https://github.com/obsproject/obs-studio/releases/download/32.1.0-rc1/OBS-Studio-32.1.0-rc1-Windows-arm64.zip",
-            "hash": "0e34115c817b972b3df7a76db5f1451bc6c534f66ceae334c0a48230768260ad"
+            "hash": "0e34115c817b972b3df7a76db5f1451bc6c534f66ceae334c0a48230768260ad",
+            "shortcuts": [
+                [
+                    "bin\\64bit\\obs64.exe",
+                    "OBS Studio (Preview)"
+                ]
+            ]
         },
         "64bit": {
             "url": "https://github.com/obsproject/obs-studio/releases/download/32.1.0-rc1/OBS-Studio-32.1.0-rc1-Windows-x64.zip",
-            "hash": "ca0a529ecd59f1e19df12b12bdae2ce4930369ec73ede9b5d9ac82fe9690c685"
+            "hash": "ca0a529ecd59f1e19df12b12bdae2ce4930369ec73ede9b5d9ac82fe9690c685",
+            "shortcuts": [
+                [
+                    "bin\\64bit\\obs64.exe",
+                    "OBS Studio (Preview)"
+                ]
+            ]
         }
     },
-    "shortcuts": [
-        [
-            "bin\\64bit\\obs64.exe",
-            "OBS Studio (Preview)"
-        ]
-    ],
     "pre_install": "if (!(Test-Path \"$persist_dir\\portable_mode.txt\")) { New-Item \"$dir\\portable_mode.txt\" | Out-Null }",
     "persist": [
         "config",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 support for Windows (OBS Studio Preview).

* **Chores**
  * Bumped release to 32.1.0-rc1.
  * Updated Windows x64 installer references to the new versioned paths.
  * Improved update-check behavior to recognize release candidates/beta tags and use the correct versioned download paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->