### PR TITLE
spark3-scala2.13: Add version 3.5.8

### DIFF
--- a/bucket/spark3-scala2.13.json
+++ b/bucket/spark3-scala2.13.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.5.8",
+    "description": "A unified analytics engine for large-scale data processing.",
+    "homepage": "https://spark.apache.org/",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/openjdk"
+    },
+    "url": "https://archive.apache.org/dist/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3-scala2.13.tgz",
+    "hash": "sha512:a90077cb4403684b5231a05b269d4c1175ec0a349a686c29c47c94462b1510eda2a9e6617ef6f9bb80de15fda3a00bf7ff8c943e605de3503541f77ad79082e9",
+    "extract_dir": "spark-3.5.8-bin-hadoop3-scala2.13",
+    "env_add_path": "bin",
+    "env_set": {
+        "SPARK_HOME": "$dir"
+    },
+    "persist": "conf",
+    "checkver": {
+        "url": "https://spark.apache.org/js/downloads.js",
+        "regex": "addRelease\\(\"(3\\.[\\d.]+)\","
+    },
+    "autoupdate": {
+        "url": "https://archive.apache.org/dist/spark/spark-$version/spark-$version-bin-hadoop3-scala2.13.tgz",
+        "hash": {
+            "url": "$url.sha512",
+            "regex": "$basename: ([A-F0-9\\s]+)$"
+        },
+        "extract_dir": "spark-$version-bin-hadoop3-scala2.13"
+    }
+}


### PR DESCRIPTION
> Note that Spark 4 is pre-built with Scala 2.13, and support for Scala 2.12 has been officially dropped. Spark 3 is pre-built with Scala 2.12 in general and Spark 3.2+ provides additional pre-built distribution with Scala 2.13.

Closes #2752
Relates to https://github.com/ScoopInstaller/Versions/commit/0a7e4c0e7f20cad1f41425ef4020370555ded113
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
