### PR TITLE
snappy-driver-installer-origin1.18: Add version 1.18.0.830

### DIFF
--- a/bucket/snappy-driver-installer-origin1.18.json
+++ b/bucket/snappy-driver-installer-origin1.18.json
@@ -21,7 +21,7 @@
     },
     "installer": {
         "script": [
-            "if (Test-Path \"$persist_dir\\sdi.cfg\") { Move-Item \"$persist_dir\\sdi.cfg\" \"$persist_dir\\sdio.cfg\" | Out-Null }",
+            "if ((Test-Path \"$persist_dir\\sdi.cfg\") -and (-not (Test-Path \"$persist_dir\\sdio.cfg\"))) { Move-Item \"$persist_dir\\sdi.cfg\" \"$persist_dir\\sdio.cfg\" | Out-Null }",
             "if (-not (Test-Path \"$persist_dir\\sdio.cfg\")) { New-Item \"$dir\\sdio.cfg\" | Out-Null }"
         ]
     },

--- a/bucket/snappy-driver-installer-origin1.18.json
+++ b/bucket/snappy-driver-installer-origin1.18.json
@@ -1,0 +1,49 @@
+{
+    "version": "1.18.0.830",
+    "description": "Device drivers installer and updater",
+    "homepage": "https://web.archive.org/web/20260721114131/https://www.glenn.delahoy.com/snappy-driver-installer-origin/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://web.archive.org/web/20260430091016id_/https://www.glenn.delahoy.com/downloads/sdio/SDIO_1.18.0.830.zip",
+    "hash": "7bb0cecaca9d69493a730763c980471a8eadd0c5bf9bf5b20df2d090e3692819",
+    "architecture": {
+        "32bit": {
+            "pre_install": [
+                "Remove-Item \"$dir\\SDIO_x64_*exe\"",
+                "Move-Item \"$dir\\SDIO_*.exe\" \"$dir\\SDIO.exe\""
+            ]
+        },
+        "64bit": {
+            "pre_install": [
+                "Move-Item \"$dir\\SDIO_x64_*.exe\" \"$dir\\SDIO.exe\"",
+                "Remove-Item \"$dir\\SDIO_*exe\""
+            ]
+        }
+    },
+    "installer": {
+        "script": [
+            "if (Test-Path \"$persist_dir\\sdi.cfg\") { Move-Item \"$persist_dir\\sdi.cfg\" \"$persist_dir\\sdio.cfg\" | Out-Null }",
+            "if (-not (Test-Path \"$persist_dir\\sdio.cfg\")) { New-Item \"$dir\\sdio.cfg\" | Out-Null }"
+        ]
+    },
+    "bin": [
+        "SDIO.exe",
+        [
+            "del_old_driverpacks.bat",
+            "SDIO_del_old_driverpacks.bat"
+        ]
+    ],
+    "shortcuts": [
+        [
+            "SDIO.exe",
+            "Snappy Driver Installer Origin Version 1.18.0"
+        ]
+    ],
+    "persist": [
+        "drivers",
+        "indexes",
+        "logs",
+        "scripts",
+        "update",
+        "sdio.cfg"
+    ]
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Manifest sourced from <https://github.com/ScoopInstaller/Extras/blob/2ed1fc0e79fee5b7c311088a34e72521df10d14a/bucket/snappy-driver-installer-origin.json>

From [homepage](<https://www.glenn.delahoy.com/snappy-driver-installer-origin/>):
> This version will be available until we get the kinks out of version 2.

which is why I'm using Wayback Machine links here.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
