### PR TITLE
php(*): Update homepage & download URLs

### DIFF
--- a/bucket/php54.json
+++ b/bucket/php54.json
@@ -1,7 +1,7 @@
 {
     "version": "5.4.45",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 5.4)",
-    "homepage": "https://windows.php.net",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -19,7 +19,7 @@
         "# Enable extensions to be found in installation-relative folder (the default is to search C:/php)",
         "(Get-Content \"$dir\\cli\\php.ini\") | % { $_ -replace ';\\s?(extension_dir = \"ext\")', '$1' } | Set-Content \"$dir\\cli\\php.ini\""
     ],
-    "url": "https://windows.php.net/downloads/releases/archives/php-5.4.45-Win32-VC9-x86.zip",
+    "url": "https://downloads.php.net/~windows/releases/archives/php-5.4.45-Win32-VC9-x86.zip",
     "hash": "38cde4bac05e916fb0c0b78a2e5bfeec9b02b4b6fc51c9a02a66e4fc1e1a1d08",
     "bin": [
         "php.exe",

--- a/bucket/php55.json
+++ b/bucket/php55.json
@@ -1,7 +1,7 @@
 {
     "version": "5.5.38",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 5.5)",
-    "homepage": "https://windows.php.net/downloads/releases",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-5.5.38-Win32-VC11-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-5.5.38-Win32-VC11-x64.zip",
             "hash": "2a5eec621c36b94a5f2c59706f219b598fafbef9930215760f854de6ffba0092"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-5.5.38-Win32-VC11-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-5.5.38-Win32-VC11-x86.zip",
             "hash": "800a7e2be97aace568848e6bb91c93114ba59793a4f89c8756c66b975f2311be"
         }
     },

--- a/bucket/php56.json
+++ b/bucket/php56.json
@@ -1,7 +1,7 @@
 {
     "version": "5.6.40",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 5.6)",
-    "homepage": "https://windows.php.net",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-5.6.40-Win32-VC11-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-5.6.40-Win32-VC11-x64.zip",
             "hash": "b312df0b16ec645adfd7ad39ce6f9dd294a4dfeb8130ee8041f8af0f89f62904"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-5.6.40-Win32-VC11-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-5.6.40-Win32-VC11-x86.zip",
             "hash": "7285219b84fbe4fe17f6aab555524aba6775fb45c4122449bb53cfff423a6847"
         }
     },

--- a/bucket/php70.json
+++ b/bucket/php70.json
@@ -1,7 +1,7 @@
 {
     "version": "7.0.33",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 7.0)",
-    "homepage": "https://windows.php.net/",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.0.33-Win32-VC14-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.0.33-Win32-VC14-x64.zip",
             "hash": "8a22c93732b576507888e011b147df80beee7b7e24f527cb6e1282b5228350c2"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.0.33-Win32-VC14-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.0.33-Win32-VC14-x86.zip",
             "hash": "5c5b7e3c4b80a6e8984dca6bb1a1e1909c5dfb2b83b0242978020f78a473ab9c"
         }
     },

--- a/bucket/php71.json
+++ b/bucket/php71.json
@@ -1,7 +1,7 @@
 {
     "version": "7.1.33",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 7.1)",
-    "homepage": "https://windows.php.net",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.1.33-Win32-VC14-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.1.33-Win32-VC14-x64.zip",
             "hash": "2f6b0c6b62de88cf5cc16e68ac6d5e3b73fc01bcb03b51fe8c8534965b8e808c"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.1.33-Win32-VC14-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.1.33-Win32-VC14-x86.zip",
             "hash": "a2d5370b5d6f9125c3fab937f4b85aea8068875af30b8e3b665c633019a2a718"
         }
     },

--- a/bucket/php72.json
+++ b/bucket/php72.json
@@ -1,7 +1,7 @@
 {
     "version": "7.2.34",
     "description": "A popular general-purpose scripting language that is especially suited to web development.",
-    "homepage": "https://windows.php.net/",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.2.34-Win32-VC15-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.2.34-Win32-VC15-x64.zip",
             "hash": "3a3d026aacf8da57ff01ace2f78f8f57494744bfb669f8545cc8f9c4ff0450a5"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.2.34-Win32-VC15-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.2.34-Win32-VC15-x86.zip",
             "hash": "ae4def064fa2e38b40e3446fcab566fef673719500af626c1078eb4feaf56d84"
         }
     },

--- a/bucket/php73.json
+++ b/bucket/php73.json
@@ -1,7 +1,7 @@
 {
     "version": "7.3.33",
     "description": "A popular general-purpose scripting language that is especially suited to web development. (version 7.3)",
-    "homepage": "https://windows.php.net/",
+    "homepage": "https://www.php.net",
     "license": {
         "identifier": "PHP-3.01",
         "url": "https://secure.php.net/license/"
@@ -11,11 +11,11 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.3.33-Win32-VC15-x64.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.3.33-Win32-VC15-x64.zip",
             "hash": "eabf265d817ea534eeeeb51995693a8fd215bc6cfc42d5fcd5e5cd56a1d5da53"
         },
         "32bit": {
-            "url": "https://windows.php.net/downloads/releases/archives/php-7.3.33-Win32-VC15-x86.zip",
+            "url": "https://downloads.php.net/~windows/releases/archives/php-7.3.33-Win32-VC15-x86.zip",
             "hash": "a73ab9dede3d0aa70a6625431d85a96b4637f06e113b711212a3ba52d6435f48"
         }
     },


### PR DESCRIPTION
Relates to: https://github.com/ScoopInstaller/Main/pull/7560#issue-3847136286

> The one to use is `downloads.php.net/~windows`, and `windows.php.net` as a separate site is going to disappear.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP package metadata for versions 5.4 through 7.3, including distribution URLs and homepage references, to ensure reliable downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->