### PR TITLE
wox-beta@2.4.0-beta.2: Fix homepage URL

### DIFF
--- a/bucket/wox-beta.json
+++ b/bucket/wox-beta.json
@@ -1,7 +1,7 @@
 {
     "version": "2.4.0-beta.2",
     "description": "A full-featured launcher, access programs and web contents as you type.",
-    "homepage": "http://www.wox.one",
+    "homepage": "https://github.com/Wox-launcher/Wox",
     "license": "MIT",
     "suggest": {
         "Python3": "python",


### PR DESCRIPTION
## Summary

- Update Wox Beta's homepage URL to the official GitHub repository.

## Change

- `http://www.wox.one` → `https://github.com/Wox-launcher/Wox`

No download URL, version, or hash changes.