### PR TITLE
7zip-dark: Add version 26.01-v0.61.0

### DIFF
--- a/bucket/7zip-dark.json
+++ b/bucket/7zip-dark.json
@@ -37,9 +37,10 @@
             "pre_install": [
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
                 "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
-                "Invoke-ExternalCommand $7zr @('x', \"$dir\\7z2600-arm64.exe\", \"-o$dir\", '-y') | Out-Null",
+                "$arm_exe = (Get-ChildItem \"$dir\\*-arm64.exe\").FullName",
+                "Invoke-ExternalCommand $7zr @('x', $arm_exe, \"-o$dir\", '-y') | Out-Null",
                 "Invoke-ExternalCommand \"$dir\\7z.exe\" @('x', \"$dir\\patch.dl\", \"-o$dir\", '-y') | Out-Null",
-                "Remove-Item \"$dir\\Uninstall.exe\", \"$dir\\7z2600-arm64.exe\", \"$dir\\patch.dl\", $7zr -Force"
+                "Remove-Item \"$dir\\Uninstall.exe\", $arm_exe, \"$dir\\patch.dl\", $7zr -Force"
             ]
         }
     },
@@ -71,20 +72,21 @@
     ],
     "checkver": {
         "github": "https://github.com/ozone10/7zip-Dark7zip",
-        "regex": "v([\\d.]+)-(v[\\d.]+)"
+        "regex": "v(?<version>[\\d.]+)-(?<patch>v[\\d.]+)",
+        "replace": "${version}-${patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": [
                     "https://www.7-zip.org/a/7z$major$minor-x64.msi",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$match2-x64.zip#/patch.dl"
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$matchPatch-x64.zip#/patch.dl"
                 ]
             },
             "arm64": {
                 "url": [
                     "https://www.7-zip.org/a/7z$major$minor-arm64.exe",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$match2-arm64.zip#/patch.dl"
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$matchPatch-arm64.zip#/patch.dl"
                 ]
             }
         }

--- a/bucket/7zip-dark.json
+++ b/bucket/7zip-dark.json
@@ -72,21 +72,21 @@
     ],
     "checkver": {
         "github": "https://github.com/ozone10/7zip-Dark7zip",
-        "regex": "v(?<version>[\\d.]+)-(?<patch>v[\\d.]+)",
-        "replace": "${version}-${patch}"
+        "regex": "v(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>v[\\d.]+)",
+        "replace": "${major}.${minor}-${patch}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://www.7-zip.org/a/7z$major$minor-x64.msi",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$matchPatch-x64.zip#/patch.dl"
+                    "https://www.7-zip.org/a/7z${matchMajor}${matchMinor}-x64.msi",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z${matchMajor}.${matchMinor}-${matchPatch}-x64.zip#/patch.dl"
                 ]
             },
             "arm64": {
                 "url": [
-                    "https://www.7-zip.org/a/7z$major$minor-arm64.exe",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$matchPatch-arm64.zip#/patch.dl"
+                    "https://www.7-zip.org/a/7z${matchMajor}${matchMinor}-arm64.exe",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z${matchMajor}.${matchMinor}-${matchPatch}-arm64.zip#/patch.dl"
                 ]
             }
         }

