### PR TITLE
(chore): Explicitly specify GitHub mode when using GitHub API

### DIFF
--- a/bucket/7zip-zstd.json
+++ b/bucket/7zip-zstd.json
@@ -33,7 +33,7 @@
         "Formats"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/mcmilk/7-Zip-zstd/releases",
+        "github": "https://api.github.com/repos/mcmilk/7-Zip-zstd/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/arduino-ide-rc.json
+++ b/bucket/arduino-ide-rc.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/arduino/arduino-ide/releases",
+        "github": "https://api.github.com/repos/arduino/arduino-ide/releases",
         "regex": "tag/([\\d.]+(-rc\\d+)?)"
     },
     "autoupdate": {

--- a/bucket/atom-beta.json
+++ b/bucket/atom-beta.json
@@ -36,7 +36,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/atom/atom/releases",
+        "github": "https://api.github.com/repos/atom/atom/releases",
         "regex": "/releases/tag/(?:v)?([\\d.]+(-beta\\d+)?)"
     },
     "autoupdate": {

--- a/bucket/bottom-nightly.json
+++ b/bucket/bottom-nightly.json
@@ -15,7 +15,7 @@
     },
     "bin": "btm.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/ClementTsang/bottom/actions/workflows/nightly.yml/runs?branch=main&status=success",
+        "github": "https://api.github.com/repos/ClementTsang/bottom/actions/workflows/nightly.yml/runs?branch=main&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {

--- a/bucket/cherry-studio-pre.json
+++ b/bucket/cherry-studio-pre.json
@@ -21,7 +21,7 @@
     ],
     "persist": "data",
     "checkver": {
-        "url": "https://api.github.com/repos/CherryHQ/cherry-studio/releases",
+        "github": "https://api.github.com/repos/CherryHQ/cherry-studio/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/cosmosdbexplorer-beta.json
+++ b/bucket/cosmosdbexplorer-beta.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sachabruttin/CosmosDbExplorer/releases",
+        "github": "https://api.github.com/repos/sachabruttin/CosmosDbExplorer/releases",
         "regex": "v([\\d.]+(-beta)?)"
     },
     "autoupdate": {

--- a/bucket/ffmpeg-nightly.json
+++ b/bucket/ffmpeg-nightly.json
@@ -21,7 +21,7 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases",
+        "github": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl\\.zip/i)].browser_download_url",
         "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl\\.zip",
         "replace": "${year}${month}${day}-${commitnum}-g${commithash}"

--- a/bucket/ffmpeg-shared-nightly.json
+++ b/bucket/ffmpeg-shared-nightly.json
@@ -21,7 +21,7 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases",
+        "github": "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl-shared\\.zip/i)].browser_download_url",
         "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl-shared\\.zip",
         "replace": "${year}${month}${day}-${commitnum}-g${commithash}"

--- a/bucket/ffmpeg-shared-yt-dlp-nightly.json
+++ b/bucket/ffmpeg-shared-yt-dlp-nightly.json
@@ -29,7 +29,7 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases",
+        "github": "https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl-shared\\.zip/i)].browser_download_url",
         "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl-shared\\.zip",
         "replace": "${year}${month}${day}-${commitnum}-g${commithash}"

--- a/bucket/ffmpeg-yt-dlp-nightly.json
+++ b/bucket/ffmpeg-yt-dlp-nightly.json
@@ -29,7 +29,7 @@
         "bin\\ffprobe.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases",
+        "github": "https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases",
         "jsonpath": "$..assets[?(@.browser_download_url =~ /ffmpeg-N-\\d+-g[0-9a-f]+-win64-gpl\\.zip/i)].browser_download_url",
         "regex": "autobuild-(?<buildtime>(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})[\\d-]+)/ffmpeg-N-(?<commitnum>\\d+)-g(?<commithash>[0-9a-f]+)-win64-gpl\\.zip",
         "replace": "${year}${month}${day}-${commitnum}-g${commithash}"

