### PR TITLE
innounp-unicode@2.67.9: Update download URL, disable checkver

### DIFF
--- a/bucket/innounp-unicode.json
+++ b/bucket/innounp-unicode.json
@@ -3,13 +3,9 @@
     "description": "Inno Setup Unpacker (Unicode)",
     "homepage": "https://www.rathlev-home.de/tools/prog-e.html#unpack",
     "license": "GPL-3.0-only",
-    "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip",
+    "url": "https://github.com/jrathlev/InnoUnpacker-Windows-GUI/releases/download/ui_2_2_9/innounp-2.zip",
     "hash": "1439f8d9e24b19e7d0b31b9c427ba4533387522a370c39280f17d3371eb7febf",
     "bin": "innounp.exe",
-    "checkver": {
-        "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/docs/innounp.htm",
-        "regex": "(?s)What's new/History.*?<b>(\\d+(?:\\.\\d+){2})</b>"
-    },
     "autoupdate": {
         "url": "https://raw.githubusercontent.com/jrathlev/InnoUnpacker-Windows-GUI/refs/heads/master/innounp-2/bin/innounp-2.zip"
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

> A bug was introduced in innounp that causes all extractions to fail. This PR rolls it back to version 2.67.9 (https://github.com/ScoopInstaller/Main/commit/0e86906e443f1953558f2032e5b50f4d786fdf7f) and disables checkver.

Relates to https://github.com/ScoopInstaller/Main/pull/8294

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
