### PR TITLE
ols-(dev|nightly): Expose odinfmt binary

### DIFF
--- a/bucket/ols-dev.json
+++ b/bucket/ols-dev.json
@@ -1,6 +1,6 @@
 {
     "version": "2026-06",
-    "description": "Language server for Odin (Dev version).",
+    "description": "Language server for Odin (Dev version) including odinfmt.",
     "homepage": "https://github.com/DanielGavin/ols",
     "license": "MIT",
     "architecture": {
@@ -11,6 +11,10 @@
                 [
                     "ols-x86_64-pc-windows-msvc.exe",
                     "ols"
+                ],
+                [
+                    "odinfmt-x86_64-pc-windows-msvc.exe",
+                    "odinfmt"
                 ]
             ]
         }

--- a/bucket/ols-nightly.json
+++ b/bucket/ols-nightly.json
@@ -1,6 +1,6 @@
 {
     "version": "20260802-gf7a73ae",
-    "description": "Language server for Odin including odinfmt.",
+    "description": "Language server for Odin (Nightly version) including odinfmt.",
     "homepage": "https://github.com/DanielGavin/ols",
     "license": "MIT",
     "architecture": {

--- a/bucket/ols-nightly.json
+++ b/bucket/ols-nightly.json
@@ -1,6 +1,6 @@
 {
     "version": "20260802-gf7a73ae",
-    "description": "Language server for Odin.",
+    "description": "Language server for Odin including odinfmt.",
     "homepage": "https://github.com/DanielGavin/ols",
     "license": "MIT",
     "architecture": {
@@ -13,6 +13,10 @@
         [
             "ols-x86_64-pc-windows-msvc.exe",
             "ols"
+        ],
+        [
+            "odinfmt-x86_64-pc-windows-msvc.exe",
+            "odinfmt"
         ]
     ],
     "checkver": {


### PR DESCRIPTION
## Summary

- expose the `odinfmt` executable already included in OLS development and nightly release archives
- add an `odinfmt` Scoop shim alongside the existing `ols` shim in both manifests

## Verification

- reinstalled `ols-dev` from the local manifest and confirmed both shims resolve
- installed `ols-nightly` from the local manifest and confirmed both shims resolve
- formatted smoke-test Odin source through `odinfmt -stdin` from each package
- restored the local `ols-dev` installation after nightly verification

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)