### PR TITLE
dbeaver-ea: Update to version 26.2.1-2026-09-07, fix checkver & autoupdate

### DIFF
--- a/bucket/dbeaver-ea.json
+++ b/bucket/dbeaver-ea.json
@@ -14,6 +14,10 @@
         "64bit": {
             "url": "https://dbeaver.io/files/ea/dbeaver-ce-26.2.1-windows-x86_64.zip",
             "hash": "d4b21c83697e1759adf1e432e7f933a625cd008152cfd96f810da32980cbbc45"
+        },
+        "arm64": {
+            "url": "https://dbeaver.io/files/ea/dbeaver-ce-26.2.1-windows-aarch64.zip",
+            "hash": "3bca3c1fea457e7c14631eb7a982b063a93d44fecaaaf81705ff5787728a8336"
         }
     },
     "extract_dir": "dbeaver",
@@ -42,7 +46,13 @@
         "architecture": {
             "64bit": {
                 "url": "https://dbeaver.io/files/ea/dbeaver-ce-$matchVer-windows-x86_64.zip"
+            },
+            "arm64": {
+                "url": "https://dbeaver.io/files/ea/dbeaver-ce-$matchVer-windows-aarch64.zip"
             }
+        },
+        "hash": {
+            "url": "$baseurl/checksum/$basename.sha256"
         }
     }
 }

--- a/bucket/dbeaver-ea.json
+++ b/bucket/dbeaver-ea.json
@@ -30,7 +30,6 @@
     "shortcuts": [
         [
             "dbeaver.exe",
-            "dbeaverc.exe",
             "DBeaver EA"
         ]
     ],

--- a/bucket/dbeaver-ea.json
+++ b/bucket/dbeaver-ea.json
@@ -1,5 +1,5 @@
 {
-    "version": "25.3.5-2026-02-11",
+    "version": "26.2.1-2026-09-07",
     "description": "Database tool for developers, SQL programmers, database administrators and analysts. (Early Access)",
     "homepage": "https://dbeaver.io",
     "license": "Apache-2.0",
@@ -12,36 +12,37 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://dbeaver.io/files/ea/dbeaver-ce-25.3.5-win32.win32.x86_64.zip",
-            "hash": "5723b743ab608f05561b166ea6724e9292e81008d797ac7ee58f1eb2d0ea8504"
+            "url": "https://dbeaver.io/files/ea/dbeaver-ce-26.2.1-windows-x86_64.zip",
+            "hash": "d4b21c83697e1759adf1e432e7f933a625cd008152cfd96f810da32980cbbc45"
         }
     },
     "extract_dir": "dbeaver",
     "bin": [
         [
-            "dbeaver-cli.exe",
-            "dbeaver-ea-cli"
-        ],
-        [
             "dbeaver.exe",
             "dbeaver-ea"
+        ],
+        [
+            "dbeaverc.exe",
+            "dbeaverc-ea"
         ]
     ],
     "shortcuts": [
         [
             "dbeaver.exe",
+            "dbeaverc.exe",
             "DBeaver EA"
         ]
     ],
     "checkver": {
         "url": "https://dbeaver.io/files/ea/",
-        "regex": "href=\"dbeaver-ce-(?<ver>[\\d.]+)-win32.win32.x86_64.zip\".*</td><td>(?<date>\\d{4}-\\d{2}-\\d{2}) \\d{2}:\\d{2}:\\d{2}</td>",
+        "regex": "href=\"dbeaver-ce-(?<ver>[\\d.]+)-windows-x86_64.zip\".*</td><td>(?<date>\\d{4}-\\d{2}-\\d{2}) \\d{2}:\\d{2}:\\d{2}</td>",
         "replace": "${ver}-${date}"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://dbeaver.io/files/ea/dbeaver-ce-$matchVer-win32.win32.x86_64.zip"
+                "url": "https://dbeaver.io/files/ea/dbeaver-ce-$matchVer-windows-x86_64.zip"
             }
         }
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
Update dbeaver-ea to 26.2.1-2026-09-07 and fix the autoupdate and checkver scripts
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->
- Relates to https://github.com/ScoopInstaller/Extras/pull/16402
- Relates to https://github.com/ScoopInstaller/Extras/pull/17241
<!--
Closes #XXXX
or
Relates to #XXXX
-->

- [X] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [X] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
