### PR TITLE
tomcat11: Add version 11.0.18

### DIFF
--- a/bucket/tomcat11.json
+++ b/bucket/tomcat11.json
@@ -1,6 +1,6 @@
 {
     "version": "11.0.18",
-    "description": "Implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologiesv. (version 11)",
+    "description": "Implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies. (version 11)",
     "homepage": "https://tomcat.apache.org",
     "license": "Apache-2.0",
     "suggest": {


### PR DESCRIPTION
## tomcat11: Add Apache Tomcat and 11 manifests

<!--
Relates and closes #2729
-->

This pull request adds new manifest for Apache Tomcat version 11, enabling the installation and management through the package system. The manifest include download URLs, hash verification, environment variable setup, and auto-update support.

**New Tomcat package manifest:**
* Addition of `tomcat11.json` manifest for Apache Tomcat 11, supporting 64-bit architecture, with similar features as above, including auto-update configuration and environment setup

- [x] Use conventional PR title: `tomcat11: Add tomcat11.json configuration for Apache Tomcat 11.0.18`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds support for installing and managing Tomcat 11.0.18 on Windows x64.
  * Includes automatic version detection and autoupdate for Tomcat binaries with verified downloads.
  * Installs runtime environment variables and preserves configuration and webapps across updates; handles extraction and startup script placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->