### PR TITLE
7zip-zstd: Update to version v26.01-1.5.7-r1, fix checkver & autoupdate

### DIFF
--- a/bucket/7zip-zstd.json
+++ b/bucket/7zip-zstd.json
@@ -1,31 +1,42 @@
 {
-    "version": "v25.01-v1.5.7-R4",
-    "description": "Multi-format compression/decompression tool with brotli and other codecs (beta version)",
-    "homepage": "https://github.com/mcmilk/7-Zip-zstd/",
-    "license": "LGPL-2.1-or-later",
+    "version": "26.01-1.5.7-r1",
+    "description": "7-Zip Zstandard is a multi-format file archiver based on 7-Zip that adds support for modern compression codecs including Zstandard, Brotli, LZ4, LZ5, Lizard, and Fast-LZMA2 while maintaining high compression ratios.",
+    "homepage": "https://mcmilk.de/projects/7-Zip-zstd/",
+    "license": {
+        "identifier": "BSD-3-Clause, LGPL-2.1-or-later",
+        "url": "https://github.com/mcmilk/7-Zip-zstd/blob/HEAD/COPYING"
+    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v25.01-v1.5.7-R4/7z25.01-zstd-x64.exe#/dl.7z",
-            "hash": "5a55a8b6abb09d4b5ddd64c95f22a5270cb46752fb7a5353073508922b141596"
+            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-x64.exe",
+            "hash": "337eb2af535d1ae752a9b78bfa2c51261c395e5827bd57e8dc0eb93685c588ed"
         },
         "32bit": {
-            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v25.01-v1.5.7-R4/7z25.01-zstd-x32.exe#/dl.7z",
-            "hash": "76fb9f4eff5235032261f5e498c5733bbd7617b7895d724a77306fa869a55e23"
+            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-x86.exe",
+            "hash": "6fda0b6793b89b3ea0bcedd6155cbc881d9199a1e8faf20ef8292e8bdf298f61"
         },
         "arm64": {
-            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v25.01-v1.5.7-R4/7z25.01-zstd-arm64.exe#/dl.7z",
-            "hash": "857a45bbdfc1b68bc32f478f438db7a5fcff3d43cc2e8512f1d4cab5195051a0"
+            "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-arm64.exe",
+            "hash": "9bf8e4b93f022df5fd669c6b29397aacbcc05244a435a8f7117c16796c4610d9"
         }
+    },
+    "installer": {
+        "script": "Expand-7zipArchive -Path \"$dir\\$fname\" -Switches '-xr!$* -xr!unins*' -Removal"
     },
     "bin": [
         "7z.exe",
-        "7zFM.exe",
-        "7zG.exe"
+        "7za.exe",
+        "7zG.exe",
+        "7zFM.exe"
     ],
     "shortcuts": [
         [
+            "7-zip.chm",
+            "7-Zip-Zstandard\\7-Zip Help"
+        ],
+        [
             "7zFM.exe",
-            "7-Zip Zstd"
+            "7-Zip-Zstandard\\7-Zip ZS File Manager"
         ]
     ],
     "persist": [
@@ -33,20 +44,21 @@
         "Formats"
     ],
     "checkver": {
-        "github": "https://api.github.com/repos/mcmilk/7-Zip-zstd/releases",
-        "jsonpath": "$[0].tag_name",
-        "regex": "([\\d\\w.-]+)"
+        "github": "https://api.github.com/repos/mcmilk/7-Zip-zstd/releases/latest",
+        "jsonpath": "$.assets[?(@.name =~ /7z(?!.+ndm)/i)].browser_download_url",
+        "regex": "(?i)download/(?<tag>v?(?<sevenzip>[^-]+)-v?(?<zstd>[^-]+)-R(?<release>\\d+))/(?<prefix>[^\"]+)-(?:arm|x)",
+        "replace": "${sevenzip}-${zstd}-r${release}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$version/7z$matchHead-zstd-x64.exe#/dl.7z"
+                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$matchTag/$matchPrefix-x64.exe"
             },
             "32bit": {
-                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$version/7z$matchHead-zstd-x32.exe#/dl.7z"
+                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$matchTag/$matchPrefix-x86.exe"
             },
             "arm64": {
-                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$version/7z$matchHead-zstd-arm64.exe#/dl.7z"
+                "url": "https://github.com/mcmilk/7-Zip-zstd/releases/download/$matchTag/$matchPrefix-arm64.exe"
             }
         }
     }