--- a/bucket/freac-continuous.json
+++ b/bucket/freac-continuous.json
@@ -31,7 +31,7 @@
     ],
     "persist": "freac.xml",
     "checkver": {
-        "url": "https://api.github.com/repos/enzo1982/freac/actions/workflows/continuous-build-windows.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/enzo1982/freac/actions/workflows/continuous-build-windows.yml/runs?branch=master&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {

--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
+        "github": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
         "regex": "FreeCAD_weekly-([\\d.]+)-Windows-x86_64"
     },
     "autoupdate": {

--- a/bucket/git-without-openssh.json
+++ b/bucket/git-without-openssh.json
@@ -71,7 +71,7 @@
         ]
     },
     "checkver": {
-        "url": "https://api.github.com/repos/git-for-windows/git/releases/latest",
+        "github": "https://api.github.com/repos/git-for-windows/git/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /Portable/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?[\\d.]+windows[\\d.]+)/PortableGit-([\\d.]+)"
     },

--- a/bucket/github-beta.json
+++ b/bucket/github-beta.json
@@ -22,7 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/desktop/desktop/tags",
+        "github": "https://api.github.com/repos/desktop/desktop/tags",
         "regex": "tags/release-([\\d.]+-beta\\d+)\""
     },
     "autoupdate": {

--- a/bucket/godot-beta.json
+++ b/bucket/godot-beta.json
@@ -34,7 +34,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-beta\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/godot-dev.json
+++ b/bucket/godot-dev.json
@@ -34,7 +34,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-dev\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/godot-mono-beta.json
+++ b/bucket/godot-mono-beta.json
@@ -37,7 +37,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-beta\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/godot-mono-dev.json
+++ b/bucket/godot-mono-dev.json
@@ -37,7 +37,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-dev\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/godot-mono-rc.json
+++ b/bucket/godot-mono-rc.json
@@ -37,7 +37,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-rc\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/godot-rc.json
+++ b/bucket/godot-rc.json
@@ -34,7 +34,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/godotengine/godot-builds/tags",
+        "github": "https://api.github.com/repos/godotengine/godot-builds/tags",
         "jsonpath": "$[?(@.name =~ /^[\\d.]+-rc\\d+$/)].name"
     },
     "autoupdate": {

--- a/bucket/goneovim-nightly.json
+++ b/bucket/goneovim-nightly.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
+        "github": "https://api.github.com/repos/akiyosi/goneovim/releases/tags/nightly",
         "script": [
             "$release = $page | ConvertFrom-Json",
             "$date = Get-Date $release.updated_at -Format 'yyyyMMdd'",

--- a/bucket/greenshot-unstable.json
+++ b/bucket/greenshot-unstable.json
@@ -16,7 +16,7 @@
     ],
     "persist": "greenshot.ini",
     "checkver": {
-        "url": "https://api.github.com/repos/greenshot/greenshot/releases",
+        "github": "https://api.github.com/repos/greenshot/greenshot/releases",
         "regex": "Greenshot-INSTALLER-([\\d.]+)-UNSTABLE-UNSIGNED"
     },
     "autoupdate": {

--- a/bucket/hadoop-winutils33.json
+++ b/bucket/hadoop-winutils33.json
@@ -46,7 +46,7 @@
     },
     "pre_install": "New-Item -ItemType SymbolicLink -Path \"$dir\\bin\" -Value \".\" | Out-Null",
     "checkver": {
-        "url": "https://api.github.com/repos/cdarlint/winutils/contents/",
+        "github": "https://api.github.com/repos/cdarlint/winutils/contents/",
         "jsonpath": "$..name",
         "reverse": true,
         "regex": "hadoop-(3.3\\.\\d+)"

--- a/bucket/helium-pre.json
+++ b/bucket/helium-pre.json
@@ -31,7 +31,7 @@
     ],
     "persist": "User Data",
     "checkver": {
-        "url": "https://api.github.com/repos/imputnet/helium-windows/releases",
+        "github": "https://api.github.com/repos/imputnet/helium-windows/releases",
         "jsonpath": "$.[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/ipfilter-nightly.json
+++ b/bucket/ipfilter-nightly.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/DavidMoore/ipfilter/releases/download/lists/ipfilter.zip",
     "hash": "fb5a6f403d0f7f5937f9bbe6489d9d64e65be95e9a657651c2a724f767494859",
     "checkver": {
-        "url": "https://api.github.com/repos/DavidMoore/ipfilter/releases/tags/lists",
+        "github": "https://api.github.com/repos/DavidMoore/ipfilter/releases/tags/lists",
         "script": [
             "$release = $page | ConvertFrom-Json",
             "Get-Date $release.assets[0].updated_at -UFormat %s"

--- a/bucket/komorebi-nightly.json
+++ b/bucket/komorebi-nightly.json
@@ -29,7 +29,7 @@
         "komorebi-bar.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/LGUG2Z/komorebi/releases/tags/nightly",
+        "github": "https://api.github.com/repos/LGUG2Z/komorebi/releases/tags/nightly",
         "jsonpath": "$.body",
         "regex": "nightly \\((\\d{4}-\\d{2}-\\d{2})\\)"
     },

--- a/bucket/lapce-nightly.json
+++ b/bucket/lapce-nightly.json
@@ -23,7 +23,7 @@
     ],
     "persist": "lapce-data",
     "checkver": {
-        "url": "https://api.github.com/repos/lapce/lapce/releases/tags/nightly",
+        "github": "https://api.github.com/repos/lapce/lapce/releases/tags/nightly",
         "script": [
             "$release = $page | ConvertFrom-Json",
             "Get-Date $release.published_at -UFormat %s"

--- a/bucket/librehardwaremonitor-dotnet10-nightly.json
+++ b/bucket/librehardwaremonitor-dotnet10-nightly.json
@@ -36,7 +36,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/runs?branch=master&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {

--- a/bucket/librehardwaremonitor-nightly.json
+++ b/bucket/librehardwaremonitor-nightly.json
@@ -33,7 +33,7 @@
         "}"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/runs?branch=master&status=success&workflow=master",
+        "github": "https://api.github.com/repos/LibreHardwareMonitor/LibreHardwareMonitor/actions/workflows/master.yml/runs?branch=master&status=success&workflow=master",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {

--- a/bucket/logseq-nightly.json
+++ b/bucket/logseq-nightly.json
@@ -16,7 +16,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/logseq/logseq/releases/tags/nightly",
+        "github": "https://api.github.com/repos/logseq/logseq/releases/tags/nightly",
         "jsonpath": "$.assets..browser_download_url",
         "regex": "Logseq-darwin-x64-(?<version>[\\d.]+)-alpha%2Bnightly.(?<date>\\d+).zip",
         "replace": "${version}-${date}"

--- a/bucket/micro-nightly.json
+++ b/bucket/micro-nightly.json
@@ -16,7 +16,7 @@
     "extract_dir": "micro-nightly",
     "bin": "micro.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/micro-editor/micro/releases/tags/nightly",
+        "github": "https://api.github.com/repos/micro-editor/micro/releases/tags/nightly",
         "regex": "updated_at.+\"([\\d\\-]+)T.*micro-(?<micro>.+)-win",
         "replace": "${2}-${1}"
     },

--- a/bucket/mpv.net-beta.json
+++ b/bucket/mpv.net-beta.json
@@ -18,7 +18,7 @@
     ],
     "persist": "portable_config",
     "checkver": {
-        "url": "https://api.github.com/repos/mpvnet-player/mpv.net/releases",
+        "github": "https://api.github.com/repos/mpvnet-player/mpv.net/releases",
         "jsonpath": "$..browser_download_url",
         "regex": "download/v(?<tag>[\\d.]+-beta)/mpv.net-v([\\d.]+)-beta-portable-x64.zip"
     },

--- a/bucket/nanazip-beta.json
+++ b/bucket/nanazip-beta.json
@@ -34,7 +34,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/M2Team/NanaZip/releases",
+        "github": "https://api.github.com/repos/M2Team/NanaZip/releases",
         "jsonpath": "$.[?(@.prerelease==true)].tag_name"
     },
     "autoupdate": {

--- a/bucket/neovide-dev.json
+++ b/bucket/neovide-dev.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/neovide/neovide/releases",
+        "github": "https://api.github.com/repos/neovide/neovide/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/neovim-nightly.json
+++ b/bucket/neovim-nightly.json
@@ -23,7 +23,7 @@
     },
     "bin": "bin\\nvim.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/neovim/neovim/releases/tags/nightly",
+        "github": "https://api.github.com/repos/neovim/neovim/releases/tags/nightly",
         "jsonpath": "$.body",
         "regex": "NVIM v([\\d.]+)-dev-([a-f\\d]+)",
         "replace": "${1}-${2}"

--- a/bucket/obs-studio-pre.json
+++ b/bucket/obs-studio-pre.json
@@ -31,7 +31,7 @@
         "portable_mode.txt"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/obsproject/obs-studio/releases",
+        "github": "https://api.github.com/repos/obsproject/obs-studio/releases",
         "jsonpath": "$[0].tag_name",
         "regex": "\\A([\\d.]+(?:-(?:rc|beta)\\d+)?)\\Z"
     },

--- a/bucket/ols-dev.json
+++ b/bucket/ols-dev.json
@@ -16,7 +16,7 @@
         }
     },
     "checkver": {
-        "url": "https://api.github.com/repos/DanielGavin/ols/releases",
+        "github": "https://api.github.com/repos/DanielGavin/ols/releases",
         "jsonpath": "$..tag_name",
         "regex": "dev-([\\d.-]+)"
     },

