### PR TITLE
php(*)-xdebug: Fix post_install script

### DIFF
--- a/bucket/php54-xdebug.json
+++ b/bucket/php54-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 5.4 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-2.4.1-5.4-vc9-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php54\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 5.4 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.remote_enable=on\",",
+        "    \"xdebug.remote_autostart=on\",",
+        "    \"xdebug.remote_connect_back=on\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 5.4 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php55-xdebug.json
+++ b/bucket/php55-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 5.5 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-2.5.5-5.5-vc11-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php55\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 5.5 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.remote_enable=on\",",
+        "    \"xdebug.remote_autostart=on\",",
+        "    \"xdebug.remote_connect_back=on\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 5.5 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php56-xdebug.json
+++ b/bucket/php56-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 5.6 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-2.5.5-5.6-vc11-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php56\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 5.6 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.remote_enable=on\",",
+        "    \"xdebug.remote_autostart=on\",",
+        "    \"xdebug.remote_connect_back=on\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 5.6 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php70-xdebug.json
+++ b/bucket/php70-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 7.0 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-2.6.1-7.0-vc14-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php70\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 7.0 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.remote_enable=on\",",
+        "    \"xdebug.remote_autostart=on\",",
+        "    \"xdebug.remote_connect_back=on\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 7.0 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php71-xdebug.json
+++ b/bucket/php71-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 7.1 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-2.9.8-7.1-vc14-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php71\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 7.1 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.remote_enable=on\",",
+        "    \"xdebug.remote_autostart=on\",",
+        "    \"xdebug.remote_connect_back=on\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 7.1 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php72-xdebug.json
+++ b/bucket/php72-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 7.2 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.1.6-7.2-vc15-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php72\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 7.2 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 7.2 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php73-xdebug.json
+++ b/bucket/php73-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 7.3 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.1.6-7.3-vc15-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php73\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 7.3 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 7.3 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php74-xdebug.json
+++ b/bucket/php74-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 7.4 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.1.6-7.4-vc15-x86_64.dll#/php_xdebug.dll",
@@ -17,19 +21,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php74\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.remote_enable=on`nxdebug.remote_autostart=on`nxdebug.remote_connect_back=on\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 7.4 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 7.4 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php80-xdebug.json
+++ b/bucket/php80-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 8.0 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.0-vs16-x86_64.dll#/php_xdebug.dll",
@@ -13,19 +17,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php80\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 8.0 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 8.0 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php81-xdebug.json
+++ b/bucket/php81-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 8.1 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.1-vs16-x86_64.dll#/php_xdebug.dll",
@@ -13,19 +17,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php81\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 8.1 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 8.1 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php82-xdebug.json
+++ b/bucket/php82-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 8.2 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.2-vs16-x86_64.dll#/php_xdebug.dll",
@@ -13,19 +17,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php82\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 8.2 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 8.2 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",

--- a/bucket/php83-xdebug.json
+++ b/bucket/php83-xdebug.json
@@ -6,6 +6,10 @@
         "identifier": "Xdebug-1.01",
         "url": "https://xdebug.org/license.php"
     },
+    "notes": [
+        "Xdebug is already enabled if PHP 8.3 was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
     "architecture": {
         "64bit": {
             "url": "https://xdebug.org/files/php_xdebug-3.4.0-8.3-vs16-x86_64.dll#/php_xdebug.dll",
@@ -13,19 +17,31 @@
         }
     },
     "post_install": [
-        "$phpconfd = \"$persist_dir\\..\\php83\\cli\\conf.d\"",
-        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=develop,debug`nxdebug.client_port=9003`nxdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
-        "if(!(test-path $phpconfd\\xdebug.ini)) {",
-        "    Write-Output \"Enabling extension $(Convert-Path $phpconfd)\\xdebug.ini\"",
-        "    Add-Content -Value $ini -Path \"$phpconfd\\xdebug.ini\"",
-        "} else {",
-        "    Write-Host -f Yellow \"PHP 8.3 was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
-        "    Write-Host -f Cyan \"$ini`n`n\"",
+        "$config = @(",
+        "    \"zend_extension=$dir\\php_xdebug.dll\",",
+        "    \"[xdebug]\",",
+        "    \"xdebug.mode=develop,debug\",",
+        "    \"xdebug.client_port=9003\",",
+        "    \"xdebug.start_with_request=trigger   # If you always want to use debug, set the value to 'yes'\"",
+        ") -join \"`n\"",
+        "$php = $app -Split '-' | Select-Object -First 1",
+        "$configUpdated = $false",
+        "foreach ($phpGlobal in @($false, $true)) {",
+        "    if (installed $php $phpGlobal) {",
+        "        $configPath = \"$(persistdir $php $phpGlobal)\\cli\\conf.d\\xdebug.ini\"",
+        "        if(-not (Test-Path -Path $configPath)) {",
+        "            $configUpdated = $true",
+        "            ensure (Split-Path $configPath -Parent) | Out-Null",
+        "            Write-Host \"Enabling extension $configPath\"",
+        "            Add-Content -Value $config -Path $configPath",
+        "        }",
+        "        break",
+        "    }",
+        "}",
+        "if(-not $configUpdated) {",
+        "    Write-Host -ForegroundColor Yellow \"You may need to manually enable php_xdebug.dll. Add the following:`n\"",
+        "    Write-Host -ForegroundColor Cyan \"$config`n`n\"",
         "}"
-    ],
-    "notes": [
-        "Xdebug is already enabled if PHP 8.3 was installed through scoop!",
-        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
     ],
     "checkver": {
         "url": "https://xdebug.org/download/historical",


### PR DESCRIPTION
- Closes #2638

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Xdebug installation detection and configuration across all PHP versions (5.4–8.3). Now dynamically detects installed PHP variants and writes configuration only when needed.

* **Chores**
  * Added clarifying notes to package manifests documenting Xdebug enablement behavior and manual configuration fallback instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->