### PR TITLE
redasm-beta: Add version 4.0.0-beta2

### DIFF
--- a/bucket/redasm-beta.json
+++ b/bucket/redasm-beta.json
@@ -1,34 +1,34 @@
 {
-  "version": "4.0.0-beta2",
-  "description": "The Open Source Disassembler (Beta release)",
-  "homepage": "https://redasm.dev",
-  "license": "GPL-3.0-or-later",
-  "suggest": {
-    "vcredist": "extras/vcredist2022"
-  },
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/redasm-dev/redasm/releases/download/v4.0.0-beta2/REDasm-4.0.0-beta2-windows-x86_64.zip",
-      "hash": "f30f69dfa95e56cfd997053befaeba3585843d368875c7ff51e5a6b893aa3d26",
-      "extract_dir": "redasm-windows-x86_64"
-    }
-  },
-  "bin": "redasm-gui.exe",
-  "shortcuts": [
-    [
-      "redasm-gui.exe",
-      "REDasm Disassembler (Beta)"
-    ]
-  ],
-  "checkver": {
-    "github": "https://api.github.com/redasm-dev/redasm"
-    "regex": "v?([\\d.]+-(?:beta|rc)\\d*|[\\d.]+)"
-  },
-  "autoupdate": {
+    "version": "4.0.0-beta2",
+    "description": "The Open Source Disassembler (Beta release)",
+    "homepage": "https://redasm.dev",
+    "license": "GPL-3.0-or-later",
+    "suggest": {
+        "vcredist": "extras/vcredist2022"
+    },
     "architecture": {
-      "64bit": {
-        "url": "https://github.com/redasm-dev/redasm/releases/download/v$version/REDasm-$version-windows-x86_64.zip"
-      }
+        "64bit": {
+            "url": "https://github.com/redasm-dev/redasm/releases/download/v4.0.0-beta2/REDasm-4.0.0-beta2-windows-x86_64.zip",
+            "hash": "f30f69dfa95e56cfd997053befaeba3585843d368875c7ff51e5a6b893aa3d26",
+            "extract_dir": "redasm-windows-x86_64"
+        }
+    },
+    "bin": "redasm-gui.exe",
+    "shortcuts": [
+        [
+            "redasm-gui.exe",
+            "REDasm Disassembler (Beta)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/redasm-dev/redasm",
+        "regex": "v?([\\d.]+-(?:beta|rc)\\d*|[\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/redasm-dev/redasm/releases/download/v$version/REDasm-$version-windows-x86_64.zip"
+            }
+        }
     }
-  }
 }

--- a/bucket/redasm-beta.json
+++ b/bucket/redasm-beta.json
@@ -1,0 +1,34 @@
+{
+  "version": "4.0.0-beta2",
+  "description": "The Open Source Disassembler (Beta release)",
+  "homepage": "https://redasm.dev",
+  "license": "GPL-3.0-or-later",
+  "suggest": {
+    "vcredist": "extras/vcredist2022"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/redasm-dev/redasm/releases/download/v4.0.0-beta2/REDasm-4.0.0-beta2-windows-x86_64.zip",
+      "hash": "f30f69dfa95e56cfd997053befaeba3585843d368875c7ff51e5a6b893aa3d26",
+      "extract_dir": "redasm-windows-x86_64"
+    }
+  },
+  "bin": "redasm-gui.exe",
+  "shortcuts": [
+    [
+      "redasm-gui.exe",
+      "REDasm Disassembler (Beta)"
+    ]
+  ],
+  "checkver": {
+    "github": "https://api.github.com/redasm-dev/redasm"
+    "regex": "v?([\\d.]+-(?:beta|rc)\\d*|[\\d.]+)"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/redasm-dev/redasm/releases/download/v$version/REDasm-$version-windows-x86_64.zip"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi! I'm the upstream maintainer and creator of [REDasm](https://github.com/redasm-dev).

This pull request brings v4 BETA to Scoop: it's a total rewrite and currently under heavy development.

I noticed that there is a very outdated 2.1.1. version in [Extras](https://github.com/ScoopInstaller/Extras/blob/master/bucket/redasm.json) which probably doesn't work anymore.

URLs are changed too:
- https://redasm.dev is the new home
- new repos are moved in https://github.com/redasm-dev
- **NOTE:** I'm still keeping `REDasmOrg` name in order to avoid supply chain attacks


- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
