### PR TITLE
odin(-dev): Update to version 2026-07a, improve checkver regex to cover hotfix versions

### DIFF
--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -20,7 +20,7 @@
     "persist": "shared",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
-        "regex": "/releases/tag/dev-([\\d-]+)"
+        "regex": "/releases/tag/dev-([\\d-]+[a-z]?)"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/odin-dev.json
+++ b/bucket/odin-dev.json
@@ -1,12 +1,12 @@
 {
-    "version": "2026-07",
+    "version": "2026-07a",
     "description": "General-purpose programming language with distinct typing, built for high performance, modern systems, and built-in data-oriented data types.",
     "homepage": "https://odin-lang.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2026-07/odin-windows-amd64-dev-2026-07.zip",
-            "hash": "af23e95498fb11f3ec6793f1fede8cd75890261541f9933031db1f52146842a1"
+            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2026-07a/odin-windows-amd64-dev-2026-07a.zip",
+            "hash": "cfe09f1c086b29d12158f14d6772a775ecc2b842119f8ff5a78e62a5cb656cf8"
         }
     },
     "pre_install": [

--- a/bucket/odin.json
+++ b/bucket/odin.json
@@ -1,13 +1,13 @@
 {
     "##": "Duplicate (alias) of the odin-dev package",
-    "version": "2026-07",
+    "version": "2026-07a",
     "description": "General-purpose programming language with distinct typing, built for high performance, modern systems, and built-in data-oriented data types.",
     "homepage": "https://odin-lang.org/",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2026-07/odin-windows-amd64-dev-2026-07.zip",
-            "hash": "af23e95498fb11f3ec6793f1fede8cd75890261541f9933031db1f52146842a1"
+            "url": "https://github.com/odin-lang/Odin/releases/download/dev-2026-07a/odin-windows-amd64-dev-2026-07a.zip",
+            "hash": "cfe09f1c086b29d12158f14d6772a775ecc2b842119f8ff5a78e62a5cb656cf8"
         }
     },
     "pre_install": [
@@ -21,7 +21,7 @@
     "persist": "shared",
     "checkver": {
         "url": "https://github.com/odin-lang/Odin/releases/latest",
-        "regex": "/releases/tag/dev-([\\d-]+)"
+        "regex": "/releases/tag/dev-([\\d-]+[a-z]?)"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
Hotfixes use a letter suffix, see: https://github.com/odin-lang/Odin/releases/tag/dev-2026-07a

[`odin.json`](https://github.com/ScoopInstaller/Versions/blob/master/bucket/odin.json) is a duplicate of `odin-dev.json`. Presumably it automatically mirrors the edits to this manifest.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
