### PR TITLE
gradle7: Update to version 7.6.6

### DIFF
--- a/bucket/gradle7.json
+++ b/bucket/gradle7.json
@@ -1,11 +1,11 @@
 {
-    "version": "7.6.1",
+    "version": "7.6.6",
     "description": "An open-source build automation tool focused on flexibility and performance. (Source code and documentation boundled)",
     "homepage": "https://gradle.org",
     "license": "Apache-2.0",
-    "hash": "518a863631feb7452b8f1b3dc2aaee5f388355cc3421bbd0275fbeadd77e84b2",
-    "url": "https://services.gradle.org/distributions/gradle-7.6.1-all.zip",
-    "extract_dir": "gradle-7.6.1",
+    "hash": "6ed4d467349e2d3f555a578829c4aeadd67d73e2ec5d213c2a62f8f2829d9fa9",
+    "url": "https://services.gradle.org/distributions/gradle-7.6.6-all.zip",
+    "extract_dir": "gradle-7.6.6",
     "bin": "bin\\gradle.bat",
     "suggest": {
         "JDK": [

--- a/bucket/gradle7.json
+++ b/bucket/gradle7.json
@@ -1,6 +1,6 @@
 {
     "version": "7.6.6",
-    "description": "An open-source build automation tool focused on flexibility and performance. (Source code and documentation boundled)",
+    "description": "An open-source build automation tool focused on flexibility and performance. (Source code and documentation bundled)",
     "homepage": "https://gradle.org",
     "license": "Apache-2.0",
     "hash": "6ed4d467349e2d3f555a578829c4aeadd67d73e2ec5d213c2a62f8f2829d9fa9",


### PR DESCRIPTION
## Chances

- https://services.gradle.org/versions/7

The Gradle team is excited to announce Gradle 7.6.6.

This is the sixth patch release for Gradle 7.6.