### PR TITLE
qbittorrent-qt6_lt20: Update to version 5.2.0, fix checkver & autoupdate

### DIFF
--- a/bucket/qbittorrent-qt6_lt20.json
+++ b/bucket/qbittorrent-qt6_lt20.json
@@ -1,38 +1,29 @@
 {
-    "version": "5.1.4",
+    "version": "5.2.0",
     "description": "Free and reliable P2P Bittorent client.",
-    "homepage": "https://www.qbittorrent.org/",
+    "homepage": "https://www.qbittorrent.org",
     "license": {
-        "identifier": "GPL-2.0-only",
-        "url": "https://github.com/qbittorrent/qBittorrent/blob/master/COPYING"
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/qbittorrent/qBittorrent/blob/HEAD/COPYING"
     },
     "architecture": {
         "64bit": {
-            "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.1.4/qbittorrent_5.1.4_qt6_lt20_x64_setup.exe#/dl.7z",
-            "hash": "sha1:75660719e5d2c812f09a71881f2b30f035438d6b"
+            "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.2.0/qbittorrent_5.2.0_lt20_x64_setup.exe#/dl.7z",
+            "hash": "sha1:af0fe1eed4176e9ecba0b66622b8720044d34edd"
         }
     },
     "pre_install": [
-        "Remove-Item \"$dir\\`$PLUGINSDIR\", \"$dir\\uninst.exe\" -Force -Recurse -ErrorAction SilentlyContinue",
-        "if ((!(Test-Path \"$persist_dir\\profile\")) -and ((Test-Path \"$persist_dir\\..\\qbittorrent-portable\\profile\") -or (Test-Path \"$env:APPDATA\\qBittorrent\"))) {",
-        "    Write-Host \"Scoop is migrating qbittorrent to use portable mode by default.\" -ForegroundColor Yellow",
-        "    Write-Host \"For details, see: https://github.com/ScoopInstaller/Extras/issues/5845\" -ForegroundColor Yellow",
-        "    if ((Test-Path \"$persist_dir\\..\\qbittorrent-portable\\profile\") -and (Test-Path \"$env:APPDATA\\qBittorrent\")) {",
-        "        Write-Host \"Both portable and non-portable qBittorrent profile exist.\" -ForegroundColor Yellow",
-        "        Write-Host \"Scoop will prioritize and import the non-portable one.\" -ForegroundColor Yellow",
-        "    }",
-        "    New-Item \"$persist_dir\\profile\" -ItemType Directory | Out-Null",
-        "    if (Test-Path \"$env:APPDATA\\qBittorrent\") {",
-        "        Write-Host \"Copying non-portable profile's config and data to Scoop persist directory...\" -ForegroundColor Yellow",
-        "        Copy-Item \"$env:APPDATA\\qBittorrent\" \"$persist_dir\\profile\\qBittorrent\\config\" -Recurse | Out-Null",
-        "        Copy-Item \"$env:LOCALAPPDATA\\qBittorrent\" \"$persist_dir\\profile\\qBittorrent\\data\" -Recurse | Out-Null",
-        "    } else {",
-        "        Write-Host \"Copying portable profile's config and data to Scoop persist directory...\" -ForegroundColor Yellow",
-        "        Write-Host \"If you haven't setup an absolute download path before torrenting, please manually migrate affected torrents, as they use relative path by default for storaging.\" -ForegroundColor Yellow",
-        "        Write-Host \"Or you can move them to an absolute download path in qbittorrent-portable and cleanly (re)install qbittorrent to let migration script to take care of them.\" -ForegroundColor Yellow",
-        "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\config\" \"$persist_dir\\profile\\qBittorrent\\config\" -Recurse | Out-Null",
-        "        Copy-Item \"$persist_dir\\..\\qbittorrent-portable\\profile\\qBittorrent\\data\" \"$persist_dir\\profile\\qBittorrent\\data\" -Recurse | Out-Null",
-        "    }",
+        "$data_dir = \"$persist_dir\\profile\\qBittorrent\\data\"",
+        "$configuration_dir = \"$persist_dir\\profile\\qBittorrent\\config\"",
+        "$data_dir, $configuration_dir | ForEach-Object { ensure $_ | Out-Null }",
+        "Remove-Item -Path \"$dir\\`$PLUGINSDIR\", \"$dir\\unins*\" -Force -Recurse -ErrorAction SilentlyContinue",
+        "if (-not (Test-Path -Path \"$data_dir\\*\") -and (Test-Path -Path \"$env:LOCALAPPDATA\\qBittorrent\\*\")) {",
+        "    Write-Host \"`nINFO  Migrating qBittorrent data to '$data_dir'...\" -ForegroundColor DarkGray",
+        "    Copy-Item -Path \"$env:LOCALAPPDATA\\qBittorrent\\*\" -Destination $data_dir -Force -Exclude 'cache' -Recurse",
+        "}",
+        "if (-not (Test-Path -Path \"$configuration_dir\\*\") -and (Test-Path -Path \"$env:APPDATA\\qBittorrent\\*\")) {",
+        "    Write-Host \"INFO  Migrating qBittorrent configurations to '$configuration_dir'...\" -ForegroundColor DarkGray",
+        "    Copy-Item -Path \"$env:APPDATA\\qBittorrent\\*\" -Destination $configuration_dir -Force -Recurse",
         "}"
     ],
     "bin": "qbittorrent.exe",
@@ -42,14 +33,18 @@
             "qBittorrent"
         ]
     ],
