### PR TITLE
llama.cpp-(*): Add shim for `llama.exe`

### DIFF
--- a/bucket/llama.cpp-cpu.json
+++ b/bucket/llama.cpp-cpu.json
@@ -30,7 +30,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-cu117.json
+++ b/bucket/llama.cpp-cu117.json
@@ -25,7 +25,8 @@
         "llama-run.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "autoupdate": {

--- a/bucket/llama.cpp-cu117.json
+++ b/bucket/llama.cpp-cu117.json
@@ -25,8 +25,7 @@
         "llama-run.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe",
-        "llama.exe"
+        "llama-tts.exe"
     ],
     "persist": "models",
     "autoupdate": {

--- a/bucket/llama.cpp-cu124.json
+++ b/bucket/llama.cpp-cu124.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-cu13.json
+++ b/bucket/llama.cpp-cu13.json
@@ -30,7 +30,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-cu131.json
+++ b/bucket/llama.cpp-cu131.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "autoupdate": {

--- a/bucket/llama.cpp-cu133.json
+++ b/bucket/llama.cpp-cu133.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-hip-radeon.json
+++ b/bucket/llama.cpp-hip-radeon.json
@@ -30,7 +30,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-opencl.json
+++ b/bucket/llama.cpp-opencl.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-sycl.json
+++ b/bucket/llama.cpp-sycl.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {

--- a/bucket/llama.cpp-vulkan.json
+++ b/bucket/llama.cpp-vulkan.json
@@ -26,7 +26,8 @@
         "llama-qwen2vl-cli.exe",
         "llama-server.exe",
         "llama-tokenize.exe",
-        "llama-tts.exe"
+        "llama-tts.exe",
+        "llama.exe"
     ],
     "persist": "models",
     "checkver": {


### PR DESCRIPTION
The llama.cpp project now recommends interacting with the cli as an all-in-one binary with subcommands (example here: https://github.com/ggml-org/llama.cpp/blob/master/README.md?plain=1#L36).

This PR adds the `llama.exe` binary to the list of linked executables. I've validated that it works by running `scoop install llama.cpp-vulkan.json` from the bucket directory of this patched branch.

Note that the `openvino` variant of the `llama.cpp` package already had this change.

Closes #3022.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