--- a/bucket/7zip-dark.json
+++ b/bucket/7zip-dark.json
@@ -1,0 +1,92 @@
+{
+    "version": "26.00-v0.48.0",
+    "description": "A multi-format file archiver with high compression ratios (Dark Mode patched by ozone10)",
+    "homepage": "https://github.com/ozone10/7zip-Dark7zip",
+    "license": "LGPL-2.1-or-later",
+    "notes": [
+        "Add 7-Zip as a context menu option by running:",
+        "reg import \"$dir\\install-context.reg\"",
+        "This version includes the Dark Mode patch by ozone10 (x64 and arm64 only)."
+    ],
+    "architecture": {
+        "64bit": {
+            "url": [
+                "https://www.7-zip.org/a/7z2600-x64.msi",
+                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.00-v0.48.0/7z26.00-v0.48.0-x64.zip#/patch.dl"
+            ],
+            "hash": [
+                "c388d0444871ca11b21237001af158cfddad7e137851795e5b65cee69b518495",
+                "89f8583d60168e099284f14940a2c301ef1b8e037416c8bed8c14c081c6d0da6"
+            ],
+            "pre_install": [
+                "Move-Item \"$dir\\Files\\7-Zip\\*\" \"$dir\" -Force",
+                "Remove-Item \"$dir\\Files\" -Recurse -Force",
+                "Invoke-ExternalCommand \"$dir\\7z.exe\" @('x', \"$dir\\patch.dl\", \"-o$dir\", '-y') | Out-Null",
+                "Remove-Item \"$dir\\patch.dl\" -Force"
+            ]
+        },
+        "arm64": {
+            "url": [
+                "https://www.7-zip.org/a/7z2600-arm64.exe",
+                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.00-v0.48.0/7z26.00-v0.48.0-arm64.zip#/patch.dl"
+            ],
+            "hash": [
+                "92fac666911336f3bbf3d99fdc48ec36fe20ac7a4200556936e61a8076ae6493",
+                "99db92902d7be8cfaec9e67fb072fbef33f624d14864519dda388c5da309ba37"
+            ],
+            "pre_install": [
+                "$7zr = Join-Path $env:TMP '7zr.exe'",
+                "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
+                "Invoke-ExternalCommand $7zr @('x', \"$dir\\7z2600-arm64.exe\", \"-o$dir\", '-y') | Out-Null",
+                "Invoke-ExternalCommand \"$dir\\7z.exe\" @('x', \"$dir\\patch.dl\", \"-o$dir\", '-y') | Out-Null",
+                "Remove-Item \"$dir\\Uninstall.exe\", \"$dir\\7z2600-arm64.exe\", \"$dir\\patch.dl\", $7zr -Force"
+            ]
+        }
+    },
+    "post_install": [
+        "$7zip_root = \"$dir\".Replace('\\', '\\\\')",
+        "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
+        "    $content = Get-Content \"$bucketsdir\\main\\scripts\\7-zip\\$_\"",
+        "    $content = $content.Replace('$7zip_root', $7zip_root)",
+        "    if ($global) {",
+        "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
+        "    }",
+        "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
+        "}"
+    ],
+    "bin": [
+        "7z.exe",
+        "7zFM.exe",
+        "7zG.exe"
+    ],
+    "shortcuts": [
+        [
+            "7zFM.exe",
+            "7-Zip"
+        ]
+    ],
+    "persist": [
+        "Codecs",
+        "Formats"
+    ],
+    "checkver": {
+        "github": "https://github.com/ozone10/7zip-Dark7zip",
+        "regex": "v([\\d.]+)-(v[\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": [
+                    "https://www.7-zip.org/a/7z$major$minor-x64.msi",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$match2-x64.zip#/patch.dl"
+                ]
+            },
+            "arm64": {
+                "url": [
+                    "https://www.7-zip.org/a/7z$major$minor-arm64.exe",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$major.$minor-$match2-arm64.zip#/patch.dl"
+                ]
+            }
+        }
+    }
+}

