### PR TITLE
oss-cad-suite-nightly: Update to version 2026-09-04, fix autoupdate, add shim for pwsh environment

### DIFF
--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2026-08-24",
+    "version": "2026-09-04",
     "description": "Open source digital design and verification tools. Includes tools for RTL synthesis, formal hardware verification, place & route, FPGA programming, and testing with support for HDLs like Verilog, Migen and Amaranth.",
     "homepage": "https://github.com/YosysHQ/oss-cad-suite-build",
     "license": "ISC",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-08-24/oss-cad-suite-windows-x64-20260824.tgz",
-            "hash": "95d3cf2a59d1617f2363ee9370bb3577799f33a07e9c66e126ddeb68e8e5814c"
+            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-09-04/oss-cad-suite-windows-x64-20260904.tgz",
+            "hash": "ce60c30eb2bb0b79dfb05030549c4f0fd0e6b4cf5e2524526b0fdfc979cde6b0"
         }
     },
     "extract_dir": "oss-cad-suite",
@@ -22,8 +22,7 @@
         ]
     ],
     "checkver": {
-        "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases",
-        "regex": "tree\\/([\\d-]+)"
+        "github": "https://github.com/YosysHQ/oss-cad-suite-build"
     },
     "autoupdate": {
         "architecture": {

--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -15,6 +15,10 @@
         [
             "start.bat",
             "oss-cad"
+        ],
+        [
+            "environment.ps1",
+            "oss-cad-pwsh"
         ]
     ],
     "checkver": {

--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -24,7 +24,7 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/$version/oss-cad-suite-windows-x64-$cleanVersion.exe#/dl.7z"
+                "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/$version/oss-cad-suite-windows-x64-$cleanVersion.tgz"
             }
         }
     }

--- a/bucket/oss-cad-suite-nightly.json
+++ b/bucket/oss-cad-suite-nightly.json
@@ -1,12 +1,12 @@
 {
-    "version": "2026-07-31",
+    "version": "2026-08-24",
     "description": "Open source digital design and verification tools. Includes tools for RTL synthesis, formal hardware verification, place & route, FPGA programming, and testing with support for HDLs like Verilog, Migen and Amaranth.",
     "homepage": "https://github.com/YosysHQ/oss-cad-suite-build",
     "license": "ISC",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-07-31/oss-cad-suite-windows-x64-20260731.exe#/dl.7z",
-            "hash": "b9c83b9aaaf8018525651e73e0f52fa56c60f9a61b7226eca9ace391e67ad2b6"
+            "url": "https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2026-08-24/oss-cad-suite-windows-x64-20260824.tgz",
+            "hash": "95d3cf2a59d1617f2363ee9370bb3577799f33a07e9c66e126ddeb68e8e5814c"
         }
     },
     "extract_dir": "oss-cad-suite",


### PR DESCRIPTION
This PR fixes the autoupdate URL (changed from .exe to .tgz in this commit: https://github.com/YosysHQ/oss-cad-suite-build/commit/695ed6ce3a61d10332578d96eb40371dc94dfb3c) and adds a new shim.

Commit one only fixes the autoupdate url.

`./bin/checkver.ps1 -u oss-cad-suite-nightly` was run to create the second commit and update the manifest to the currently newest version.

Commit three adds a shim for the PowerShell environment, so that it can also be uses, same as the already existing one for command prompt.

<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