--- a/bucket/orcaslicer-nightly.json
+++ b/bucket/orcaslicer-nightly.json
@@ -17,7 +17,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/OrcaSlicer/OrcaSlicer/releases/tags/nightly-builds",
+        "github": "https://api.github.com/repos/OrcaSlicer/OrcaSlicer/releases/tags/nightly-builds",
         "script": "($page | ConvertFrom-Json).updated_at | Get-Date -UFormat %s",
         "regex": "^(\\d+)$"
     },

--- a/bucket/pester4.json
+++ b/bucket/pester4.json
@@ -14,7 +14,7 @@
         "name": "Pester"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/pester/Pester/tags?per_page=100",
+        "github": "https://api.github.com/repos/pester/Pester/tags?per_page=100",
         "regex": "tags/(4[\\d.]+)\""
     },
     "autoupdate": {

--- a/bucket/pragtical-rolling.json
+++ b/bucket/pragtical-rolling.json
@@ -19,7 +19,7 @@
     ],
     "persist": "user",
     "checkver": {
-        "url": "https://api.github.com/repos/pragtical/pragtical/actions/workflows/rolling.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/pragtical/pragtical/actions/workflows/rolling.yml/runs?branch=master&status=success",
         "script": [
             "$content = ConvertFrom-Json $page",
             "if ((-not $content) -or (-not $content.workflow_runs) -or ($content.workflow_runs.Count -eq 0)) {",

--- a/bucket/prismlauncher-git.json
+++ b/bucket/prismlauncher-git.json
@@ -80,7 +80,7 @@
         "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/PrismLauncher/PrismLauncher/actions/workflows/build.yml/runs?branch=develop&status=success&event=push",
+        "github": "https://api.github.com/repos/PrismLauncher/PrismLauncher/actions/workflows/build.yml/runs?branch=develop&status=success&event=push",
         "script": [
             "$workflows = $page | ConvertFrom-Json",
             "$fullSha = $workflows.workflow_runs[0].head_sha",

--- a/bucket/prusaslicer-pre.json
+++ b/bucket/prusaslicer-pre.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/prusa3d/PrusaSlicer/releases",
+        "github": "https://api.github.com/repos/prusa3d/PrusaSlicer/releases",
         "jsonpath": "$[0].assets..name",
         "regex": "PrusaSlicer-([\\d.]+(?:-[a-z]+\\d+)?)\\+win64-(?<timestamp>\\d{12})_signed\\.zip"
     },

--- a/bucket/pwsh-beta.json
+++ b/bucket/pwsh-beta.json
@@ -27,7 +27,7 @@
     "pre_install": "if(!(Test-Path \"$dir\\profile.ps1\")) { New-Item \"$dir\\profile.ps1\" -ItemType File }",
     "persist": "profile.ps1",
     "checkver": {
-        "url": "https://api.github.com/repos/PowerShell/PowerShell/releases",
+        "github": "https://api.github.com/repos/PowerShell/PowerShell/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/qbittorrent-nightly.json
+++ b/bucket/qbittorrent-nightly.json
@@ -65,7 +65,7 @@
         "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-associations.reg\" }"
     },
     "checkver": {
-        "url": "https://api.github.com/repos/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/qbittorrent/qBittorrent/actions/workflows/ci_windows.yaml/runs?branch=master&status=success",
         "script": [
             "$ci_workflows = $page | ConvertFrom-Json",
             "$ci_file = Invoke-RestMethod https://raw.githubusercontent.com/qbittorrent/qBittorrent/master/.github/workflows/ci_windows.yaml",

--- a/bucket/qt-creator-beta.json
+++ b/bucket/qt-creator-beta.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/qt-creator/qt-creator/releases/latest",
+        "github": "https://api.github.com/repos/qt-creator/qt-creator/releases/latest",
         "jsonpath": "$.assets[0].browser_download_url",
         "regex": "/releases/download/v([\\w.-]+)/qt-creator-\\w+-(?<nums>\\d+)\\.\\w+$"
     },

--- a/bucket/qview-nightly.json
+++ b/bucket/qview-nightly.json
@@ -29,7 +29,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/jurplel/qView/actions/workflows/build.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/jurplel/qView/actions/workflows/build.yml/runs?branch=master&status=success",
         "script": [
             "$workflows = $page | ConvertFrom-Json",
             "$api = $workflows.workflow_runs[0]",

--- a/bucket/raddebugger-alpha.json
+++ b/bucket/raddebugger-alpha.json
@@ -21,7 +21,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/EpicGamesExt/raddebugger/releases",
+        "github": "https://api.github.com/repos/EpicGamesExt/raddebugger/releases",
         "jsonpath": "$.[?(@.tag_name =~ /v[\\d.]+-alpha/)].tag_name",
         "regex": "v([\\d.]+-alpha)"
     },

--- a/bucket/rufus-beta.json
+++ b/bucket/rufus-beta.json
@@ -22,7 +22,7 @@
         "rufus_files"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/pbatard/rufus/releases?per_page=1",
+        "github": "https://api.github.com/repos/pbatard/rufus/releases?per_page=1",
         "jsonpath": "$[0].tag_name",
         "regex": "v([\\w._]+)"
     },

--- a/bucket/rustdesk-nightly.json
+++ b/bucket/rustdesk-nightly.json
@@ -20,7 +20,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/rustdesk/rustdesk/releases/tags/nightly",
+        "github": "https://api.github.com/repos/rustdesk/rustdesk/releases/tags/nightly",
         "script": [
             "$api = $page | ConvertFrom-Json",
             "foreach ($name in $api.assets.name) { if ($name -clike '*-x86_64.exe') { $asset = $name; break } }",

--- a/bucket/sfsu-beta.json
+++ b/bucket/sfsu-beta.json
@@ -20,7 +20,7 @@
     "notes": "In order to replace scoop commands use `Invoke-Expression (&sfsu hook)` in your Powershell profile.",
     "bin": "sfsu.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/winpax/sfsu/releases",
+        "github": "https://api.github.com/repos/winpax/sfsu/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/sharex-dev.json
+++ b/bucket/sharex-dev.json
@@ -18,7 +18,7 @@
         "ShareX"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/ShareX/DevBuilds/releases",
+        "github": "https://api.github.com/repos/ShareX/DevBuilds/releases",
         "jsonpath": "$..tag_name",
         "regex": "v([\\d.]+)"
     },

--- a/bucket/smplayer-with-smtube.json
+++ b/bucket/smplayer-with-smtube.json
@@ -56,7 +56,7 @@
         "screenshots"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/smplayer-dev/smtube/releases/latest",
+        "github": "https://api.github.com/repos/smplayer-dev/smtube/releases/latest",
         "script": [
             "# matching from Extras bucket to avoid mangling FossHub mode in the script",
             "$url = 'https://raw.githubusercontent.com/ScoopInstaller/Extras/master/bucket/smplayer.json'",

--- a/bucket/spotbugs-beta.json
+++ b/bucket/spotbugs-beta.json
@@ -23,7 +23,7 @@
     ],
     "persist": "plugin",
     "checkver": {
-        "url": "https://api.github.com/repos/spotbugs/spotbugs/releases",
+        "github": "https://api.github.com/repos/spotbugs/spotbugs/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/spotify-qt-nightly.json
+++ b/bucket/spotify-qt-nightly.json
@@ -17,7 +17,7 @@
     ],
     "bin": "spotify-qt.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/kraxarn/spotify-qt-nightly/releases/latest",
+        "github": "https://api.github.com/repos/kraxarn/spotify-qt-nightly/releases/latest",
         "jsonpath": "$.assets[0].name",
         "regex": "\\Aspotify-qt-v([\\w.-]+)-win(?:64|32)\\.zip\\Z"
     },

--- a/bucket/sqlitebrowser-nightly.json
+++ b/bucket/sqlitebrowser-nightly.json
@@ -33,7 +33,7 @@
     ],
     "persist": "Data",
     "checkver": {
-        "url": "https://api.github.com/repos/sqlitebrowser/sqlitebrowser/releases/tags/continuous",
+        "github": "https://api.github.com/repos/sqlitebrowser/sqlitebrowser/releases/tags/continuous",
         "script": [
             "$release = $page | ConvertFrom-Json",
             "$date = Get-Date $release.updated_at -Format 'yyyyMMdd'",

--- a/bucket/sunshine-pre.json
+++ b/bucket/sunshine-pre.json
@@ -28,7 +28,7 @@
     ],
     "persist": "config",
     "checkver": {
-        "url": "https://api.github.com/repos/LizardByte/Sunshine/releases",
+        "github": "https://api.github.com/repos/LizardByte/Sunshine/releases",
         "jsonpath": "$[0].tag_name",
         "regex": "\\Av([\\d.]+)\\Z"
     },

--- a/bucket/syncplay-beta.json
+++ b/bucket/syncplay-beta.json
@@ -17,7 +17,7 @@
     ],
     "persist": "syncplay.ini",
     "checkver": {
-        "url": "https://api.github.com/repos/Syncplay/syncplay/releases",
+        "github": "https://api.github.com/repos/Syncplay/syncplay/releases",
         "script": [
             "$releases = $page | ConvertFrom-Json",
             "if (($ver = $releases[0].tag_name)[0] -eq ($prefix = 'v')) { $ver = $ver.Substring(1) } else { $prefix = '' }",

--- a/bucket/taiga-beta.json
+++ b/bucket/taiga-beta.json
@@ -25,7 +25,7 @@
         "data/db/anime.xml"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/erengy/taiga/releases",
+        "github": "https://api.github.com/repos/erengy/taiga/releases",
         "jsonpath": "$.[0].tag_name",
         "regex": "v([\\w.-]+)"
     },

--- a/bucket/v2rayn-pre.json
+++ b/bucket/v2rayn-pre.json
@@ -30,7 +30,7 @@
     ],
     "persist": "guiConfigs",
     "checkver": {
-        "url": "https://api.github.com/repos/2dust/v2rayN/releases",
+        "github": "https://api.github.com/repos/2dust/v2rayN/releases",
         "jsonpath": "$[0].tag_name",
         "regex": "(?:v|V)?([\\d.]+)"
     },

