### PR TITLE
fluent-search-nightly: Add version 1.1.1.6

### DIFF
--- a/bucket/fluent-search-nightly.json
+++ b/bucket/fluent-search-nightly.json
@@ -1,0 +1,35 @@
+{
+    "version": "1.1.1.6",
+    "description": "Nightly build of Fluent Search, a search tool for running apps, browser tabs, in-app content, files and more.",
+    "homepage": "https://fluentsearch.net/",
+    "license": "Freeware",
+    "notes": "Nightly builds are pre-release builds and may contain bugs.",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.1.1.6/fluent-search-portable-x64.zip",
+            "hash": "56af7baa3ab7f43a594b7d70eab82cbf6646b05622862098b2603652c3b7bc77"
+        }
+    },
+    "pre_install": "if([environment]::OSVersion.Version.Major -lt 10) { error 'This app requires Windows 10 or 11'; break }",
+    "shortcuts": [
+        [
+            "FluentSearch.exe",
+            "Fluent Search Nightly"
+        ]
+    ],
+    "persist": [
+        "Blast\\FluentSearchPlugins",
+        "Blast\\Settings"
+    ],
+    "checkver": {
+        "url": "https://github.com/adirh3/Fluent-Search/releases",
+        "regex": "releases/tag/(?<version>[\\d.]+)\"[^>]*>[^<]+ Nightly<"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/adirh3/Fluent-Search/releases/download/$version/fluent-search-portable-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/fluent-search-nightly.json
+++ b/bucket/fluent-search-nightly.json
@@ -3,7 +3,6 @@
     "description": "Nightly build of Fluent Search, a search tool for running apps, browser tabs, in-app content, files and more.",
     "homepage": "https://fluentsearch.net/",
     "license": "Freeware",
-    "notes": "Nightly builds are pre-release builds and may contain bugs.",
     "architecture": {
         "64bit": {
             "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.1.1.6/fluent-search-portable-x64.zip",

--- a/bucket/fluent-search-nightly.json
+++ b/bucket/fluent-search-nightly.json
@@ -10,7 +10,7 @@
             "hash": "56af7baa3ab7f43a594b7d70eab82cbf6646b05622862098b2603652c3b7bc77"
         }
     },
-    "pre_install": "if([environment]::OSVersion.Version.Major -lt 10) { error 'This app requires Windows 10 or 11'; break }",
+    "pre_install": "if([Environment]::OSVersion.Version.Major -lt 10) { error 'This app requires Windows 10 or 11'; break }",
     "shortcuts": [
         [
             "FluentSearch.exe",

--- a/bucket/fluent-search-nightly.json
+++ b/bucket/fluent-search-nightly.json
@@ -8,6 +8,10 @@
         "64bit": {
             "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.1.1.6/fluent-search-portable-x64.zip",
             "hash": "56af7baa3ab7f43a594b7d70eab82cbf6646b05622862098b2603652c3b7bc77"
+        },
+        "arm64": {
+            "url": "https://github.com/adirh3/Fluent-Search/releases/download/1.1.1.6/fluent-search-portable-arm64.zip",
+            "hash": "593ac57b3b6accfd8ba2968f3e7475528356cd68107b96a6af474d78c7fdaf9d"
         }
     },
     "pre_install": "if([Environment]::OSVersion.Version.Major -lt 10) { error 'This app requires Windows 10 or 11'; break }",
@@ -29,6 +33,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/adirh3/Fluent-Search/releases/download/$version/fluent-search-portable-x64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/adirh3/Fluent-Search/releases/download/$version/fluent-search-portable-arm64.zip"
             }
         }
     }


### PR DESCRIPTION
Closes #2799

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

- add `fluent-search-nightly` to the Versions bucket
- use the upstream GitHub nightly portable x64 release asset
- track the current nightly release via the GitHub releases page
- preserve Fluent Search portable settings directories

## Verification

- JSON parses correctly
- `checkver.ps1 bucket/fluent-search-nightly.json` returns `1.1.1.6`
- downloaded asset hash matches manifest hash
- extracted archive contains `FluentSearch.exe`
- embedded `FluentSearch.exe` version is `1.1.1.6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fluent Search Nightly build now available for 64‑bit and ARM64 on Windows 10 or later.
  * Automatic updates enabled for the nightly channel across both architectures.
  * Installer creates a Start Menu shortcut and preserves user data and settings directories.
  * Installer will abort on unsupported Windows versions to prevent incompatible installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->