### PR TITLE
freerdp-nightly: Fix bin for renamed/removed upstream binaries

### DIFF
--- a/bucket/freerdp-nightly.json
+++ b/bucket/freerdp-nightly.json
@@ -12,10 +12,8 @@
     "extract_dir": "archive\\install\\bin",
     "bin": [
         "freerdp-proxy.exe",
-        "sdl2-freerdp.exe",
-        "sdl3-freerdp.exe",
+        "sdl-freerdp.exe",
         "sfreerdp-server.exe",
-        "wfreerdp.exe",
         "winpr-hash.exe",
         "winpr-makecert.exe"
     ],


### PR DESCRIPTION
### Prerequisites

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)

## Summary

Upstream FreeRDP renamed/removed binaries in the nightly Windows build: `sdl2-freerdp.exe` and `sdl3-freerdp.exe` were merged into a single `sdl-freerdp.exe`, and `wfreerdp.exe` is no longer shipped. The current `bin` list still references the old names, so `scoop install`/`update freerdp-nightly` fails on shim creation.

Verified against the actual artifact of the pinned build (2045): `archive/install/bin` now contains exactly `freerdp-proxy.exe`, `sdl-freerdp.exe`, `sfreerdp-server.exe`, `winpr-hash.exe`, `winpr-makecert.exe` — the manifest `bin` is updated to match. Version/url/hash/checkver/autoupdate are untouched (already current in master).

Closes #2976

## Test Plan

- [x] Downloaded the pinned build 2045 artifact and listed `archive/install/bin` — matches the new `bin` list exactly
- [x] Manifest JSON still validates structurally (single-file scope)
- [ ] Windows scoop install/update smoke (maintainer CI `/verify`)