--- a/bucket/7zip-dark.json
+++ b/bucket/7zip-dark.json
@@ -1,42 +1,50 @@
 {
-    "version": "26.00-v0.48.0",
+    "version": "26.01-v0.61.0",
     "description": "A multi-format file archiver with high compression ratios (Dark Mode patched by ozone10)",
     "homepage": "https://github.com/ozone10/7zip-Dark7zip",
-    "license": "LGPL-2.1-or-later",
+    "license": {
+        "identifier": "MIT,MPL-2.0,BSD-2-Clause,BSD-3-Clause,LGPL-2.1-or-later",
+        "url": "https://github.com/ozone10/7zip-Dark7zip/blob/main/LICENSE.md"
+    },
     "notes": [
-        "Add 7-Zip as a context menu option by running:",
+        "To avoid Scoop installing a duplicate default 7zip, please execute the following command:",
+        "scoop config use_external_7zip true",
+        "",
+        "To register the context menu entry, please execute the following command:",
         "reg import \"$dir\\install-context.reg\"",
-        "This version includes the Dark Mode patch by ozone10 (x64 and arm64 only)."
+        "",
+        "If an error occurs while attempting to delete files during uninstallation, run the following command and then retry:",
+        "Stop-Process -Name 'explorer'"
     ],
     "architecture": {
         "64bit": {
             "url": [
-                "https://www.7-zip.org/a/7z2600-x64.msi",
-                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.00-v0.48.0/7z26.00-v0.48.0-x64.zip#/patch.dl"
+                "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-x64.msi",
+                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.01-v0.61.0/7z26.01-v0.61.0-x64.zip#/patch.dl"
             ],
             "hash": [
-                "c388d0444871ca11b21237001af158cfddad7e137851795e5b65cee69b518495",
-                "89f8583d60168e099284f14940a2c301ef1b8e037416c8bed8c14c081c6d0da6"
+                "a47ea8dcf8bc08e6de474cae77c828e031fa22cb528f6095defffebf11cd02f2",
+                "5fab69ad6a906ff06ad497a6954877218819f356c375d52d3bda6b5785ae6e25"
             ],
+            "extract_dir": "Files\\7-Zip",
             "pre_install": [
-                "Move-Item \"$dir\\Files\\7-Zip\\*\" \"$dir\" -Force",
-                "Remove-Item \"$dir\\Files\" -Recurse -Force",
                 "Invoke-ExternalCommand \"$dir\\7z.exe\" @('x', \"$dir\\patch.dl\", \"-o$dir\", '-y') | Out-Null",
                 "Remove-Item \"$dir\\patch.dl\" -Force"
             ]
         },
         "arm64": {
             "url": [
-                "https://www.7-zip.org/a/7z2600-arm64.exe",
-                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.00-v0.48.0/7z26.00-v0.48.0-arm64.zip#/patch.dl"
+                "https://github.com/ip7z/7zip/releases/download/26.01/7z2601-arm64.exe",
+                "https://github.com/ozone10/7zip-Dark7zip/releases/download/v26.01-v0.61.0/7z26.01-v0.61.0-arm64.zip#/patch.dl"
             ],
             "hash": [
-                "92fac666911336f3bbf3d99fdc48ec36fe20ac7a4200556936e61a8076ae6493",
-                "99db92902d7be8cfaec9e67fb072fbef33f624d14864519dda388c5da309ba37"
+                "1fecf4e3407950939c8ffcc3e42e3039821997dea155301c75369474e5f15175",
+                "8c9af32b1c66ad4b1b8597b054b82719045327fe0dcab8986186600ba8b7133d"
             ],
             "pre_install": [
                 "$7zr = Join-Path $env:TMP '7zr.exe'",
-                "Invoke-WebRequest https://www.7-zip.org/a/7zr.exe -OutFile $7zr",
+                "$7zVersion = $version -split '-' | Select-Object -First 1",
+                "Invoke-WebRequest -Uri \"https://github.com/ip7z/7zip/releases/download/$7zVersion/7zr.exe\" -OutFile $7zr",
                 "$arm_exe = (Get-ChildItem \"$dir\\*-arm64.exe\").FullName",
                 "Invoke-ExternalCommand $7zr @('x', $arm_exe, \"-o$dir\", '-y') | Out-Null",
                 "Invoke-ExternalCommand \"$dir\\7z.exe\" @('x', \"$dir\\patch.dl\", \"-o$dir\", '-y') | Out-Null",
@@ -45,48 +53,51 @@
         }
     },
     "post_install": [
-        "$7zip_root = \"$dir\".Replace('\\', '\\\\')",
-        "'install-context.reg', 'uninstall-context.reg' | ForEach-Object {",
-        "    $content = Get-Content \"$bucketsdir\\main\\scripts\\7-zip\\$_\"",
-        "    $content = $content.Replace('$7zip_root', $7zip_root)",
-        "    if ($global) {",
-        "       $content = $content.Replace('HKEY_CURRENT_USER', 'HKEY_LOCAL_MACHINE')",
-        "    }",
-        "    Set-Content \"$dir\\$_\" $content -Encoding Ascii",
+        "$7zip_dir = $dir -replace '\\\\', '\\\\'",
+        "Get-ChildItem -Path \"$bucketsdir\\main\\scripts\\7-zip\" -Filter '*.reg' -File | ForEach-Object {",
+        "    $content = Get-Content -Path $_.FullName -Encoding utf8",
+        "    if ($global) { $content = $content -replace 'HKEY_CURRENT_USER(?=.+Classes)', 'HKEY_LOCAL_MACHINE' }",
+        "    $content -replace '{{7zip_dir}}', $7zip_dir | Set-Content -Path \"$dir\\$($_.Name)\" -Encoding unicode",
         "}"
     ],
     "bin": [
         "7z.exe",
-        "7zFM.exe",
-        "7zG.exe"
+        "7zG.exe",
+        "7zFM.exe"
     ],
     "shortcuts": [
         [
             "7zFM.exe",
-            "7-Zip"
+            "7-Zip\\7-Zip File Manager (Dark Mode)"
+        ],
+        [
+            "7-zip.chm",
+            "7-Zip\\7-Zip Help"
         ]
     ],
     "persist": [
         "Codecs",
         "Formats"
     ],
+    "uninstaller": {
+        "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" *> $null }"
+    },
     "checkver": {
         "github": "https://github.com/ozone10/7zip-Dark7zip",
-        "regex": "v(?<major>\\d+)\\.(?<minor>\\d+)-(?<patch>v[\\d.]+)",
-        "replace": "${major}.${minor}-${patch}"
+        "regex": "v([\\d.]+-v[\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": [
-                    "https://www.7-zip.org/a/7z${matchMajor}${matchMinor}-x64.msi",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z${matchMajor}.${matchMinor}-${matchPatch}-x64.zip#/patch.dl"
+                    "https://github.com/ip7z/7zip/releases/download/$matchHead/7z$majorVersion$minorVersion-x64.msi",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$version-x64.zip#/patch.dl"
                 ]
             },
             "arm64": {
                 "url": [
-                    "https://www.7-zip.org/a/7z${matchMajor}${matchMinor}-arm64.exe",
-                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z${matchMajor}.${matchMinor}-${matchPatch}-arm64.zip#/patch.dl"
+                    "https://github.com/ip7z/7zip/releases/download/$matchHead/7z$majorVersion$minorVersion-arm64.exe",
+                    "https://github.com/ozone10/7zip-Dark7zip/releases/download/v$version/7z$version-arm64.zip#/patch.dl"
                 ]
             }
         }


### PR DESCRIPTION
This PR adds a new manifest for **7-Zip-Dark**, a patched version of 7-Zip that supports native Dark Mode.

- **Project Homepage**: https://github.com/ozone10/7zip-Dark7zip
- **Version**: 26.00 (Patch v0.48.0)
- **Changes**: 
    - Added support for x64 and arm64 architectures.
    - Implemented a custom installation logic to overlay the dark mode patch onto the official 7-Zip binaries.
    - Excluded 32-bit support as it is not provided by the upstream patch project.

Relates to main/7zip
- [x] Use conventional PR title: `7zip-dark@26.00-v0.48.0: initial release`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the 7zip-Dark variant with architecture-specific install flows for 64-bit and ARM64, including required binary extraction and patch application.
  * Installer rewrites context registry scripts to reflect the chosen install root and optional global installation.
  * Declares installed executables, a file manager shortcut, persisted user data (codecs/formats), and GitHub-based version/autoupdate checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->