### PR TITLE
bundletool: Add version 1.18.3

### DIFF
--- a/bucket/bundletool.json
+++ b/bucket/bundletool.json
@@ -16,10 +16,6 @@
             "bundletool"
         ]
     ],
-    "persist": [
-        "cfg",
-        "logs"
-    ],
     "checkver": {
         "url": "https://api.github.com/repos/google/bundletool/releases/latest",
         "jsonpath": "$.tag_name"
@@ -29,7 +25,7 @@
         "hash": {
             "mode": "json",
             "url": "https://api.github.com/repos/google/bundletool/releases/latest",
-            "jsonpath": "$.assets[?(@.name.match(/bundletool-all-.*\\.jar/))].digest",
+            "jsonpath": "$.assets[?(@.name == \"bundletool-all-$version.jar\"].digest",
             "regex": "sha256:([a-fA-F0-9]{64})"
         }
     }


### PR DESCRIPTION
Bundletool is a tool to manipulate Android App Bundles and Android SDK Bundles.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `bundletool: Add bundletool.json configuration for bundletool 1.18.3`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a package manifest with auto-update support for bundletool (GitHub release detection and update metadata).
  * Added Windows launcher support with persistent configuration and logs directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->