--- a/bucket/vidcoder-beta.json
+++ b/bucket/vidcoder-beta.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/RandomEngy/VidCoder/releases",
+        "github": "https://api.github.com/repos/RandomEngy/VidCoder/releases",
         "jsonpath": "$[?(@.target_commitish == 'beta')].tag_name",
         "regex": "v([\\d.]+-beta)"
     },

--- a/bucket/windows-terminal-preview.json
+++ b/bucket/windows-terminal-preview.json
@@ -68,7 +68,7 @@
     ],
     "pre_uninstall": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" }",
     "checkver": {
-        "url": "https://api.github.com/repos/microsoft/terminal/releases",
+        "github": "https://api.github.com/repos/microsoft/terminal/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v([\\d.]+)"
     },

--- a/bucket/winsw-pre.json
+++ b/bucket/winsw-pre.json
@@ -15,7 +15,7 @@
     },
     "bin": "WinSW.exe",
     "checkver": {
-        "url": "https://api.github.com/repos/winsw/winsw/releases",
+        "github": "https://api.github.com/repos/winsw/winsw/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v(?<version>[\\w-.]+)"
     },

--- a/bucket/xdman-beta.json
+++ b/bucket/xdman-beta.json
@@ -14,7 +14,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/subhra74/xdm/releases",
+        "github": "https://api.github.com/repos/subhra74/xdm/releases",
         "jsonpath": "$[0].tag_name"
     },
     "autoupdate": {

--- a/bucket/xournalpp-nightly.json
+++ b/bucket/xournalpp-nightly.json
@@ -23,7 +23,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/xournalpp/xournalpp/releases/tags/nightly",
+        "github": "https://api.github.com/repos/xournalpp/xournalpp/releases/tags/nightly",
         "regex": "xournalpp-(?<main>[\\d.]+)\\+dev-nightly-(?<date>\\d{8})",
         "replace": "${main}-${date}"
     },

