### PR TITLE
wezterm-nightly: Switch to wezterm/wezterm repo, fix checkver and autoupdate

### DIFF
--- a/bucket/wezterm-nightly.json
+++ b/bucket/wezterm-nightly.json
@@ -1,7 +1,7 @@
 {
-    "version": "nightly",
+    "version": "20260706-c53ca64",
     "description": "GPU-accelerated terminal emulator (nightly builds)",
-    "homepage": "https://github.com/wez/wezterm",
+    "homepage": "https://github.com/wezterm/wezterm",
     "license": "Apache-2.0",
     "notes": [
         "Add \"Open with Wezterm\" as a context menu option by running:",
@@ -9,7 +9,8 @@
     ],
     "architecture": {
         "64bit": {
-            "url": "https://github.com/wez/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip"
+            "url": "https://github.com/wezterm/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip",
+            "hash": "4e98f2d34e428a1920b929f3dae70896b2761516a44c980b96bd28b550033f75"
         }
     },
     "installer": {
@@ -42,5 +43,31 @@
     ],
     "uninstaller": {
         "script": "if ($cmd -eq 'uninstall') { reg import \"$dir\\uninstall-context.reg\" *> $null }"
+    },
+    "checkver": {
+        "github": "https://api.github.com/repos/wezterm/wezterm/releases/tags/nightly",
+        "script": [
+            "$release = $page | ConvertFrom-Json",
+            "$date = Get-Date $release.updated_at -Format 'yyyyMMdd'",
+            "if ($release.target_commitish -match '^[0-9a-f]{40}$') {",
+            "    $commit = $release.target_commitish.Substring(0, 7)",
+            "} else {",
+            "    $commit = (Invoke-RestMethod 'https://api.github.com/repos/wezterm/wezterm/commits/nightly').sha.Substring(0, 7)",
+            "}",
+            "$output = @{'result' = \"$date-$commit\"} | ConvertTo-Json -Compress",
+            "Write-Output $output"
+        ],
+        "jsonpath": "$.result",
+        "regex": "(?<version>^\\d{8}-[0-9a-f]{7})"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/wezterm/wezterm/releases/download/nightly/WezTerm-windows-nightly.zip",
+                "hash": {
+                    "url": "$url.sha256"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The WezTerm project moved from `wez/wezterm` to the `wezterm/wezterm` organization, and this manifest still pointed at the old repository. On top of that, `version` was hardcoded to the literal string `nightly`, so `scoop update` / `scoop status` could never detect a newer nightly build and the package effectively never updated after install.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
