### PR TITLE
sumatrapdf-pre: Add version 3.7.18454

### DIFF
--- a/bucket/sumatrapdf-pre.json
+++ b/bucket/sumatrapdf-pre.json
@@ -1,0 +1,49 @@
+{
+    "version": "18454",
+    "description": "PDF and eBook reader (pre-release)",
+    "homepage": "https://www.sumatrapdfreader.org/free-pdf-reader",
+    "license": "GPL-3.0-only,BSD-2-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.sumatrapdfreader.org/dl/prerel/18454/SumatraPDF-prerel-64.zip",
+            "hash": "a2b3226213a647bd80fe0cebaf1b1150186e3f06302d60eed49effe958cb26e8"
+        },
+        "arm64": {
+            "url": "https://www.sumatrapdfreader.org/dl/prerel/18454/SumatraPDF-prerel-arm64.zip",
+            "hash": "de17d6a446a5102314d55508b0f5422f1a536c63a7c5b3ba755bd33916f778c6"
+        }
+    },
+    "pre_install": [
+        "$file = 'SumatraPDF-settings.txt'",
+        "if (!(Test-Path \"$persist_dir\\$file\")) {",
+        "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
+        "    Set-Content \"$dir\\$file\" 'CheckForUpdates = false' -Encoding Ascii",
+        "}",
+        "Get-ChildItem \"$dir\\SumatraPDF-*.exe\" | Rename-Item -NewName 'SumatraPDF.exe'"
+    ],
+    "bin": "SumatraPDF.exe",
+    "shortcuts": [
+        [
+            "SumatraPDF.exe",
+            "SumatraPDF"
+        ]
+    ],
+    "persist": [
+        "SumatraPDF-settings.txt",
+        "sumatrapdfcache"
+    ],
+    "checkver": {
+        "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js",
+        "regex": "var sumLatestVer = (\\d+);"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$version/SumatraPDF-prerel-64.zip"
+            },
+            "arm64": {
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$version/SumatraPDF-prerel-arm64.zip"
+            }
+        }
+    }
+}

--- a/bucket/sumatrapdf-pre.json
+++ b/bucket/sumatrapdf-pre.json
@@ -16,7 +16,7 @@
     "pre_install": [
         "$file = 'SumatraPDF-settings.txt'",
         "if (!(Test-Path \"$persist_dir\\$file\")) {",
-        "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
+        "    Write-Host 'File' $file 'does not exist. Creating.' -f Yellow",
         "    Set-Content \"$dir\\$file\" 'CheckForUpdates = false' -Encoding Ascii",
         "}",
         "Get-ChildItem \"$dir\\SumatraPDF-*.exe\" | Rename-Item -NewName 'SumatraPDF.exe'"

--- a/bucket/sumatrapdf-pre.json
+++ b/bucket/sumatrapdf-pre.json
@@ -1,0 +1,50 @@
+{
+    "version": "3.7.18454",
+    "description": "PDF and eBook reader (pre-release)",
+    "homepage": "https://www.sumatrapdfreader.org/free-pdf-reader",
+    "license": "GPL-3.0-only,BSD-2-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.sumatrapdfreader.org/dl/prerel/18454/SumatraPDF-prerel-64.zip",
+            "hash": "a2b3226213a647bd80fe0cebaf1b1150186e3f06302d60eed49effe958cb26e8"
+        },
+        "arm64": {
+            "url": "https://www.sumatrapdfreader.org/dl/prerel/18454/SumatraPDF-prerel-arm64.zip",
+            "hash": "de17d6a446a5102314d55508b0f5422f1a536c63a7c5b3ba755bd33916f778c6"
+        }
+    },
+    "pre_install": [
+        "$file = 'SumatraPDF-settings.txt'",
+        "if (!(Test-Path \"$persist_dir\\$file\")) {",
+        "    Write-Host 'File' $file 'does not exists. Creating.' -f Yellow",
+        "    Set-Content \"$dir\\$file\" 'CheckForUpdates = false' -Encoding Ascii",
+        "}",
+        "Get-ChildItem \"$dir\\SumatraPDF-*.exe\" | Rename-Item -NewName 'SumatraPDF.exe'"
+    ],
+    "bin": "SumatraPDF.exe",
+    "shortcuts": [
+        [
+            "SumatraPDF.exe",
+            "SumatraPDF"
+        ]
+    ],
+    "persist": [
+        "SumatraPDF-settings.txt",
+        "sumatrapdfcache"
+    ],
+    "checkver": {
+        "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js",
+        "regex": "var sumLatestVer = (?<build>\\d+);",
+        "replace": "3.7.${build}"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$matchBuild/SumatraPDF-prerel-64.zip"
+            },
+            "arm64": {
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$matchBuild/SumatraPDF-prerel-arm64.zip"
+            }
+        }
+    }
+}

--- a/bucket/sumatrapdf-pre.json
+++ b/bucket/sumatrapdf-pre.json
@@ -1,6 +1,6 @@
 {
-    "version": "18454",
-    "description": "PDF and eBook reader (pre-release)",
+    "version": "3.7.18454",
+    "description": "PDF and eBook reader (Pre-release).",
     "homepage": "https://www.sumatrapdfreader.org/free-pdf-reader",
     "license": "GPL-3.0-only,BSD-2-Clause",
     "architecture": {
@@ -33,16 +33,24 @@
         "sumatrapdfcache"
     ],
     "checkver": {
-        "url": "https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js",
-        "regex": "var sumLatestVer = (\\d+);"
+        "url": "https://www.sumatrapdfreader.org/docs/Version-history",
+        "script": [
+            "$page -match 'next:\\s*(\\d+\\.\\d+)' | Out-Null",
+            "$major_version = $matches[1]",
+            "$page = Invoke-WebRequest -Uri 'https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js' -UseBasicParsing",
+            "$page -match 'sumLatestVer\\s*=\\s*(\\d+);' | Out-Null",
+            "$patch_version = $matches[1]",
+            "Write-Output \"$major_version.$patch_version\""
+        ],
+        "regex": "^([\\d.]+)$"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://www.sumatrapdfreader.org/dl/prerel/$version/SumatraPDF-prerel-64.zip"
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$patchVersion/SumatraPDF-prerel-64.zip"
             },
             "arm64": {
-                "url": "https://www.sumatrapdfreader.org/dl/prerel/$version/SumatraPDF-prerel-arm64.zip"
+                "url": "https://www.sumatrapdfreader.org/dl/prerel/$patchVersion/SumatraPDF-prerel-arm64.zip"
             }
         }
     }

--- a/bucket/sumatrapdf-pre.json
+++ b/bucket/sumatrapdf-pre.json
@@ -37,7 +37,7 @@
         "script": [
             "$page -match 'next:\\s*(\\d+\\.\\d+)' | Out-Null",
             "$major_version = $matches[1]",
-            "$page = Invoke-WebRequest -Uri 'https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js' -UseBasicParsing",
+            "$page = (Invoke-WebRequest -Uri 'https://files2.sumatrapdfreader.org/software/sumatrapdf/sumatralatest.js' -UseBasicParsing).Content",
             "$page -match 'sumLatestVer\\s*=\\s*(\\d+);' | Out-Null",
             "$patch_version = $matches[1]",
             "Write-Output \"$major_version.$patch_version\""


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #2896

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added pre-release installer package for SumatraPDF 3.7.18454 with official 64-bit and ARM64 support.
  * Enabled automatic update detection and secure verification of downloaded installers.
  * Preserves user settings and application cache across installs and updates.
  * Adds a desktop shortcut and streamlined system integration for easier access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->