### PR TITLE
neovide-dev: Switch to nightly builds

### DIFF
--- a/bucket/neovide-dev.json
+++ b/bucket/neovide-dev.json
@@ -1,15 +1,15 @@
 {
-    "version": "0.16.2",
-    "description": "A simple GUI for Neovim (prerelease version)",
-    "homepage": "https://github.com/Kethku/neovide",
+    "version": "20260727-7f90c12",
+    "description": "A simple GUI for Neovim (nightly version)",
+    "homepage": "https://neovide.dev",
     "license": "MIT",
     "suggest": {
         "neovim": "neovim"
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/neovide/neovide/releases/download/0.16.2/neovide.exe.zip",
-            "hash": "d1e071d8bf676a500988820b852843e811fc8355396ce72e8f4c7ed2c744e2e2"
+            "url": "https://github.com/neovide/neovide/releases/download/nightly/neovide-windows-x86_64.zip",
+            "hash": "d57aab4d0ab4e08d6dc94f6fbea8c66ef9aaefb0d033dbb672d9243a2f7ce2c6"
         }
     },
     "bin": "neovide.exe",
@@ -20,13 +20,21 @@
         ]
     ],
     "checkver": {
-        "github": "https://api.github.com/repos/neovide/neovide/releases",
-        "jsonpath": "$[0].tag_name"
+        "github": "https://api.github.com/repos/neovide/neovide/releases/tags/nightly",
+        "script": [
+            "$release = $page | ConvertFrom-Json",
+            "$date = Get-Date $release.updated_at -Format 'yyyyMMdd'",
+            "$commit = $release.target_commitish",
+            "$output = @{'result' = \"$date-$commit\"} | ConvertTo-Json -Compress",
+            "Write-Output $output"
+        ],
+        "jsonpath": "$.result",
+        "regex": "(?<version>^\\d{8}-[0-9a-f]{7})"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/neovide/neovide/releases/download/$version/neovide.exe.zip"
+                "url": "https://github.com/neovide/neovide/releases/download/nightly/neovide-windows-x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
## 📖 Description

Closes #2975 — `neovide-dev` was tracking the stable release instead of nightly: its checkver read `$[0].tag_name` from the releases list (which resolves to the latest stable tag) and its autoupdate URL pointed at the stable asset, so the manifest stayed byte-identical to `extras/neovide` (0.16.2, same hash).

Switches the manifest to the upstream `nightly` prerelease:

- `checkver` → queries `releases/tags/nightly` and derives the version as `<yyyyMMdd>-<short commit>` from the release's `updated_at` and `target_commitish`, following the `goneovim-nightly` pattern in this bucket (`neovim-nightly`, `micro-nightly`, `komorebi-nightly` use the same `releases/tags/nightly` endpoint)
- `architecture.64bit.url` / `autoupdate` → nightly asset `neovide-windows-x86_64.zip` under the fixed `nightly` tag (as suggested in the issue)
- `version` / `hash` → current nightly `20260727-7f90c12`, sha256 computed from a fresh download of the asset
- `homepage` → `https://neovide.dev` (the old `github.com/Kethku/neovide` URL predates the org move), aligned with `extras/neovide`
- `description` → "(nightly version)"

## 🧪 Test Plan

- Nightly asset downloads with HTTP 200; sha256 of a fresh download matches the manifest
- The zip contains exactly `neovide.exe` at its root, matching `bin` and `shortcuts`
- Checkver extraction simulated against the live GitHub API response (`updated_at` + `target_commitish` → `20260727-7f90c12`)
- Manifest validates against the Scoop JSON schema
- Not run: end-to-end `scoop install` / `checkver` (no Windows/Scoop environment at hand) — relying on maintainer CI (`/verify`) for the final smoke

## ✅ Checklist

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)
- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] The hash was computed from the actual downloaded release asset