--- a/bucket/7zip-zstd.json
+++ b/bucket/7zip-zstd.json
@@ -1,5 +1,5 @@
 {
-    "version": "26.01-1.5.7-r1",
+    "version": "v26.01-1.5.7-r1",
     "description": "7-Zip Zstandard is a multi-format file archiver based on 7-Zip that adds support for modern compression codecs including Zstandard, Brotli, LZ4, LZ5, Lizard, and Fast-LZMA2 while maintaining high compression ratios.",
     "homepage": "https://mcmilk.de/projects/7-Zip-zstd/",
     "license": {
@@ -47,7 +47,7 @@
         "github": "https://api.github.com/repos/mcmilk/7-Zip-zstd/releases/latest",
         "jsonpath": "$.assets[?(@.name =~ /7z(?!.+ndm)/i)].browser_download_url",
         "regex": "(?i)download/(?<tag>v?(?<sevenzip>[^-]+)-v?(?<zstd>[^-]+)-R(?<release>\\d+))/(?<prefix>[^\"]+)-(?:arm|x)",
-        "replace": "${sevenzip}-${zstd}-r${release}"
+        "replace": "v${sevenzip}-${zstd}-r${release}"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
### Summary

Updates `7zip-zstd` to version **26.01-1.5.7-r1**, rewrites the description, updates project URLs, adds shortcuts, and heavily modernizes the `checkver` / `autoupdate` parsing logic to maintain future compatibility.

### Changes

- Update version to **26.01-1.5.7-r1** (standardizing the version string structure) and refresh hashes.
- Expand `description` with full details of supported modern compression codecs.
- Update `homepage` to the official project domain (`https://mcmilk.de/...`).
- Improve `license` field to dual-license (BSD-3-Clause, LGPL-2.1-or-later) with full SPDX alignment and explicit `HEAD` file URL.
- Add an explicit `installer` script utilizing `Expand-7zipArchive` to clean up temporary uninstaller and installation structures.
- Restructure `bin` list order and append `7za.exe`.
- Add a new shortcut for the help documentation (`7-zip.chm`) and refine the File Manager shortcut path to prevent main-menu pollution.
- Total rewrite of `checkver` to parse `/releases/latest` using a robust JSONPath filtering mechanism and custom regex named capture groups (`matchTag`, `matchSevenzip`, `matchZstd`, `matchRelease`, `matchPrefix`) to streamline the version format matching.
- Update `autoupdate` URLs to adaptively consume the new regex tokens.

### Notes

- The upstream repository changed its naming convention for 32-bit binaries from `x32` to `x86` in recent releases.
- Shortcuts are now cleanly organized within a dedicated `7-Zip-Zstandard` start menu folder.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ develop ≡]
└─> .\checkver.ps1 -App 'D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions\bucket\7zip-zstd.json' -f
7zip-zstd: 26.01-1.5.7-r1 (scoop version is 26.01-1.5.7-r1)
Forcing autoupdate!
Autoupdating 7zip-zstd
DEBUG[1781422800] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:500:5
DEBUG[1781422800] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1781422800] $substitutions.$buildVersion
DEBUG[1781422800] $substitutions.$baseurl                       https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1
DEBUG[1781422800] $substitutions.$preReleaseVersion             r1
DEBUG[1781422800] $substitutions.$version                       26.01-1.5.7-r1
DEBUG[1781422800] $substitutions.$matchTail                     -1.5.7-r1
DEBUG[1781422800] $substitutions.$matchHead                     26.01
DEBUG[1781422800] $substitutions.$patchVersion
DEBUG[1781422800] $substitutions.$underscoreVersion             26_01_1_5_7_r1
DEBUG[1781422800] $substitutions.$dotVersion                    26.01.1.5.7.r1
DEBUG[1781422800] $substitutions.$matchTag                      v26.01-v1.5.7-R1
DEBUG[1781422800] $substitutions.$matchSevenzip                 26.01
DEBUG[1781422800] $substitutions.$url                           https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-x86.exe
DEBUG[1781422800] $substitutions.$matchZstd                     1.5.7
DEBUG[1781422800] $substitutions.$matchRelease                  1
DEBUG[1781422800] $substitutions.$dashVersion                   26-01-1-5-7-r1
DEBUG[1781422800] $substitutions.$basenameNoExt                 7z26.01-zstd-x86
DEBUG[1781422800] $substitutions.$urlNoExt                      https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-x86
DEBUG[1781422800] $substitutions.$cleanVersion                  2601157r1
DEBUG[1781422800] $substitutions.$matchPrefix                   7z26.01-zstd
DEBUG[1781422800] $substitutions.$minorVersion                  01
DEBUG[1781422800] $substitutions.$majorVersion                  26
DEBUG[1781422800] $substitutions.$basename                      7z26.01-zstd-x86.exe
DEBUG[1781422800] $hashfile_url = $null -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
DEBUG[1781422802] $jsonpath = $..assets[?(@.browser_download_url == 'https://github.com/mcmilk/7-Zip-zstd/releases/download/v26.01-v1.5.7-R1/7z26.01-zstd-x86.exe')].digest -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 6fda0b6793b89b3ea0bcedd6155cbc881d9199a1e8faf20ef8292e8bdf298f61 using Github Mode
... ...
Writing updated 7zip-zstd manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)