### PR TITLE
orcaslicer-nightly: Update to version 1785345112, fix autoupdate, add arm64 support

### DIFF
--- a/bucket/orcaslicer-nightly.json
+++ b/bucket/orcaslicer-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "1782641910",
+    "version": "1785339462",
     "description": "G-code generator for 3D printers (Bambu, Prusa, Voron, VzBot, RatRig, Creality, etc.)",
     "homepage": "https://github.com/OrcaSlicer/OrcaSlicer",
     "license": "AGPL-3.0-or-later",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_nightly_portable.zip",
-            "hash": "de802d23cd922b4ab7dfecca15acb7b921f593562a41dca9c1c9abe5ecb7cf50"
+            "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_x64_nightly_portable.zip",
+            "hash": "ac99e3b4d7434d140511b8e2d772ef6b2bc442afbc8c9246f44e3fffe49ceeb0"
         }
     },
     "extract_dir": "OrcaSlicer",
@@ -29,7 +29,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_nightly_portable.zip"
+                "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_x64_nightly_portable.zip"
             }
         }
     }

--- a/bucket/orcaslicer-nightly.json
+++ b/bucket/orcaslicer-nightly.json
@@ -1,5 +1,5 @@
 {
-    "version": "1785339462",
+    "version": "1785345112",
     "description": "G-code generator for 3D printers (Bambu, Prusa, Voron, VzBot, RatRig, Creality, etc.)",
     "homepage": "https://github.com/OrcaSlicer/OrcaSlicer",
     "license": "AGPL-3.0-or-later",
@@ -7,6 +7,10 @@
         "64bit": {
             "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_x64_nightly_portable.zip",
             "hash": "ac99e3b4d7434d140511b8e2d772ef6b2bc442afbc8c9246f44e3fffe49ceeb0"
+        },
+        "arm64": {
+            "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_arm64_nightly_portable.zip",
+            "hash": "665e82ac5625603432c67f24b09cb34b33255d4c3cbaf130c347897bad718303"
         }
     },
     "extract_dir": "OrcaSlicer",
@@ -30,6 +34,9 @@
         "architecture": {
             "64bit": {
                 "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_x64_nightly_portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/OrcaSlicer/OrcaSlicer/releases/download/nightly-builds/OrcaSlicer_Windows_arm64_nightly_portable.zip"
             }
         }
     }


### PR DESCRIPTION
## 📖 Description

Relates to https://github.com/ScoopInstaller/Extras/pull/18268

> https://github.com/OrcaSlicer/OrcaSlicer/releases/tag/v2.4.1
With the new ARM64 builds, the Windows x64 installer and portable downloads now carry an _x64 suffix in their filenames to distinguish them from the ARM64 ones.

Fixes #2971 — `orcaslicer-nightly` download fails because upstream renamed the Windows nightly assets to include the arch infix (`OrcaSlicer_Windows_x64_nightly_portable.zip`); the manifest and its autoupdate URL still pointed at the old name (`OrcaSlicer_Windows_nightly_portable.zip`), which now 404s.

Changes:
- `architecture.64bit.url` → live x64 asset URL
- `architecture.64bit.hash` → sha256 of the current nightly zip (full local download verified)
- `version` → current release.updated_at epoch (1785339462)
- `autoupdate.architecture.64bit.url` aligned

## ✅ Checklist

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] The manifest file(s) are in the correct format and pass all 7 verify checks where possible
- [x] The hash was computed from the actual downloaded release asset
