### PR TITLE
php85: Add version 8.5.4

### DIFF
--- a/bucket/php85.json
+++ b/bucket/php85.json
@@ -1,0 +1,61 @@
+{
+    "version": "8.5.4",
+    "description": "PHP, a popular general-purpose scripting language that is especially suited to web development. (version 8.5)",
+    "homepage": "https://www.php.net",
+    "license": "PHP-3.01",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.4-Win32-vs17-x64.zip",
+            "hash": "4fdf52526a892aaa9c99a4f32ad4b4e18c400134b4a414941f97121a0925d8a3"
+        },
+        "32bit": {
+            "url": "https://downloads.php.net/~windows/releases/archives/php-8.5.4-Win32-vs17-x86.zip",
+            "hash": "760557d90e12bdb8fd67ddf43f318efb10082c4624ca0e6345fa86974bbdf444"
+        }
+    },
+    "pre_install": [
+        "# Create directory for custom PHP configuration",
+        "if (!(Test-Path \"$dir\\cli\\conf.d\")) {",
+        "    (New-Item -Type directory \"$dir\\cli\\conf.d\") | Out-Null",
+        "}"
+    ],
+    "post_install": [
+        "# Enable extensions to be found in installation-relative folder (the default is to search C:/php)",
+        "(Get-Content \"$dir\\cli\\php.ini\") | % { $_ -replace ';\\s?(extension_dir = \"ext\")', '$1' } | Set-Content \"$dir\\cli\\php.ini\""
+    ],
+    "bin": [
+        "php.exe",
+        "php-cgi.exe",
+        "phpdbg.exe"
+    ],
+    "env_set": {
+        "PHP_INI_SCAN_DIR": "$dir\\cli;$dir\\cli\\conf.d;"
+    },
+    "persist": [
+        "cli",
+        [
+            "php.ini-production",
+            "cli\\php.ini"
+        ]
+    ],
+    "checkver": {
+        "url": "https://www.php.net/releases/branches.php",
+        "jsonpath": "$.[?(@.branch == '8.5')].latest"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-Win32-vs17-x64.zip"
+            },
+            "32bit": {
+                "url": "https://downloads.php.net/~windows/releases/archives/php-$version-Win32-vs17-x86.zip"
+            }
+        },
+        "hash": {
+            "url": "https://downloads.php.net/~windows/releases/sha256sum.txt"
+        }
+    }
+}


### PR DESCRIPTION
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PHP 8.5.4 with automated installation and configuration for both 64-bit and 32-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->