### PR TITLE
tomcat10: Add version 10.1.52

### DIFF
--- a/bucket/tomcat10.json
+++ b/bucket/tomcat10.json
@@ -1,6 +1,6 @@
 {
     "version": "10.1.52",
-    "description": "Implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies",
+    "description": "Implementation of the Java Servlet, JavaServer Pages, Java Expression Language and Java WebSocket technologies. (version 10)",
     "homepage": "https://tomcat.apache.org",
     "license": "Apache-2.0",
     "suggest": {


### PR DESCRIPTION
## tomcat10: Add Apache Tomcat 10 manifests

<!--
Relates and closes #2729
-->

This pull request adds new manifest for Apache Tomcat versions 10, enabling the installation and management through the package system. The manifest include download URLs, hash verification, environment variable setup, and auto-update support.

**New Tomcat package manifest:**
* Addition of `tomcat10.json` manifest for Apache Tomcat 10, supporting both 32-bit and 64-bit architectures, with versioned download URLs, hash checks, environment variable configuration, and persistence for configuration and webapps directories

- [x] Use conventional PR title: `tomcat10: Add tomcat10.json configuration for Apache Tomcat 10.1.52`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apache Tomcat 10.1.52 is now available for Windows (64-bit and 32-bit). Installer sets up recommended environment variables, preserves configuration and webapps between updates, verifies downloads for integrity, and supports automatic version detection and in-place updates for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->