### PR TITLE
android-studio-(rc|beta|canary): remove beta & add RC & fix Canary

### DIFF
--- a/bucket/android-studio-canary.json
+++ b/bucket/android-studio-canary.json
@@ -1,18 +1,18 @@
 {
-    "version": "2025.2.3.8",
+    "version": "2025.3.3.2",
     "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
     "homepage": "https://developer.android.com/studio/preview",
     "license": {
         "identifier": "Freeware",
-        "url": "https://developer.android.com/studio/terms.html"
+        "url": "https://developer.android.com/studio/terms"
     },
     "suggest": {
         "Android SDK": "android-clt"
     },
     "architecture": {
         "64bit": {
-            "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2025.2.3.8/android-studio-2025.2.3.8-windows.zip",
-            "hash": "cf56f6067bacf805bfa79f799439312c6c8f120b10ab7c1b524090c11bacb361",
+            "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.3.2/android-studio-panda3-canary2-windows.zip",
+            "hash": "072aac84121fed2ed2b3ca5e1a4275444b06b06dc2ff34e94feecf6cb44b4caf",
             "shortcuts": [
                 [
                     "bin\\studio64.exe",
@@ -23,13 +23,11 @@
     },
     "pre_install": "'uninstall.exe' | ForEach-Object { Remove-Item \"$dir/$_\" -Recurse }",
     "extract_dir": "android-studio",
-    "checkver": {
-        "regex": "agree_canary_win_bundle_download[\\s\\S]+?android-studio-([\\d.]+)-windows\\.exe"
-    },
+    "checkver": "/install/(?<version>[\\d.]+)/(?<filename>android-studio.*-canary\\d+-windows)\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip"
+                "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/$version/$matchFilename.zip"
             }
         }
     }

--- a/bucket/android-studio-rc.json
+++ b/bucket/android-studio-rc.json
@@ -1,35 +1,33 @@
 {
-    "version": "2025.2.3.8",
+    "version": "2025.3.2.5",
     "description": "The official IDE for Android development, which includes everything you need to build Android apps.",
     "homepage": "https://developer.android.com/studio/preview",
     "license": {
         "identifier": "Freeware",
-        "url": "https://developer.android.com/studio/terms.html"
+        "url": "https://developer.android.com/studio/terms"
     },
     "suggest": {
         "Android SDK": "android-clt"
     },
     "architecture": {
         "64bit": {
-            "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2025.2.3.8/android-studio-2025.2.3.8-windows.zip",
-            "hash": "cf56f6067bacf805bfa79f799439312c6c8f120b10ab7c1b524090c11bacb361",
+            "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/2025.3.2.5/android-studio-panda2-rc1-windows.zip",
+            "hash": "f23bdbf1d220ec26c8bd79836fad75b4df28eb853470b333012226e244a07937",
             "shortcuts": [
                 [
                     "bin\\studio64.exe",
-                    "Android Studio Beta"
+                    "Android Studio RC"
                 ]
             ]
         }
     },
     "pre_install": "'uninstall.exe' | ForEach-Object { Remove-Item \"$dir/$_\" -Recurse }",
     "extract_dir": "android-studio",
-    "checkver": {
-        "regex": "agree_beta_win_bundle_download[\\s\\S]+?android-studio-([\\d.]+)-windows\\.exe"
-    },
+    "checkver": "/install/(?<version>[\\d.]+)/(?<filename>android-studio.*-rc\\d+-windows)\\.exe",
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://redirector.gvt1.com/edgedl/android/studio/ide-zips/$version/android-studio-$version-windows.zip"
+                "url": "https://edgedl.me.gvt1.com/android/studio/ide-zips/$version/$matchFilename.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->
### Changes

- **Remove**
  - Remove the configuration file `android-studio-beta.json`
  - [Android Studio download archives](https://developer.android.com/studio/archive) no longer have beta versions
- **Add**
  - Add the configuration file `android-studio-rc.json`
  - The beta version has been changed to RC version
- **Fix**
  - Fix checkver & autoupdate
- **Chores**
  - Standardized license URL formatting

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Android Studio Canary updated to 2025.3.3.2 with new download location, updated verification hash, and added "Android Studio Canary" shortcut label.
  * Android Studio RC updated to 2025.3.2.5 with new download location, updated verification hash, and renamed shortcut to "Android Studio RC".
  * License URL paths simplified and automated update/check patterns revised for more reliable version detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->