### PR TITLE
cloudcompare-alpha@2.14.beta: Fix hash

### DIFF
--- a/bucket/cloudcompare-alpha.json
+++ b/bucket/cloudcompare-alpha.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://cloudcompare.org/release/CloudCompare_v2.14.beta_bin_x64.7z",
-            "hash": "2bc6bc272a1f938db9d15ec1a540aa4b159eb27987a6cb95bf403aec250ed970"
+            "hash": "a1d941383af2075d10f93a23d066a7be7df99df03d37ac1b29f63f2d517a48ae"
         }
     },
     "extract_dir": "CloudCompare_v2.14.beta_bin_x64",


### PR DESCRIPTION
> [!IMPORTANT]
Changed hash from the unreproducable
```2bc6bc272a1f938db9d15ec1a540aa4b159eb27987a6cb95bf403aec250ed970```
to the correct SHA-256
```a1d941383af2075d10f93a23d066a7be7df99df03d37ac1b29f63f2d517a48ae```

<img width="500" alt="Hash Validation Success-2026-08-29-022305" src="https://github.com/user-attachments/assets/9ab02ec9-6bae-4e6c-a1ae-069dd6839f65" />

> [!NOTE]
> Screenshot of reported hash from Scoop versus calculated hash from NanaZip
<img width="600" alt="Screenshot 2026-08-28 143436" src="https://github.com/user-attachments/assets/55ed4e53-86fa-489e-870f-df2f0438c5bc" />  

> [!NOTE]
> - [x] Use conventional PR title:  
>    - `<manifest-name[@version]|chore>: <general summary of the pull request>`
> - [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->