### PR TITLE
aria2-openssl: Add OpenSSL build for TLS 1.3 support

### DIFF
--- a/bucket/aria2-openssl.json
+++ b/bucket/aria2-openssl.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.37.0-1",
+    "version": "1.37.0",
     "description": "aria2 with OpenSSL backend for TLS 1.3 support. Use this if default aria2 fails with TLS 1.3-only servers (e.g., Tutanota).",
     "homepage": "https://aria2.github.io/",
     "license": "GPL-2.0-or-later",

--- a/bucket/aria2-openssl.json
+++ b/bucket/aria2-openssl.json
@@ -1,0 +1,25 @@
+{
+    "version": "1.37.0-1",
+    "description": "aria2 with OpenSSL backend for TLS 1.3 support. Use this if default aria2 fails with TLS 1.3-only servers (e.g., Tutanota).",
+    "homepage": "https://aria2.github.io/",
+    "license": "GPL-2.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/asdo92/aria2-static-builds/releases/download/v1.37.0/aria2-1.37.0-win-64bit-build1.7z",
+            "hash": "5f747059df8c53a729d53e2256d76635e1513070a60f32a8e81a6cb31c6e22bf"
+        }
+    },
+    "bin": "aria2c.exe",
+    "checkver": {
+        "url": "https://api.github.com/repos/asdo92/aria2-static-builds/releases?per_page=1",
+        "jsonpath": "$[0].tag_name",
+        "regex": "v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/asdo92/aria2-static-builds/releases/download/v$version/aria2-$version-win-64bit-build1.7z"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add `aria2-openssl` to the Versions bucket as an OpenSSL-linked `aria2` build for users who need TLS 1.3 support.

## Problem
The default `aria2` setup in Scoop relies on Windows TLS (Schannel). On Windows 10 and older Windows Server versions, that can fail against TLS 1.3-only endpoints.

## Solution
Provide an OpenSSL-linked `aria2` package in the Versions bucket.

## Usage
```powershell
scoop install aria2-openssl
scoop config aria2-path "$(scoop prefix aria2-openssl)\aria2c.exe"
```

Relates to ScoopInstaller/Extras#17010.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
