### PR TITLE
llama.cpp-cu133(-dll): Add version b9404

### DIFF
--- a/bucket/llama.cpp-cu133-dll.json
+++ b/bucket/llama.cpp-cu133-dll.json
@@ -11,8 +11,7 @@
     },
     "env_add_path": ".",
     "checkver": {
-        "url": "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest",
-        "jsonpath": "$.tag_name",
+        "github": "https://github.com/ggml-org/llama.cpp",
         "regex": "(b[\\d]+)"
     },
     "autoupdate": {

--- a/bucket/llama.cpp-cu133-dll.json
+++ b/bucket/llama.cpp-cu133-dll.json
@@ -1,11 +1,11 @@
 {
-    "version": "b9401",
+    "version": "b9404",
     "description": "CUDA DLLs for llama.cpp (version 13.3)",
     "homepage": "https://github.com/ggml-org/llama.cpp",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9401/cudart-llama-bin-win-cuda-13.3-x64.zip",
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9404/cudart-llama-bin-win-cuda-13.3-x64.zip",
             "hash": "1462a050eb4c684921ba51dcc4cc488a036674c3e73e9945ee705b854808d03e"
         }
     },

--- a/bucket/llama.cpp-cu133-dll.json
+++ b/bucket/llama.cpp-cu133-dll.json
@@ -1,0 +1,25 @@
+{
+    "version": "b9401",
+    "description": "CUDA DLLs for llama.cpp (version 13.3)",
+    "homepage": "https://github.com/ggml-org/llama.cpp",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9401/cudart-llama-bin-win-cuda-13.3-x64.zip",
+            "hash": "1462a050eb4c684921ba51dcc4cc488a036674c3e73e9945ee705b854808d03e"
+        }
+    },
+    "env_add_path": ".",
+    "checkver": {
+        "url": "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "(b[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ggml-org/llama.cpp/releases/download/$version/cudart-llama-bin-win-cuda-13.3-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/llama.cpp-cu133.json
+++ b/bucket/llama.cpp-cu133.json
@@ -30,8 +30,7 @@
     ],
     "persist": "models",
     "checkver": {
-        "url": "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest",
-        "jsonpath": "$.tag_name",
+        "github": "https://github.com/ggml-org/llama.cpp",
         "regex": "(b[\\d]+)"
     },
     "autoupdate": {

--- a/bucket/llama.cpp-cu133.json
+++ b/bucket/llama.cpp-cu133.json
@@ -1,0 +1,44 @@
+{
+    "version": "b9401",
+    "description": "Inference of LLaMA model in pure C/C++ (CUDA 13.3 version)",
+    "homepage": "https://github.com/ggml-org/llama.cpp",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9401/llama-b9401-bin-win-cuda-13.3-x64.zip",
+            "hash": "28030f6cccd66a5eea002109eac1d5c31e5fe1b116700b1106b09dbe175b7480"
+        }
+    },
+    "bin": [
+        "llama-batched-bench.exe",
+        "llama-bench.exe",
+        "llama-cli.exe",
+        "llama-completion.exe",
+        "llama-fit-params.exe",
+        "llama-gemma3-cli.exe",
+        "llama-gguf-split.exe",
+        "llama-imatrix.exe",
+        "llama-llava-cli.exe",
+        "llama-minicpmv-cli.exe",
+        "llama-mtmd-cli.exe",
+        "llama-perplexity.exe",
+        "llama-quantize.exe",
+        "llama-qwen2vl-cli.exe",
+        "llama-server.exe",
+        "llama-tokenize.exe",
+        "llama-tts.exe"
+    ],
+    "persist": "models",
+    "checkver": {
+        "url": "https://api.github.com/repos/ggml-org/llama.cpp/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "(b[\\d]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ggml-org/llama.cpp/releases/download/$version/llama-$version-bin-win-cuda-13.3-x64.zip"
+            }
+        }
+    }
+}

--- a/bucket/llama.cpp-cu133.json
+++ b/bucket/llama.cpp-cu133.json
@@ -1,12 +1,12 @@
 {
-    "version": "b9401",
+    "version": "b9404",
     "description": "Inference of LLaMA model in pure C/C++ (CUDA 13.3 version)",
     "homepage": "https://github.com/ggml-org/llama.cpp",
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9401/llama-b9401-bin-win-cuda-13.3-x64.zip",
-            "hash": "28030f6cccd66a5eea002109eac1d5c31e5fe1b116700b1106b09dbe175b7480"
+            "url": "https://github.com/ggml-org/llama.cpp/releases/download/b9404/llama-b9404-bin-win-cuda-13.3-x64.zip",
+            "hash": "3ce93b4eb43f57e3e98caff1bfba008c82d7229e6ad8791649925d19fe0d8a24"
         }
     },
     "bin": [


### PR DESCRIPTION
Updated llama.cpp for CUDA 13 to CUDA 13.3 version.
Previous CUDA 13.1 version is no longer being updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Windows x64 CUDA 13.3 package manifests for llama.cpp (DLL and standard binary distributions).
  * Updated packages to the latest release (b9404) and ensured download verification and model persistence paths.
  * Enabled automatic version discovery and autoupdate from upstream releases.
  * Environment path setup included so installed binaries are immediately usable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ScoopInstaller/Versions/pull/2891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->