### PR TITLE
vscode-insiders: Update to version 1.127.0-1782374470674, refine checkver

### DIFF
--- a/bucket/vscode-insiders.json
+++ b/bucket/vscode-insiders.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.127.0-2026.174.17.8",
+    "version": "1.127.0-1782374470674",
     "description": "Visual Studio Code is a lightweight but powerful source code editor (Insiders, Portable Edition).",
     "homepage": "https://code.visualstudio.com/insiders",
     "license": {
@@ -66,8 +66,7 @@
         "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
         "script": [
             "$release = $page | ConvertFrom-Json -ErrorAction Stop",
-            "$time = [DateTimeOffset]::FromUnixTimeMilliseconds($release.timestamp)",
-            "Write-Output \"$($release.url), $($time.Year).$($time.DayOfYear).$($time.Hour).$($time.Minute)\""
+            "Write-Output \"$($release.url), $($release.timestamp)\""
         ],
         "regex": "insider/(?<commit>[^/]+)/VSCode-win32-x64-(?<prefix>[\\d.]+)[^\\d]+(?<suffix>[\\d.]+)",
         "replace": "${prefix}-${suffix}"

--- a/bucket/vscode-insiders.json
+++ b/bucket/vscode-insiders.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.126.0-e6f4d6c",
+    "version": "1.126.0-2026.173.5",
     "description": "Visual Studio Code is a lightweight but powerful source code editor (Insiders, Portable Edition).",
-    "homepage": "https://code.visualstudio.com/",
+    "homepage": "https://code.visualstudio.com/insiders",
     "license": {
         "identifier": "Freeware",
         "url": "https://code.visualstudio.com/License/"
@@ -64,23 +64,27 @@
     },
     "checkver": {
         "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
-        "jsonpath": "$..['version', 'productVersion']",
-        "regex": "^\\[\"(?<commit>(?<commitShort>[0-9a-f]{7})[0-9a-f]*)\",\"(?<productVersion>.+)-insider\"",
-        "replace": "${productVersion}-${commitShort}"
+        "script": [
+            "$release = $page | ConvertFrom-Json -ErrorAction Stop",
+            "$time = [DateTimeOffset]::FromUnixTimeMilliseconds($release.timestamp)",
+            "Write-Output \"$($release.url), $($time.Year).$($time.DayOfYear).$($time.Hour)\""
+        ],
+        "regex": "insider/(?<commit>[^/]+)/VSCode-win32-x64-(?<prefix>[\\d.]+)[^\\d]+(?<suffix>[\\d.]+)",
+        "replace": "${prefix}-${suffix}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
                 "url": "https://vscode.download.prss.microsoft.com/dbazure/download/insider/$matchCommit/VSCode-win32-x64-$matchHead-insider.zip",
                 "hash": {
-                    "url": "https://update.code.visualstudio.com/api/update/win32-x64-archive/insider/latest",
+                    "url": "https://update.code.visualstudio.com/api/versions/$matchHead-insider/win32-x64-archive/insider",
                     "jsonpath": "$.sha256hash"
                 }
             },
             "arm64": {
                 "url": "https://vscode.download.prss.microsoft.com/dbazure/download/insider/$matchCommit/VSCode-win32-arm64-$matchHead-insider.zip",
                 "hash": {
-                    "url": "https://update.code.visualstudio.com/api/update/win32-arm64-archive/insider/latest",
+                    "url": "https://update.code.visualstudio.com/api/versions/$matchHead-insider/win32-arm64-archive/insider",
                     "jsonpath": "$.sha256hash"
                 }
             }


### PR DESCRIPTION
### Summary

Updates `vscode-insiders` to version **1.127.0-2026.174.17.8** and completely overhauls the `checkver` mechanism to parse upstream release timestamps dynamically via a custom script.

### Related issues or pull requests

- Relates to #2499 

### Changes

- Update version to **1.127.0-2026.174.17.8**
- Correct `homepage` to point directly to the Insiders landing page (`https://code.visualstudio.com/insiders`)
- Refactor `checkver` from JSONPath extraction to a custom `script` tracking release timestamp and year/day-of-year metadata
- Rewrite `autoupdate` block to fetch hash from version-specific endpoints (`/api/versions/$matchHead...`) instead of the generic `/latest` endpoint

### Notes

- The new versioning schema transitions from `<productVersion>-<commitShort>` to a time-based format `<prefix>-<year>.<dayOfYear>.<hour>.<minute>` to improve version sorting consistency for Insiders builds.

### Testing

<details>

<summary>The test results are as follows:</summary> <br>

```powershell
┏[ D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Versions][ vscode-insiders ≡]
└─> .\bin\checkver.ps1 -App .\bucket\vscode-insiders.json -f
vscode-insiders: 1.127.0-2026.174.17.8 (scoop version is 1.126.0-2026.173.5) autoupdate available
Forcing autoupdate!
Autoupdating vscode-insiders
... ...
DEBUG[1782271167] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:230:5
DEBUG[1782271167] $substitutions.$basenameNoExt                 VSCode-win32-arm64-1.127.0-insider
DEBUG[1782271167] $substitutions.$matchHead                     1.127.0
DEBUG[1782271167] $substitutions.$buildVersion
DEBUG[1782271167] $substitutions.$version                       1.127.0-2026.174.17.8
DEBUG[1782271167] $substitutions.$majorVersion                  1
DEBUG[1782271167] $substitutions.$preReleaseVersion             2026.174.17.8
DEBUG[1782271167] $substitutions.$basename                      VSCode-win32-arm64-1.127.0-insider.zip
DEBUG[1782271167] $substitutions.$cleanVersion                  112702026174178
DEBUG[1782271167] $substitutions.$matchCommit                   2858f2c0200dc2f4f87aca248c69daaf85f3ce69
DEBUG[1782271167] $substitutions.$underscoreVersion             1_127_0_2026_174_17_8
DEBUG[1782271167] $substitutions.$matchSuffix                   2026.174.17.8
DEBUG[1782271167] $substitutions.$matchTail                     -2026.174.17.8
DEBUG[1782271167] $substitutions.$dotVersion                    1.127.0.2026.174.17.8
DEBUG[1782271167] $substitutions.$baseurl                       https://vscode.download.prss.microsoft.com/dbazure/download/insider/2858f2c0200dc2f4f87aca248c69daaf85f3ce69
DEBUG[1782271167] $substitutions.$url                           https://vscode.download.prss.microsoft.com/dbazure/download/insider/2858f2c0200dc2f4f87aca248c69daaf85f3ce69/VSCode-win32-ar…
DEBUG[1782271167] $substitutions.$dashVersion                   1-127-0-2026-174-17-8
DEBUG[1782271167] $substitutions.$minorVersion                  127
DEBUG[1782271167] $substitutions.$patchVersion                  0
DEBUG[1782271167] $substitutions.$matchPrefix                   1.127.0
DEBUG[1782271167] $substitutions.$urlNoExt                      https://vscode.download.prss.microsoft.com/dbazure/download/insider/2858f2c0200dc2f4f87aca248c69daaf85f3ce69/VSCode-win32-ar…
DEBUG[1782271167] $hashfile_url = https://update.code.visualstudio.com/api/versions/1.127.0-insider/win32-arm64-archive/insider -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:233:5
Searching hash for VSCode-win32-arm64-1.127.0-insider.zip in https://update.code.visualstudio.com/api/versions/1.127.0-insider/win32-arm64-archive/insider
DEBUG[1782271169] $jsonpath = $.sha256hash -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:140:5
Found: 41922e7ad278520ba18dcd218b1cbccd8b09a5934e5d3dd3e17f253137ba0799 using Json Mode
Writing updated vscode-insiders manifest

```

</details>

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)