### PR TITLE
freecad-weekly: Update to version 2026.05.13, fix checkver & autoupdate

### DIFF
--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -6,10 +6,10 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2026.05.13/FreeCAD_weekly-2026.05.13-Windows-x86_64.7z",
-            "hash": "60f10c94653b8cc1b382e873fa81d9a7fc19924591d0debf7bc40aafb2503840"
+            "hash": "60f10c94653b8cc1b382e873fa81d9a7fc19924591d0debf7bc40aafb2503840",
+            "extract_dir": "FreeCAD_weekly-2026.05.13-Windows-x86_64"
         }
     },
-    "extract_dir": "FreeCAD_weekly-2026.05.13-Windows-x86_64",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
@@ -20,14 +20,17 @@
     "checkver": {
         "github": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
         "jsonpath": "$[?(@.tag_name =~ /weekly/)].tag_name",
-        "regex": "-([\\d.]+)"
+        "regex": "weekly-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64.7z",
+                "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64"
             }
         },
-        "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64"
+        "hash": {
+            "url": "$url-SHA256.txt"
+        }
     }
 }

--- a/bucket/freecad-weekly.json
+++ b/bucket/freecad-weekly.json
@@ -1,15 +1,15 @@
 {
-    "version": "2026.03.25",
+    "version": "2026.05.13",
     "description": "A free and open-source multi-platform parametric 3D modeler.",
     "homepage": "https://www.freecadweb.org",
     "license": "LGPL-2.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2026.03.25/FreeCAD_weekly-2026.03.25-Windows-x86_64-py311.7z",
-            "hash": "71ff2db6907b5f162100ea69675f8317e3716cf2491f47836233e782fcabbfe2"
+            "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-2026.05.13/FreeCAD_weekly-2026.05.13-Windows-x86_64.7z",
+            "hash": "60f10c94653b8cc1b382e873fa81d9a7fc19924591d0debf7bc40aafb2503840"
         }
     },
-    "extract_dir": "FreeCAD_weekly-2026.03.25-Windows-x86_64-py311",
+    "extract_dir": "FreeCAD_weekly-2026.05.13-Windows-x86_64",
     "bin": "bin\\FreeCADCmd.exe",
     "shortcuts": [
         [
@@ -19,14 +19,15 @@
     ],
     "checkver": {
         "github": "https://api.github.com/repos/FreeCAD/FreeCAD/releases",
-        "regex": "FreeCAD_weekly-([\\d.]+)-Windows-x86_64"
+        "jsonpath": "$[?(@.tag_name =~ /weekly/)].tag_name",
+        "regex": "-([\\d.]+)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64-py311.7z"
+                "url": "https://github.com/FreeCAD/FreeCAD/releases/download/weekly-$version/FreeCAD_weekly-$version-Windows-x86_64.7z"
             }
         },
-        "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64-py311"
+        "extract_dir": "FreeCAD_weekly-$version-Windows-x86_64"
     }
 }


### PR DESCRIPTION
Relates to:
- [#6641](https://github.com/ScoopInstaller/Scoop/pull/6641)
- [pull request 2837](https://github.com/ScoopInstaller/Versions/pull/2837) 

I found that `checkver` is broken after pull request 2837 with the released version of scoop.

Switched scoop to the develop branch and got further, but it still broke.

This is my attempt at a fix using jsonpath to find the latest weekly dev build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FreeCAD weekly metadata to 2026.05.13 with refreshed Windows x86_64 download URL and checksum.
  * Adjusted autoupdate rules for weekly release detection and URL templating to match new artifact naming.
  * Removed the Python-version suffix from Windows artifact names and standardized checksum URL pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Versions/pull/2856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->