### PR TITLE
(chore): Fix CUDA version mismatches

### DIFF
--- a/bucket/cuda6.json
+++ b/bucket/cuda6.json
@@ -1,5 +1,5 @@
 {
-    "version": "6.5.14",
+    "version": "6.0.37",
     "description": "A parallel computing platform and programming model invented by NVIDIA",
     "homepage": "https://developer.nvidia.com/cuda/toolkit",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://developer.download.nvidia.com/compute/cuda/6_5/rel/installers/cuda_6.5.14_windows_general_64.exe#/dl.7z",
-            "hash": "f3e2c3c13ce0ecc67a5f7d7367f18d5ee0abfd50a7b6cdd10e0feb7b823fde6d"
+            "url": "https://developer.download.nvidia.com/compute/cuda/6_0/rel/installers/cuda_6.0.37_winvista_win7_win8.1_general_64.exe#/dl.7z",
+            "hash": "2fb61339862aa97471cfbc659d0fd6a1fd463a52aab564adf20100b4767f307c"
         }
     },
     "installer": {
@@ -27,6 +27,6 @@
     ],
     "env_set": {
         "CUDA_PATH": "$dir",
-        "CUDA_PATH_V6_5": "$dir"
+        "CUDA_PATH_V6_0": "$dir"
     }
 }

--- a/bucket/cuda7.json
+++ b/bucket/cuda7.json
@@ -1,5 +1,5 @@
 {
-    "version": "7.5.18",
+    "version": "7.0.28",
     "description": "A parallel computing platform and programming model invented by NVIDIA",
     "homepage": "https://developer.nvidia.com/cuda/toolkit",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_win10.exe#/dl.7z",
-            "hash": "04d0d1c98692b16d16f776328b30c74a42ec45f08edd8ce175a872ab5e2653a2"
+            "url": "https://developer.download.nvidia.com/compute/cuda/7_0/Prod/local_installers/cuda_7.0.28_windows.exe#/dl.7z",
+            "hash": "0e19f279da851674601ad94bfe197dcac0290ccafacc546c4498ba665e2012e0"
         }
     },
     "installer": {
@@ -28,6 +28,6 @@
     ],
     "env_set": {
         "CUDA_PATH": "$dir",
-        "CUDA_PATH_V7_5": "$dir"
+        "CUDA_PATH_V7_0": "$dir"
     }
 }

--- a/bucket/cuda9.json
+++ b/bucket/cuda9.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.2.148",
+    "version": "9.0.176",
     "description": "A parallel computing platform and programming model invented by NVIDIA",
     "homepage": "https://developer.nvidia.com/cuda/toolkit",
     "license": {
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://developer.nvidia.com/compute/cuda/9.2/Prod2/local_installers2/cuda_9.2.148_win10#/dl.7z",
-            "hash": "md5:f6c170a7452098461070dbba3e6e58f1"
+            "url": "https://developer.nvidia.com/compute/cuda/9.0/Prod/local_installers/cuda_9.0.176_win10-exe#/dl.7z",
+            "hash": "md5:ecba5d6c7d86ab5c3c3be97330ca85a0"
         }
     },
     "installer": {
@@ -27,6 +27,6 @@
     ],
     "env_set": {
         "CUDA_PATH": "$dir",
-        "CUDA_PATH_V9_2": "$dir"
+        "CUDA_PATH_V9_0": "$dir"
     }
 }


### PR DESCRIPTION
These manifests had copy-paste errors where the version and URL were pointing to a different CUDA version than the filename suggested:
- cuda6.json: Was pointing to CUDA 6.5 instead of 6.0
- cuda7.json: Was pointing to CUDA 7.5 instead of 7.0  
- cuda9.json: Was pointing to CUDA 9.2 instead of 9.0