### PR TITLE
groovy-classic: add manifest for legacy groovy (version <= 2.4.3)

### DIFF
--- a/bucket/groovy-classic.json
+++ b/bucket/groovy-classic.json
@@ -1,0 +1,37 @@
+{
+    "version": "2.4.3",
+    "description": "Legacy 'Groovy Classic' binaries. This manifest provides older distributions of the Groovy programming language released up until version 2.4.3 (March 2015), before the transition to the Apache Software Foundation.",
+    "homepage": "https://www.groovy-lang.org",
+    "license": "Apache-2.0",
+    "suggest": {
+        "JDK": "java/temurin8-jdk",
+        "groovyserv": "groovyserv"
+    },
+    "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-2.4.3.zip",
+    "hash": "b0c11d2ca5003956f1393138282a6e802af8c0033c5afdc8dc3af1e512e1dbe1",
+    "extract_dir": "groovy-2.4.3",
+    "bin": [
+        "bin\\grape.bat",
+        "bin\\groovy.bat",
+        "bin\\groovyc.bat",
+        "bin\\groovyConsole.bat",
+        "bin\\groovydoc.bat",
+        "bin\\groovysh.bat",
+        "bin\\java2groovy.bat",
+        "bin\\startGroovy.bat"
+    ],
+    "env_set": {
+        "GROOVY_HOME": "$dir"
+    },
+    "checkver": {
+        "url": "https://groovy.apache.org/download.html",
+        "regex": "groovy-binary-([\\d.]+)\\.zip"
+    },
+    "autoupdate": {
+        "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-$version.zip",
+        "hash": {
+            "url": "$url.sha256"
+        },
+        "extract_dir": "groovy-$version"
+    }
+}

--- a/bucket/groovy-classic.json
+++ b/bucket/groovy-classic.json
@@ -25,7 +25,7 @@
     },
     "checkver": {
         "url": "https://groovy.apache.org/download.html",
-        "regex": "groovy-binary-([\\d.]+)\\.zip"
+        "regex": "groovy-binary-2\\.4\\.3\\.zip"
     },
     "autoupdate": {
         "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-$version.zip",

--- a/bucket/groovy-classic.json
+++ b/bucket/groovy-classic.json
@@ -23,10 +23,6 @@
     "env_set": {
         "GROOVY_HOME": "$dir"
     },
-    "checkver": {
-        "url": "https://groovy.apache.org/download.html",
-        "regex": "groovy-binary-2\\.4\\.3\\.zip"
-    },
     "autoupdate": {
         "url": "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/groovy-binary-$version.zip",
         "hash": {


### PR DESCRIPTION
Legacy 'Groovy Classic' binaries. This manifest provides older distributions of the Groovy programming language released up until version 2.4.3 (March 2015), before the transition to the Apache Software Foundation.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the legacy "Groovy Classic" distribution (v2.4.3), enabling installation of legacy Groovy binaries.
  * Provides environment configuration for runtime use and includes Windows executable entrypoint support.
  * Includes a pinned release artifact for reproducible installs and automated update/check behavior for easier maintenance and integrity verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Versions/pull/2873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->