### PR TITLE
llama.cpp-cu131: Add version b8373

### DIFF
--- a/bucket/llama.cpp-cu131.json
+++ b/bucket/llama.cpp-cu131.json
@@ -1,12 +1,12 @@
 {
-    "version": "b8372",
+    "version": "b8373",
     "description": "Inference of LLaMA model in pure C/C++ (CUDA 13.1 version)",
     "homepage": "https://github.com/ggml-org/llama.cpp",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b8372/llama-b8372-bin-win-cuda-13.1-x64.zip",
-            "hash": "e846e22fa1fdb2fc0316efdd10812770ad6f2bc91fb81d5ebe209e61676da482"
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b8373/llama-b8373-bin-win-cuda-13.1-x64.zip",
+            "hash": "21416340097b0ddb86ed9cd5111dadae84afa0f6350dc53c011b811fd2cc06e1"
         }
     },
     "bin": [


### PR DESCRIPTION
Added CUDA 13.1 version of llama.cpp with autoupdate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Windows x64 package for llama.cpp with CUDA 13.1 (version b8373, MIT licensed).
  * Provides an installable bundle with prebuilt binaries and a persistent "models" directory so models remain cached across updates.
  * Includes automatic version checking and autoupdate support to streamline installation and future upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->