--- a/bucket/yazi-nightly.json
+++ b/bucket/yazi-nightly.json
@@ -21,7 +21,7 @@
         "yazi.exe"
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/sxyazi/yazi/releases",
+        "github": "https://api.github.com/repos/sxyazi/yazi/releases",
         "jsonpath": "$[0].target_commitish",
         "regex": "(\\w{7})"
     },

--- a/bucket/zed-nightly.json
+++ b/bucket/zed-nightly.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases/latest",
+        "github": "https://api.github.com/repos/deevus/zed-windows-builds/releases/latest",
         "jp": "$.tag_name",
         "regex": "(\\d{4}-\\d{2}-\\d{2})"
     },

--- a/bucket/zed-opengl-nightly.json
+++ b/bucket/zed-opengl-nightly.json
@@ -18,7 +18,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/deevus/zed-windows-builds/releases/latest",
+        "github": "https://api.github.com/repos/deevus/zed-windows-builds/releases/latest",
         "jp": "$.tag_name",
         "regex": "(\\d{4}-\\d{2}-\\d{2})"
     },

--- a/bucket/zed-pre.json
+++ b/bucket/zed-pre.json
@@ -28,7 +28,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/zed-industries/zed/releases",
+        "github": "https://api.github.com/repos/zed-industries/zed/releases",
         "jsonpath": "$[?(@.prerelease == true)].tag_name",
         "regex": "v([\\w.-]+)-pre"
     },

--- a/deprecated/strawberry-nightly.json
+++ b/deprecated/strawberry-nightly.json
@@ -26,7 +26,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://api.github.com/repos/strawberrymusicplayer/strawberry/actions/workflows/build.yml/runs?branch=master&status=success",
+        "github": "https://api.github.com/repos/strawberrymusicplayer/strawberry/actions/workflows/build.yml/runs?branch=master&status=success",
         "jsonpath": "$.workflow_runs[0].id"
     },
     "autoupdate": {


### PR DESCRIPTION
Per ScoopInstaller/Scoop#6641, to make authenticated GitHub API requests with a token in checkver, GitHub mode must be explicitly specified. Additionally, `checkver.github` now allows configuring either a GitHub repo URL or a GitHub API URL.

Some `checkver` may still not work. However, since there is still another breaking change (ScoopInstaller/Scoop#6653) that hasn't been merged yet, we may wait until it is merged before fixing this issue to avoid duplicating work.
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated version-checking configuration across 75+ package manifests to standardize how GitHub API endpoints are referenced in version detection settings. Changed from generic `url` fields to explicit `github` fields for improved clarity and consistency in package update mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->