### PR TITLE
handbrake-snapshot: Update to version 20260705-e02d1e31a

### DIFF
--- a/bucket/handbrake-snapshot.json
+++ b/bucket/handbrake-snapshot.json
@@ -1,5 +1,5 @@
 {
-    "version": "20260630-5e4735b97",
+    "version": "20260705-e02d1e31a",
     "description": "Snapshot releases of the tool for converting video from nearly any format to a selection of modern, widely supported codecs.",
     "homepage": "https://handbrake.fr",
     "license": "GPL-2.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/HandBrake/HandBrake-snapshots/releases/download/win/HandBrake-20260630-5e4735b97-x86_64-Win_GUI.zip",
-            "hash": "7de01b48c47574b58ee3986c9a25ff2e4b0de5f29ce534521754605478ef670b"
+            "url": "https://github.com/HandBrake/HandBrake-snapshots/releases/download/win/HandBrake-20260705-e02d1e31a-x86_64-Win_GUI.zip",
+            "hash": "dc22e43aee9fb4f9f76f6a4bbdbeb01da91701015cd9e62820ba090eb294bc33"
         }
     },
     "extract_dir": "HandBrake",


### PR DESCRIPTION
Updates the deleted snapshot asset to the current Windows portable build. Closes #2949.