-    "persist": "profile",
+    "persist": [
+        "profile",
+        "qt.conf"
+    ],
     "checkver": {
-        "sourceforge": "qbittorrent/qbittorrent-win32"
+        "sourceforge": "qbittorrent/qbittorrent-win32",
+        "regex": "qbittorrent_([\\d.]+)_(?<build>(?:qt6_)?lt20)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_qt6_lt20_x64_setup.exe#/dl.7z"
+                "url": "https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-$version/qbittorrent_$version_$matchBuild_x64_setup.exe#/dl.7z"
             }
         }
     }


### PR DESCRIPTION
### Summary

Updates `qbittorrent-qt6_lt20` to version **5.2.0**, updates the license to GPL-3.0-or-later, and significantly refactors the `pre_install` script for better reliability.

### Related issues or pull requests

- Relates to https://github.com/ScoopInstaller/Extras/issues/12170
- Closes #2848 

### Changes

- Update version to **5.2.0** and refresh hashes.
- Update `license` to **GPL-3.0-or-later** and point to the `HEAD` version of the COPYING file.
- Refactor `pre_install` script:
  - Simplify migration logic by decoupling configuration and data path checks.
  - Exclude the `cache` folder during migration to minimize unnecessary disk usage.
  - Change console output to `DarkGray` for a more streamlined installation experience.
- Expand `persist` field to include both `profile` and `qt.conf`.
- Modernize `checkver` and `autoupdate` using a named capture group `matchBuild` to dynamically handle upstream filename variations (e.g., `qt6_lt20` vs `lt20`).

### Notes

- The SourceForge release filenames for v5.2.0 have changed (omitting the `qt6_` prefix). The new regex in `checkver` ensures that future updates will correctly capture the build string regardless of this prefix.
- The `pre_install` script no longer checks for `qbittorrent-portable` paths to keep the manifest focused on standard Scoop migration patterns.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions][ qbittorrent-qt6_lt20 ≡]
└─> .\bin\checkver.ps1 -App '.\bucket\qbittorrent-qt6_lt20.json' -f
qbittorrent-qt6_lt20: 5.2.0 (scoop version is 5.2.0)
Forcing autoupdate!
Autoupdating qbittorrent-qt6_lt20
DEBUG[1778915868] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1778915868] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1778915868] $substitutions.$dashVersion                   5-2-0
DEBUG[1778915868] $substitutions.$version                       5.2.0
DEBUG[1778915868] $substitutions.$dotVersion                    5.2.0
DEBUG[1778915868] $substitutions.$urlNoExt                      https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.2.0/qbittorrent_5.2.0_lt20_x64_setup
DEBUG[1778915868] $substitutions.$matchHead                     5.2.0
DEBUG[1778915868] $substitutions.$patchVersion                  0
DEBUG[1778915868] $substitutions.$minorVersion                  2
DEBUG[1778915868] $substitutions.$basenameNoExt                 qbittorrent_5.2.0_lt20_x64_setup
DEBUG[1778915868] $substitutions.$url                           https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.2.0/qbittorrent_5.2.0_lt20_x64_setup.exe
DEBUG[1778915868] $substitutions.$baseurl                       https://downloads.sourceforge.net/project/qbittorrent/qbittorrent-win32/qbittorrent-5.2.0
DEBUG[1778915868] $substitutions.$cleanVersion                  520
DEBUG[1778915868] $substitutions.$underscoreVersion             5_2_0
DEBUG[1778915868] $substitutions.$buildVersion                  
DEBUG[1778915868] $substitutions.$match1                        5.2.0
DEBUG[1778915868] $substitutions.$matchBuild                    lt20
DEBUG[1778915868] $substitutions.$preReleaseVersion             5.2.0
DEBUG[1778915868] $substitutions.$majorVersion                  5
DEBUG[1778915868] $substitutions.$basename                      qbittorrent_5.2.0_lt20_x64_setup.exe
DEBUG[1778915868] $substitutions.$matchTail                     
DEBUG[1778915868] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1778915870] $regex = "qbittorrent_5\.2\.0_lt20_x64_setup\.exe":.*?"sha1":\s*"([a-fA-F0-9]{40})" -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:80:9
Found: sha1:af0fe1eed4176e9ecba0b66622b8720044d34edd using Sourceforge Mode
Writing updated qbittorrent-qt6_lt20 manifest

┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions][ qbittorrent-qt6_lt20 ≡]
└─> scoop install '.\bucket\qbittorrent-qt6_lt20.json'
Installing 'qbittorrent-qt6_lt20' (5.2.0) [64bit] from 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions\bucket\qbittorrent-qt6_lt20.json'
Loading qbittorrent_5.2.0_lt20_x64_setup.exe from cache.
Checking hash of qbittorrent_5.2.0_lt20_x64_setup.exe... OK.
Extracting qbittorrent_5.2.0_lt20_x64_setup.exe... Done.
Running pre_install script... Done.
Linking D:\Software\Scoop\Local\apps\qbittorrent-qt6_lt20\current => D:\Software\Scoop\Local\apps\qbittorrent-qt6_lt20\5.2.0
Creating shim for 'qbittorrent'.
Making D:\Software\Scoop\Local\shims\qbittorrent.exe a GUI binary.
Creating shortcut for qBittorrent (qbittorrent.exe)
Persisting profile
Persisting qt.conf
'qbittorrent-qt6_lt20' (5.2.0) was installed successfully!

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated qBittorrent to version 5.2.0
  * License updated to GPL-3.0-or-later

* **New Features**
  * Added persistent storage for qt.conf configuration

* **Bug Fixes**
  * Improved installation and data migration logic for better reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Versions/pull/2855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->