### PR TITLE
everything-alpha: Update to version 1.5.0.1409a, fix checkver, drop arm64 support

### DIFF
--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -17,10 +17,6 @@
         "32bit": {
             "url": "https://www.voidtools.com/Everything-1.5.0.1408a.x86.zip",
             "hash": "d7e211b0c0126fdaa256099e6c6a204ec960f8777b173c11d0d1f1956365fe66"
-        },
-        "arm64": {
-            "url": "https://www.voidtools.com/Everything-1.5.0.1408a.ARM64.zip",
-            "hash": "786a799a301184a428492bd28abb699b99add9f834d10c821c030cf94d27b701"
         }
     },
     "pre_install": [
@@ -64,13 +60,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.voidtools.com/Everything-$version.x64.zip"
+                "url": "https://www.voidtools.com/Everything-1.5.0.$version.x64.zip"
             },
             "32bit": {
-                "url": "https://www.voidtools.com/Everything-$version.x86.zip"
-            },
-            "arm64": {
-                "url": "https://www.voidtools.com/Everything-$version.ARM64.zip"
+                "url": "https://www.voidtools.com/Everything-1.5.0.$version.x86.zip"
             }
         }
     }

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -4,6 +4,8 @@
     "homepage": "https://www.voidtools.com",
     "license": "MIT",
     "notes": [
+        "Note: Version 1.5 Alpha is no longer under development; to get the latest versions, switch to `everything-beta`.",
+        "You are responsible for migrating your data; consult the official guide for assistance, keeping in mind the differences in directory structures.",
         "To add Everything to right-click context menu, run:",
         "reg import \"$dir\\install-context.reg\""
     ],

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -5,8 +5,9 @@
     "license": "MIT",
     "notes": [
         "Note: Version 1.5 Alpha is no longer under development; to get the latest versions, switch to `everything-beta`.",
-        "You are responsible for migrating your data; consult the official migration guide for assistance beetwen \"portable\" and \"manual\" import sections",
-        "keeping in mind the differences in directory structures.",
+        "You are responsible for migrating your data;",
+        "To migrate, uninstall this package, copy the persistent files over the beta files",
+        "(removing `-1.5a` from all filenames that contain it), and then re-initialize the service from the settings.",
         "To add Everything to right-click context menu, run:",
         "reg import \"$dir\\install-context.reg\""
     ],

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "notes": [
         "Note: Version 1.5 Alpha is no longer under development; to get the latest versions, switch to `everything-beta`.",
-        "You are responsible for migrating your data; consult the official guide for assistance, keeping in mind the differences in directory structures.",
+        "You are responsible for migrating your data; consult the official migration guide for assistance beetwen \"portable\" and \"manual\" import sections",
+        "keeping in mind the differences in directory structures.",
         "To add Everything to right-click context menu, run:",
         "reg import \"$dir\\install-context.reg\""
     ],

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -56,8 +56,8 @@
     ],
     "persist": "plugins",
     "checkver": {
-        "url": "https://www.voidtools.com/forum/viewtopic.php?f=12&t=9787",
-        "regex": "Everything-([\\d.]+a)\\.x86"
+        "url": "https://www.voidtools.com/forum/viewtopic.php?t=9787",
+        "regex": "\\[([\\d.]+a)\\]"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.5.0.1408a",
+    "version": "1.5.0.1409a",
     "description": "Locate files and folders by name instantly.",
     "homepage": "https://www.voidtools.com",
     "license": "MIT",
@@ -11,12 +11,12 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://www.voidtools.com/Everything-1.5.0.1408a.x64.zip",
-            "hash": "28984cbb8c3b748e3af5cf0a66cf7d7f0f28dab18483e4381f5e74d3242ddbd2"
+            "url": "https://www.voidtools.com/Everything-1.5.0.1409a.x64.zip",
+            "hash": "e16b3e3f562b13dbc3368b4a78357274ee9515bd3eaada58302c0f3c26af9c0c"
         },
         "32bit": {
-            "url": "https://www.voidtools.com/Everything-1.5.0.1408a.x86.zip",
-            "hash": "d7e211b0c0126fdaa256099e6c6a204ec960f8777b173c11d0d1f1956365fe66"
+            "url": "https://www.voidtools.com/Everything-1.5.0.1409a.x86.zip",
+            "hash": "f1fffd46f6075fa6cc1d9286df260f190f2e30c038680460ec25b2be20c4830f"
         }
     },
     "pre_install": [
@@ -55,15 +55,16 @@
     "persist": "plugins",
     "checkver": {
         "url": "https://www.voidtools.com/forum/viewtopic.php?t=9787",
-        "regex": "\\[([\\d.]+a)\\]"
+        "regex": "\\[([\\d.]+a)\\]",
+        "replace": "1.5.0.${1}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.voidtools.com/Everything-1.5.0.$version.x64.zip"
+                "url": "https://www.voidtools.com/Everything-$version.x64.zip"
             },
             "32bit": {
-                "url": "https://www.voidtools.com/Everything-1.5.0.$version.x86.zip"
+                "url": "https://www.voidtools.com/Everything-$version.x86.zip"
             }
         }
     }

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -4,10 +4,9 @@
     "homepage": "https://www.voidtools.com",
     "license": "MIT",
     "notes": [
-        "Note: Version 1.5 Alpha is no longer under development; to get the latest versions, switch to `everything-beta`.",
-        "You are responsible for migrating your data;",
-        "To migrate, uninstall this package, copy the persistent files over the beta files",
-        "(removing `-1.5a` from all filenames that contain it), and then re-initialize the service from the settings.",
+        "Everything 1.5 is now in BETA. The BETA version is available in Scoop as \"versions/everything-beta\".",
+        "For upgrade guide, please visit: https://www.voidtools.com/forum/viewtopic.php?t=17663#portable",
+        "",
         "To add Everything to right-click context menu, run:",
         "reg import \"$dir\\install-context.reg\""
     ],

--- a/bucket/everything-alpha.json
+++ b/bucket/everything-alpha.json
@@ -56,9 +56,8 @@
     ],
     "persist": "plugins",
     "checkver": {
-        "url": "https://www.voidtools.com/forum/viewtopic.php?t=9787",
-        "regex": "\\[([\\d.]+a)\\]",
-        "replace": "1.5.0.${1}"
+        "url": "https://www.voidtools.com/forum/viewtopic.php?sd=d&t=9787",
+        "regex": "Everything-([\\d.]+a)\\.x64"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

Everything 1.5 has moved to beta; alpha manifest update
arm removed due to missing releases (which were blocking the checkver)

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
Closes #2850

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Everything alpha updated to 1.5.0.1409a; release notes now indicate Everything 1.5 is BETA and include an upgrade guide link.
  * Migration, uninstall, and copy instructions expanded for switching to beta builds.
  * Download URLs and integrity hashes refreshed for 64‑bit and 32‑bit builds.
  * ARM64 removed from this package.
  * Automatic update checks adjusted to target 64‑bit alpha builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Versions/pull/2851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->