### PR TITLE
freerdp-nightly: Update to version 3.24.3-dev0-1974.3f39b90d0, drop 32bit support

### DIFF
--- a/bucket/freerdp-nightly.json
+++ b/bucket/freerdp-nightly.json
@@ -1,16 +1,12 @@
 {
-    "version": "3.24.3-dev0-1966.1d3c2d0b6",
+    "version": "3.24.3-dev0-1974.3f39b90d0",
     "description": "A free implementation of the Remote Desktop Protocol (RDP).",
     "homepage": "https://www.freerdp.com/",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://ci.freerdp.com/job/freerdp-nightly-windows/1966/arch=win64,label=vs2017/artifact/*zip*/archive.zip",
-            "hash": "53869bd2caa8eb3a2ba8e40cf134c7ec950187787bce0931f220e656e6c05532"
-        },
-        "32bit": {
-            "url": "https://ci.freerdp.com/job/freerdp-nightly-windows/1966/arch=win32,label=vs2017/artifact/*zip*/archive.zip",
-            "hash": "f4ed86d097878f6e23bc0e957dcf023cee285dcce867ff27180fc61550239e64"
+            "url": "https://ci.freerdp.com/job/freerdp-nightly-windows/1974/arch=win64,label=vs2017/artifact/*zip*/archive.zip",
+            "hash": "9e961cc1ea4c7e3943cb15adc53f2147cad99b13405ff318d446f4b5f7a8c28b"
         }
     },
     "extract_dir": "archive\\install\\bin",
@@ -39,9 +35,6 @@
         "architecture": {
             "64bit": {
                 "url": "https://ci.freerdp.com/job/freerdp-nightly-windows/$matchBuild/arch=win64,label=vs2017/artifact/*zip*/archive.zip"
-            },
-            "32bit": {
-                "url": "https://ci.freerdp.com/job/freerdp-nightly-windows/$matchBuild/arch=win32,label=vs2017/artifact/*zip*/archive.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

32bit binaries removed on the latest builds

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Nightly build version updated to the latest development release.
  * 32-bit system support has been discontinued; the application now exclusively supports 64-bit systems.
  * Auto-update configuration updated to reflect 64-bit-only availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->